### PR TITLE
fix a clang report 'heap-use-after-free' error

### DIFF
--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -1009,6 +1009,7 @@ TEST(MetaClientTest, HeartbeatTest) {
     }
     sleep(FLAGS_heartbeat_interval_secs + 1);
     ASSERT_EQ(1, ActiveHostsMan::getActiveHosts(cluster.metaKV_.get()).size());
+    client->unRegisterListener();
 }
 
 


### PR DESCRIPTION
clang CI report 'heap-use-after-free' error in meta client test, 

because listener will free while test finished 

but there still a back ground heart beat thread using it .

unregister that listener, before test finished. 