### PR TITLE
fix heap-use-after-free error of meta client 

### DIFF
--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -978,6 +978,7 @@ TEST(MetaClientTest, DiffTest) {
     sleep(FLAGS_heartbeat_interval_secs + 1);
     ASSERT_EQ(1, listener->spaceNum);
     ASSERT_EQ(9, listener->partNum);
+    client->unRegisterListener();
 }
 
 TEST(MetaClientTest, HeartbeatTest) {


### PR DESCRIPTION
This is an unstable test case，Let me repeat check it multiple times on CI system.
Please hold this PR.