### PR TITLE
Unify LookupAndTraverse interface with common layer.

### DIFF
--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -134,11 +134,11 @@ cpp2::ErrorCode GetNeighborsProcessor::checkAndBuildContexts(const cpp2::GetNeig
     if (code != cpp2::ErrorCode::SUCCEEDED) {
         return code;
     }
-    code = buildTagContext(req);
+    code = buildTagContext(req.get_traverse_spec());
     if (code != cpp2::ErrorCode::SUCCEEDED) {
         return code;
     }
-    code = buildEdgeContext(req);
+    code = buildEdgeContext(req.get_traverse_spec());
     if (code != cpp2::ErrorCode::SUCCEEDED) {
         return code;
     }
@@ -153,7 +153,7 @@ cpp2::ErrorCode GetNeighborsProcessor::checkAndBuildContexts(const cpp2::GetNeig
     return cpp2::ErrorCode::SUCCEEDED;
 }
 
-cpp2::ErrorCode GetNeighborsProcessor::buildTagContext(const cpp2::GetNeighborsRequest& req) {
+cpp2::ErrorCode GetNeighborsProcessor::buildTagContext(const cpp2::TraverseSpec& req) {
     cpp2::ErrorCode ret = cpp2::ErrorCode::SUCCEEDED;
     if (!req.__isset.vertex_props) {
         // If the list is not given, no prop will be returned.
@@ -179,7 +179,7 @@ cpp2::ErrorCode GetNeighborsProcessor::buildTagContext(const cpp2::GetNeighborsR
     return cpp2::ErrorCode::SUCCEEDED;
 }
 
-cpp2::ErrorCode GetNeighborsProcessor::buildEdgeContext(const cpp2::GetNeighborsRequest& req) {
+cpp2::ErrorCode GetNeighborsProcessor::buildEdgeContext(const cpp2::TraverseSpec& req) {
     edgeContext_.offset_ = tagContext_.propContexts_.size() + 2;
     cpp2::ErrorCode ret = cpp2::ErrorCode::SUCCEEDED;
     if (!req.__isset.edge_props) {
@@ -202,6 +202,7 @@ cpp2::ErrorCode GetNeighborsProcessor::buildEdgeContext(const cpp2::GetNeighbors
     if (ret != cpp2::ErrorCode::SUCCEEDED) {
         return ret;
     }
+    // TODO : verify req.__isset.stat_props
     ret = handleEdgeStatProps(req.stat_props);
     if (ret != cpp2::ErrorCode::SUCCEEDED) {
         return ret;

--- a/src/storage/query/GetNeighborsProcessor.h
+++ b/src/storage/query/GetNeighborsProcessor.h
@@ -40,8 +40,8 @@ protected:
     void onProcessFinished() override;
 
     cpp2::ErrorCode checkAndBuildContexts(const cpp2::GetNeighborsRequest& req) override;
-    cpp2::ErrorCode buildTagContext(const cpp2::GetNeighborsRequest& req);
-    cpp2::ErrorCode buildEdgeContext(const cpp2::GetNeighborsRequest& req);
+    cpp2::ErrorCode buildTagContext(const cpp2::TraverseSpec& req);
+    cpp2::ErrorCode buildEdgeContext(const cpp2::TraverseSpec& req);
 
     // build tag/edge col name in response when prop specified
     void buildTagColName(const std::vector<cpp2::VertexProp>& tagProps);

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -130,8 +130,9 @@ void QueryBaseProcessor<REQ, RESP>::addReturnPropContext(
 
 template<typename REQ, typename RESP>
 cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildYields(const REQ& req) {
+    const auto& traverseSpec = req.get_traverse_spec();
     resultDataSet_.colNames.emplace_back("_expr");
-    if (!req.__isset.expressions) {
+    if (!traverseSpec.__isset.expressions) {
         return cpp2::ErrorCode::SUCCEEDED;
     }
     // todo(doodle): support expression yields later
@@ -140,10 +141,11 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildYields(const REQ& req) {
 
 template<typename REQ, typename RESP>
 cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildFilter(const REQ& req) {
-    if (!req.__isset.filter) {
+    const auto& traverseSpec = req.get_traverse_spec();
+    if (!traverseSpec.__isset.filter) {
         return cpp2::ErrorCode::SUCCEEDED;
     }
-    const auto& filterStr = *req.get_filter();
+    const auto& filterStr = *traverseSpec.get_filter();
     if (!filterStr.empty()) {
         // the filter expression **must** return a bool
         filter_ = std::move(Expression::decode(filterStr));

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -134,7 +134,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::OUT_EDGE;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::OUT_EDGE;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -153,7 +153,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::IN_EDGE;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::IN_EDGE;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -172,7 +172,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -191,7 +191,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         tags.emplace_back(team, std::vector<std::string>{"name"});
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -446,7 +446,7 @@ TEST(GetNeighborsTest, StatTest) {
             statProp.stat = cpp2::StatType::SUM;
             statProps.emplace_back(std::move(statProp));
         }
-        req.stat_props = std::move(statProps);
+        req.traverse_spec.stat_props = std::move(statProps);
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -503,7 +503,7 @@ TEST(GetNeighborsTest, StatTest) {
             statProp.stat = cpp2::StatType::MAX;
             statProps.emplace_back(std::move(statProp));
         }
-        req.stat_props = std::move(statProps);
+        req.traverse_spec.stat_props = std::move(statProps);
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -705,7 +705,7 @@ TEST(GetNeighborsTest, TtlTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -749,7 +749,7 @@ TEST(GetNeighborsTest, TtlTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -930,7 +930,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges, true);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -948,7 +948,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -966,7 +966,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -984,7 +984,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::IN_EDGE;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::IN_EDGE;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -1002,7 +1002,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::OUT_EDGE;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::OUT_EDGE;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -1020,7 +1020,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -1038,7 +1038,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -1067,7 +1067,7 @@ TEST(GetNeighborsTest, MultiVersionTest) {
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
-        req.edge_direction = cpp2::EdgeDirection::BOTH;
+        req.traverse_spec.edge_direction = cpp2::EdgeDirection::BOTH;
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
         auto fut = processor->getFuture();
@@ -1110,7 +1110,7 @@ TEST(GetNeighborsTest, FilterTest) {
                 new EdgePropertyExpression(new std::string(folly::to<std::string>(serve)),
                                            new std::string("teamAvgScore")),
                 new ConstantExpression(Value(20)));
-            req.set_filter(Expression::encode(exp));
+            req.traverse_spec.set_filter(Expression::encode(exp));
         }
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
@@ -1161,7 +1161,7 @@ TEST(GetNeighborsTest, FilterTest) {
                         new std::string(folly::to<std::string>(serve)),
                         new std::string("teamCareer")),
                     new ConstantExpression(Value(4))));
-            req.set_filter(Expression::encode(exp));
+            req.traverse_spec.set_filter(Expression::encode(exp));
         }
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
@@ -1212,7 +1212,7 @@ TEST(GetNeighborsTest, FilterTest) {
                         new std::string(folly::to<std::string>(player)),
                         new std::string("games")),
                     new ConstantExpression(Value(1000))));
-            req.set_filter(Expression::encode(exp));
+            req.traverse_spec.set_filter(Expression::encode(exp));
         }
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
@@ -1263,7 +1263,7 @@ TEST(GetNeighborsTest, FilterTest) {
                         new std::string(folly::to<std::string>(player)),
                         new std::string("avgScore")),
                     new ConstantExpression(Value(18))));
-            req.set_filter(Expression::encode(exp));
+            req.traverse_spec.set_filter(Expression::encode(exp));
         }
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
@@ -1356,7 +1356,7 @@ TEST(GetNeighborsTest, FilterTest) {
                 new EdgePropertyExpression(new std::string(folly::to<std::string>(serve)),
                                            new std::string("teamGames")),
                 new ConstantExpression(Value(1000)));
-            req.set_filter(Expression::encode(exp));
+            req.traverse_spec.set_filter(Expression::encode(exp));
         }
 
         auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);

--- a/src/storage/test/QueryTestUtils.h
+++ b/src/storage/test/QueryTestUtils.h
@@ -174,6 +174,7 @@ public:
             bool returnNoneProps = false) {
         std::hash<std::string> hash;
         cpp2::GetNeighborsRequest req;
+        decltype(req.traverse_spec) traverseSpec;
         req.space_id = 1;
         req.column_names.emplace_back("_vid");
         for (const auto& vertex : vertices) {
@@ -183,12 +184,12 @@ public:
             req.parts[partId].emplace_back(std::move(row));
         }
         for (const auto& edge : over) {
-            req.edge_types.emplace_back(edge);
+            traverseSpec.edge_types.emplace_back(edge);
         }
 
         std::vector<cpp2::VertexProp> vertexProps;
         if (tags.empty() && !returnNoneProps) {
-            req.set_vertex_props(std::move(vertexProps));
+            traverseSpec.set_vertex_props(std::move(vertexProps));
         } else if (!returnNoneProps) {
             for (const auto& tag : tags) {
                 TagID tagId = tag.first;
@@ -199,12 +200,12 @@ public:
                 }
                 vertexProps.emplace_back(std::move(tagProp));
             }
-            req.set_vertex_props(std::move(vertexProps));
+            traverseSpec.set_vertex_props(std::move(vertexProps));
         }
 
         std::vector<cpp2::EdgeProp> edgeProps;
         if (edges.empty() && !returnNoneProps) {
-            req.set_edge_props(std::move(edgeProps));
+            traverseSpec.set_edge_props(std::move(edgeProps));
         } else if (!returnNoneProps) {
             for (const auto& edge : edges) {
                 EdgeType edgeType = edge.first;
@@ -215,8 +216,9 @@ public:
                 }
                 edgeProps.emplace_back(std::move(edgeProp));
             }
-            req.set_edge_props(std::move(edgeProps));
+            traverseSpec.set_edge_props(std::move(edgeProps));
         }
+        req.set_traverse_spec(std::move(traverseSpec));
         return req;
     }
 


### PR DESCRIPTION
A new interface has been added for lookupAndTraverse in common layer. ( PR #140).
Unify LookupAndTraverse interface for storage layer compilation.