### PR TITLE
Limit the maximum columns to 16 for index .

### DIFF
--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -30,6 +30,14 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
         return;
     }
 
+    // A maximum of 16 columns are allowed in the index
+    if (columnSet.size() > 16) {
+        LOG(ERROR) << "The number of index columns exceeds maximum limit 16";
+        handleErrorCode(cpp2::ErrorCode::E_CONFLICT);
+        onFinished();
+        return;
+    }
+
     folly::SharedMutex::WriteHolder wHolder(LockUtils::edgeIndexLock());
     auto ret = getIndexID(space, indexName);
     if (ret.ok()) {
@@ -43,7 +51,6 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
         return;
     }
 
-    std::map<std::string, std::vector<cpp2::ColumnDef>> edgeColumns;
     auto edgeTypeRet = getEdgeType(space, edgeName);
     if (!edgeTypeRet.ok()) {
         LOG(ERROR) << "Create Edge Index Failed: " << edgeName << " not exist";

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -29,6 +29,14 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
         return;
     }
 
+    // A maximum of 16 columns are allowed in the index.
+    if (columnSet.size() > 16) {
+        LOG(ERROR) << "The number of index columns exceeds maximum limit 16";
+        handleErrorCode(cpp2::ErrorCode::E_CONFLICT);
+        onFinished();
+        return;
+    }
+
     folly::SharedMutex::WriteHolder wHolder(LockUtils::tagIndexLock());
     auto ret = getIndexID(space, indexName);
     if (ret.ok()) {


### PR DESCRIPTION
In nebula 2.0, we added null value check in index key, null values symbol is a bitSet of 2 bytes, So a maximum of 16 columns are allowed in an index.