### PR TITLE
Support nullable for index meta

### DIFF
--- a/src/meta/processors/BaseProcessor.h
+++ b/src/meta/processors/BaseProcessor.h
@@ -188,12 +188,6 @@ protected:
     StatusOr<TagID> getTagId(GraphSpaceID spaceId, const std::string& name);
 
     /**
-     * Fetch the latest version tag's fields.
-     */
-    std::unordered_map<std::string, cpp2::PropertyType>
-    getLatestTagFields(const cpp2::Schema& latestTagSchema);
-
-    /**
      * Fetch the latest version tag's schema.
      */
     StatusOr<cpp2::Schema>
@@ -208,13 +202,6 @@ protected:
      * Return the edgeType for name.
      */
     StatusOr<EdgeType> getEdgeType(GraphSpaceID spaceId, const std::string& name);
-
-    /**
-     * Fetch the latest version edge's fields.
-     */
-    std::unordered_map<std::string, cpp2::PropertyType>
-    getLatestEdgeFields(const cpp2::Schema& latestEdgeSchema);
-
 
     /**
      * Fetch the latest version edge's schema.

--- a/src/meta/processors/BaseProcessor.inl
+++ b/src/meta/processors/BaseProcessor.inl
@@ -253,18 +253,6 @@ StatusOr<EdgeType> BaseProcessor<RESP>::getEdgeType(GraphSpaceID spaceId,
 
 
 template <typename RESP>
-std::unordered_map<std::string, cpp2::PropertyType>
-BaseProcessor<RESP>::getLatestTagFields(const cpp2::Schema& latestTagSchema) {
-    std::unordered_map<std::string, cpp2::PropertyType> propertyNames;
-    for (auto &column : latestTagSchema.get_columns()) {
-        propertyNames.emplace(std::move(column.get_name()),
-                              std::move(column.get_type()));
-    }
-    return propertyNames;
-}
-
-
-template <typename RESP>
 StatusOr<cpp2::Schema>
 BaseProcessor<RESP>::getLatestTagSchema(GraphSpaceID spaceId, const TagID tagId) {
     auto key = MetaServiceUtils::schemaTagPrefix(spaceId, tagId);
@@ -276,18 +264,6 @@ BaseProcessor<RESP>::getLatestTagSchema(GraphSpaceID spaceId, const TagID tagId)
 
     auto iter = ret.value().get();
     return MetaServiceUtils::parseSchema(iter->val());
-}
-
-
-template <typename RESP>
-std::unordered_map<std::string, cpp2::PropertyType>
-BaseProcessor<RESP>::getLatestEdgeFields(const cpp2::Schema& latestEdgeSchema) {
-    std::unordered_map<std::string, cpp2::PropertyType> propertyNames;
-    for (auto &column : latestEdgeSchema.get_columns()) {
-        propertyNames.emplace(std::move(column.get_name()),
-                              std::move(column.get_type()));
-    }
-    return propertyNames;
 }
 
 

--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -68,23 +68,19 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
        return;
     }
 
-    auto fields = getLatestEdgeFields(latestEdgeSchema);
+    const auto& schemaCols = latestEdgeSchema.get_columns();
     std::vector<cpp2::ColumnDef> columns;
     for (auto &field : fieldNames) {
-        auto iter = std::find_if(std::begin(fields), std::end(fields),
-                                 [field](const auto& pair) { return field == pair.first; });
+        auto iter = std::find_if(schemaCols.begin(), schemaCols.end(),
+                                 [field](const auto& col) { return field == col.get_name(); });
 
-        if (iter == fields.end()) {
+        if (iter == schemaCols.end()) {
             LOG(ERROR) << "Field " << field << " not found in Edge " << edgeName;
             handleErrorCode(cpp2::ErrorCode::E_NOT_FOUND);
             onFinished();
             return;
         } else {
-            auto type = fields[field];
-            cpp2::ColumnDef column;
-            column.set_name(std::move(field));
-            column.set_type(std::move(type));
-            columns.emplace_back(std::move(column));
+            columns.emplace_back(*iter);
         }
     }
 

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -66,22 +66,18 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
        return;
     }
 
-    auto fields = getLatestTagFields(latestTagSchema);
+    const auto& schemaCols = latestTagSchema.get_columns();
     std::vector<cpp2::ColumnDef> columns;
     for (auto &field : fieldNames) {
-        auto iter = std::find_if(std::begin(fields), std::end(fields),
-                                 [field](const auto& pair) { return field == pair.first; });
-        if (iter == fields.end()) {
+        auto iter = std::find_if(schemaCols.begin(), schemaCols.end(),
+                                 [field](const auto& col) { return field == col.get_name(); });
+        if (iter == schemaCols.end()) {
             LOG(ERROR) << "Field " << field << " not found in Tag " << tagName;
             handleErrorCode(cpp2::ErrorCode::E_NOT_FOUND);
             onFinished();
             return;
         } else {
-            auto type = fields[field];
-            cpp2::ColumnDef column;
-            column.set_name(std::move(field));
-            column.set_type(std::move(type));
-            columns.emplace_back(std::move(column));
+            columns.emplace_back(*iter);
         }
     }
 

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -220,7 +220,8 @@ public:
         return ret;
     }
 
-    static void mockTag(kvstore::KVStore* kv, int32_t tagNum, SchemaVer version = 0) {
+    static void mockTag(kvstore::KVStore* kv, int32_t tagNum,
+                        SchemaVer version = 0, bool nullable = false) {
         std::vector<nebula::kvstore::KV> tags;
         SchemaVer ver = version;
         for (auto t = 0; t < tagNum; t++) {
@@ -230,6 +231,9 @@ public:
                 cpp2::ColumnDef column;
                 column.name = folly::stringPrintf("tag_%d_col_%d", tagId, i);
                 column.type = i < 1 ? PropertyType::INT64 : PropertyType::STRING;
+                if (nullable) {
+                    column.set_nullable(nullable);
+                }
                 srcsch.columns.emplace_back(std::move(column));
             }
             auto tagName = folly::stringPrintf("tag_%d", tagId);
@@ -247,7 +251,8 @@ public:
         baton.wait();
     }
 
-    static void mockEdge(kvstore::KVStore* kv, int32_t edgeNum, SchemaVer version = 0) {
+    static void mockEdge(kvstore::KVStore* kv, int32_t edgeNum,
+                         SchemaVer version = 0, bool nullable = false) {
         std::vector<nebula::kvstore::KV> edges;
         SchemaVer ver = version;
         for (auto t = 0; t < edgeNum; t++) {
@@ -257,6 +262,9 @@ public:
                 cpp2::ColumnDef column;
                 column.name = folly::stringPrintf("edge_%d_col_%d", edgeType, i);
                 column.type = i < 1 ? PropertyType::INT64 : PropertyType::STRING;
+                if (nullable) {
+                    column.set_nullable(nullable);
+                }
                 srcsch.columns.emplace_back(std::move(column));
             }
             auto edgeName = folly::stringPrintf("edge_%d", edgeType);
@@ -373,6 +381,11 @@ public:
         for (int32_t i = 0; i < size; i++) {
             if (result[i].get_name() != expected[i].get_name() ||
                 result[i].get_type() != expected[i].get_type()) {
+                return false;
+            }
+            if (result[i].__isset.nullable != expected[i].__isset.nullable ||
+                (result[i].__isset.nullable == true &&
+                *result[i].get_nullable() != *expected[i].get_nullable())) {
                 return false;
             }
         }


### PR DESCRIPTION
nebula 2.0 support nullable value in tag|edge schema . Index metadata synchronized.
Used for index value encode and decode.