### PR TITLE
Refactor the index storage structure

### DIFF
--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -114,6 +114,12 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
             onFinished();
             return;
         } else {
+            if (iter->get_type() == cpp2::PropertyType::STRING) {
+                LOG(ERROR) << "The string type does not allow indexing";
+                handleErrorCode(cpp2::ErrorCode::E_UNSUPPORTED);
+                onFinished();
+                return;
+            }
             columns.emplace_back(*iter);
         }
     }

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -112,6 +112,12 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
             onFinished();
             return;
         } else {
+            if (iter->get_type() == cpp2::PropertyType::STRING) {
+                LOG(ERROR) << "The string type does not allow indexing";
+                handleErrorCode(cpp2::ErrorCode::E_UNSUPPORTED);
+                onFinished();
+                return;
+            }
             columns.emplace_back(*iter);
         }
     }

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -571,6 +571,27 @@ TEST(MetaClientTest, TagIndexTest) {
     IndexID singleFieldIndexID;
     IndexID multiFieldIndexID;
     {
+        std::vector<cpp2::ColumnDef> columns;
+        cpp2::ColumnDef column0;
+        column0.set_name("col_string");
+        column0.set_type(PropertyType::STRING);
+        columns.emplace_back(std::move(column0));
+        cpp2::Schema schema;
+        schema.set_columns(std::move(columns));
+        auto result = client->createTagSchema(space,
+                                               folly::stringPrintf("tag_string"),
+                                               schema).get();
+        ASSERT_TRUE(result.ok());
+    }
+    {
+        std::vector<std::string>&& fields {"col_string"};
+        auto result = client->createTagIndex(space,
+                                              "string_index",
+                                              "tag_string",
+                                              std::move(fields)).get();
+        ASSERT_FALSE(result.ok());
+    }
+    {
         for (auto i = 0; i < 2; i++) {
             std::vector<cpp2::ColumnDef> columns;
             cpp2::ColumnDef column0;
@@ -580,7 +601,8 @@ TEST(MetaClientTest, TagIndexTest) {
 
             cpp2::ColumnDef column1;
             column1.set_name(folly::stringPrintf("tag_%d_col_1", i));
-            column1.set_type(PropertyType::STRING);
+            column1.set_type(PropertyType::FIXED_STRING);
+            column1.set_type_length(20);
             columns.emplace_back(std::move(column1));
 
             cpp2::Schema schema;
@@ -659,7 +681,8 @@ TEST(MetaClientTest, TagIndexTest) {
 
             cpp2::ColumnDef stringColumn;
             stringColumn.set_name("tag_0_col_1");
-            stringColumn.set_type(PropertyType::STRING);
+            stringColumn.set_type(PropertyType::FIXED_STRING);
+            stringColumn.set_type_length(20);
             columns.emplace_back(std::move(stringColumn));
 
             auto multiFieldResult = values[1].get_fields();
@@ -730,6 +753,27 @@ TEST(MetaClientTest, EdgeIndexTest) {
     IndexID singleFieldIndexID;
     IndexID multiFieldIndexID;
     {
+        std::vector<cpp2::ColumnDef> columns;
+        cpp2::ColumnDef column0;
+        column0.set_name("col_string");
+        column0.set_type(PropertyType::STRING);
+        columns.emplace_back(std::move(column0));
+        cpp2::Schema schema;
+        schema.set_columns(std::move(columns));
+        auto result = client->createEdgeSchema(space,
+                                               folly::stringPrintf("edge_string"),
+                                               schema).get();
+        ASSERT_TRUE(result.ok());
+    }
+    {
+        std::vector<std::string>&& fields {"col_string"};
+        auto result = client->createEdgeIndex(space,
+                                              "string_edge",
+                                              "edge_string",
+                                              std::move(fields)).get();
+        ASSERT_FALSE(result.ok());
+    }
+    {
         for (auto i = 0; i < 2; i++) {
             std::vector<cpp2::ColumnDef> columns;
             cpp2::ColumnDef column0;
@@ -739,7 +783,8 @@ TEST(MetaClientTest, EdgeIndexTest) {
 
             cpp2::ColumnDef column1;
             column1.set_name(folly::stringPrintf("edge_%d_col_1", i));
-            column1.set_type(PropertyType::STRING);
+            column1.set_type(PropertyType::FIXED_STRING);
+            column1.set_type_length(20);
             columns.emplace_back(std::move(column1));
 
             cpp2::Schema schema;
@@ -819,7 +864,8 @@ TEST(MetaClientTest, EdgeIndexTest) {
             columns.emplace_back(std::move(intColumn));
             cpp2::ColumnDef stringColumn;
             stringColumn.set_name("edge_0_col_1");
-            stringColumn.set_type(PropertyType::STRING);
+            stringColumn.set_type(PropertyType::FIXED_STRING);
+            stringColumn.set_type_length(20);
             columns.emplace_back(std::move(stringColumn));
             auto multiFieldResult = values[1].get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, multiFieldResult));

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -972,7 +972,7 @@ TEST(ProcessorTest, ListOrGetTagsTest) {
         ASSERT_EQ(cols.size(), 2);
         for (auto i = 0; i < 2; i++) {
             ASSERT_EQ(folly::stringPrintf("tag_%d_col_%d", 0, i), cols[i].get_name());
-            ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::STRING),
+            ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING),
                       cols[i].get_type());
         }
     }
@@ -994,7 +994,7 @@ TEST(ProcessorTest, ListOrGetTagsTest) {
         ASSERT_EQ(cols.size(), 2);
         for (auto i = 0; i < 2; i++) {
             ASSERT_EQ(folly::stringPrintf("tag_%d_col_%d", 0, i), cols[i].get_name());
-            ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::STRING),
+            ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING),
                       cols[i].get_type());
         }
     }
@@ -1047,7 +1047,7 @@ TEST(ProcessorTest, ListOrGetEdgesTest) {
             ASSERT_EQ(cols.size(), 2);
             for (auto i = 0; i < 2; i++) {
                 ASSERT_EQ(folly::stringPrintf("edge_%d_col_%d", t, i), cols[i].get_name());
-                ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::STRING),
+                ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING),
                 cols[i].get_type());
             }
         }
@@ -1070,7 +1070,7 @@ TEST(ProcessorTest, ListOrGetEdgesTest) {
         ASSERT_EQ(cols.size(), 2);
         for (auto i = 0; i < 2; i++) {
             ASSERT_EQ(folly::stringPrintf("edge_%d_col_%d", 0, i), cols[i].get_name());
-            ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::STRING),
+            ASSERT_EQ((i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING),
                       cols[i].get_type());
         }
     }
@@ -2295,7 +2295,7 @@ TEST(ProcessorTest, TagIndexTest) {
 
             cpp2::ColumnDef stringColumn;
             stringColumn.set_name("tag_0_col_1");
-            stringColumn.set_type(PropertyType::STRING);
+            stringColumn.set_type(PropertyType::FIXED_STRING);
             columns.emplace_back(std::move(stringColumn));
 
             auto multiItem = items[1];
@@ -2307,7 +2307,7 @@ TEST(ProcessorTest, TagIndexTest) {
             std::vector<cpp2::ColumnDef> columns;
             cpp2::ColumnDef stringColumn;
             stringColumn.set_name("tag_0_col_1");
-            stringColumn.set_type(PropertyType::STRING);
+            stringColumn.set_type(PropertyType::FIXED_STRING);
             columns.emplace_back(std::move(stringColumn));
             cpp2::ColumnDef intColumn;
             intColumn.set_name("tag_0_col_0");
@@ -2589,7 +2589,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
 
             cpp2::ColumnDef stringColumn;
             stringColumn.set_name("edge_0_col_1");
-            stringColumn.set_type(PropertyType::STRING);
+            stringColumn.set_type(PropertyType::FIXED_STRING);
             columns.emplace_back(std::move(stringColumn));
 
             auto multiItem = items[1];
@@ -2601,7 +2601,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
             std::vector<cpp2::ColumnDef> columns;
             cpp2::ColumnDef stringColumn;
             stringColumn.set_name("edge_0_col_1");
-            stringColumn.set_type(PropertyType::STRING);
+            stringColumn.set_type(PropertyType::FIXED_STRING);
             columns.emplace_back(std::move(stringColumn));
             cpp2::ColumnDef intColumn;
             intColumn.set_name("edge_0_col_0");

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -220,7 +220,10 @@ public:
             for (auto i = 0; i < 2; i++) {
                 cpp2::ColumnDef column;
                 column.name = folly::stringPrintf("tag_%d_col_%d", tagId, i);
-                column.type = i < 1 ? PropertyType::INT64 : PropertyType::STRING;
+                column.type = i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING;
+                if (i > 0) {
+                    column.set_type_length(8);
+                }
                 if (nullable) {
                     column.set_nullable(nullable);
                 }
@@ -251,7 +254,10 @@ public:
             for (auto i = 0; i < 2; i++) {
                 cpp2::ColumnDef column;
                 column.name = folly::stringPrintf("edge_%d_col_%d", edgeType, i);
-                column.type = i < 1 ? PropertyType::INT64 : PropertyType::STRING;
+                column.type = i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING;
+                if (i > 0) {
+                    column.set_type_length(8);
+                }
                 if (nullable) {
                     column.set_nullable(nullable);
                 }

--- a/src/mock/MockData.cpp
+++ b/src/mock/MockData.cpp
@@ -456,9 +456,9 @@ std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockTypicaSchemaV2() {
     schema->addField("col_float", meta::cpp2::PropertyType::FLOAT);
     schema->addField("col_float_null", meta::cpp2::PropertyType::FLOAT, 0, true);
     schema->addField("col_float_default", meta::cpp2::PropertyType::FLOAT, 0, false, 2.2F);
-    schema->addField("col_str", meta::cpp2::PropertyType::STRING);
-    schema->addField("col_str_null", meta::cpp2::PropertyType::STRING, 0, true);
-    schema->addField("col_str_default", meta::cpp2::PropertyType::STRING, 0, false, "sky");
+    schema->addField("col_str", meta::cpp2::PropertyType::FIXED_STRING, 6);
+    schema->addField("col_str_null", meta::cpp2::PropertyType::FIXED_STRING, 6, true);
+    schema->addField("col_str_default", meta::cpp2::PropertyType::FIXED_STRING, 6, false, "sky");
     schema->addField("col_date", meta::cpp2::PropertyType::DATE);
     schema->addField("col_date_null", meta::cpp2::PropertyType::DATE, 0, true);
 
@@ -511,12 +511,14 @@ MockData::mockTypicaIndexColumns() {
 
     meta::cpp2::ColumnDef col_str;
     col_str.name = "col_str";
-    col_str.type = meta::cpp2::PropertyType::STRING;
+    col_str.type = meta::cpp2::PropertyType::FIXED_STRING;
+    col_str.set_type_length(6);
     cols.emplace_back(std::move(col_str));
 
     meta::cpp2::ColumnDef col_str_null;
     col_str_null.name = "col_str_null";
-    col_str_null.type = meta::cpp2::PropertyType::STRING;
+    col_str_null.type = meta::cpp2::PropertyType::FIXED_STRING;
+    col_str_null.set_type_length(6);
     col_str_null.set_nullable(true);
     cols.emplace_back(std::move(col_str_null));
 

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -192,6 +192,5 @@ BaseProcessor<RESP>::encodeRowVal(const meta::NebulaSchemaProvider* schema,
 
     return std::move(rowWrite).moveEncodedStr();
 }
-
 }  // namespace storage
 }  // namespace nebula

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -276,13 +276,13 @@ public:
                          VertexID vId,
                          RowReader* reader,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-        std::vector<Value::Type> colsType;
-        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+        bool nullable = false;
+        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), nullable);
         if (!values.ok()) {
             return "";
         }
         return IndexKeyUtils::vertexIndexKey(planContext_->vIdLen_, partId, index->get_index_id(),
-                                             vId, values.value(), colsType);
+                                             vId, values.value(), nullable);
     }
 
 private:
@@ -591,8 +591,8 @@ public:
                          RowReader* reader,
                          const cpp2::EdgeKey& edgeKey,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-        std::vector<Value::Type> colsType;
-        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+        bool nullable = false;
+        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), nullable);
         if (!values.ok()) {
             return "";
         }
@@ -603,7 +603,7 @@ public:
                                            edgeKey.get_ranking(),
                                            edgeKey.get_dst(),
                                            values.value(),
-                                           colsType);
+                                           nullable);
     }
 
 private:

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -218,8 +218,8 @@ std::string AddEdgesProcessor::indexKey(PartitionID partId,
                                         RowReader* reader,
                                         const folly::StringPiece& rawKey,
                                         std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-    std::vector<Value::Type> colsType;
-    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+    bool nullable = false;
+    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), nullable);
     if (!values.ok()) {
         return "";
     }
@@ -228,7 +228,7 @@ std::string AddEdgesProcessor::indexKey(PartitionID partId,
                                        NebulaKeyUtils::getSrcId(spaceVidLen_, rawKey).str(),
                                        NebulaKeyUtils::getRank(spaceVidLen_, rawKey),
                                        NebulaKeyUtils::getDstId(spaceVidLen_, rawKey).str(),
-                                       values.value(), colsType);
+                                       values.value(), nullable);
 }
 
 }  // namespace storage

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -220,15 +220,15 @@ std::string AddVerticesProcessor::indexKey(PartitionID partId,
                                            VertexID vId,
                                            RowReader* reader,
                                            std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-    std::vector<Value::Type> colsType;
-    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+    bool nullable = false;
+    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), nullable);
     if (!values.ok()) {
         return "";
     }
     return IndexKeyUtils::vertexIndexKey(spaceVidLen_, partId,
                                          index->get_index_id(),
                                          vId, values.value(),
-                                         colsType);
+                                         nullable);
 }
 
 }  // namespace storage

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -136,10 +136,10 @@ DeleteEdgesProcessor::deleteEdges(PartitionID partId,
                                 return folly::none;
                             }
                         }
-                        std::vector<Value::Type> colsType;
+                        bool nullable = false;
                         auto values = IndexKeyUtils::collectIndexValues(reader.get(),
                                                                         index->get_fields(),
-                                                                        colsType);
+                                                                        nullable);
                         if (!values.ok()) {
                             continue;
                         }
@@ -149,7 +149,7 @@ DeleteEdgesProcessor::deleteEdges(PartitionID partId,
                                                                     rank,
                                                                     dstId,
                                                                     values.value(),
-                                                                    colsType);
+                                                                    nullable);
                         batchHolder->remove(std::move(indexKey));
                     }
                 }

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -153,10 +153,11 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                                 return folly::none;
                             }
                         }
-                        std::vector<Value::Type> colsType;
+                        bool nullable = false;
                         const auto& cols = index->get_fields();
                         auto values = IndexKeyUtils::collectIndexValues(reader.get(),
-                                                                        cols, colsType);
+                                                                        cols,
+                                                                        nullable);
                         if (!values.ok()) {
                             continue;
                         }
@@ -164,7 +165,7 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                                                                       indexId,
                                                                       vertex,
                                                                       values.value(),
-                                                                      colsType);
+                                                                      nullable);
                         batchHolder->remove(std::move(indexKey));
                     }
                 }

--- a/src/storage/test/IndexWriteTest.cpp
+++ b/src/storage/test/IndexWriteTest.cpp
@@ -294,49 +294,48 @@ TEST(IndexTest, VerticesValueTest) {
         }
 
         LOG(INFO) << "Check insert index...";
-        std::vector<Value> values;
-        std::vector<Value::Type> colsType;
+        std::vector<IndexValue> values;
         Value nullValue = Value(NullType::__NULL__);
         // col_bool
-        values.emplace_back(Value(true));
-        colsType.emplace_back(Value::Type::BOOL);
+        values.emplace_back(std::make_tuple(Value(true), Value::Type::BOOL,
+                                            IndexKeyUtils::valueLength(Value::Type::BOOL)));
         // col_bool_null
-        values.emplace_back(nullValue);
-        colsType.emplace_back(Value::Type::BOOL);
+        values.emplace_back(std::make_tuple(nullValue, Value::Type::BOOL,
+                                            IndexKeyUtils::valueLength(Value::Type::BOOL)));
         // col_bool_default
-        values.emplace_back(Value(true));
-        colsType.emplace_back(Value::Type::BOOL);
+        values.emplace_back(std::make_tuple(Value(true), Value::Type::BOOL,
+                                            IndexKeyUtils::valueLength(Value::Type::BOOL)));
         // col_int
-        values.emplace_back(Value(1L));
-        colsType.emplace_back(Value::Type::INT);
+        values.emplace_back(std::make_tuple(Value(1L), Value::Type::INT,
+                                            IndexKeyUtils::valueLength(Value::Type::INT)));
         // col_int_null
-        values.emplace_back(nullValue);
-        colsType.emplace_back(Value::Type::INT);
+        values.emplace_back(std::make_tuple(nullValue, Value::Type::INT,
+                                            IndexKeyUtils::valueLength(Value::Type::INT)));
         // col_float
-        values.emplace_back(Value(1.1f));
-        colsType.emplace_back(Value::Type::FLOAT);
+        values.emplace_back(std::make_tuple(Value(1.1f), Value::Type::FLOAT,
+                                            IndexKeyUtils::valueLength(Value::Type::FLOAT)));
         // col_float_null
-        values.emplace_back(Value(5.5f));
-        colsType.emplace_back(Value::Type::FLOAT);
+        values.emplace_back(std::make_tuple(Value(5.5f), Value::Type::FLOAT,
+                                            IndexKeyUtils::valueLength(Value::Type::FLOAT)));
         // col_str
-        values.emplace_back(Value("string"));
-        colsType.emplace_back(Value::Type::STRING);
+        values.emplace_back(std::make_tuple(Value("string"), Value::Type::STRING,
+                                            IndexKeyUtils::valueLength(Value::Type::STRING, 6)));
         // col_str_null
-        values.emplace_back(nullValue);
-        colsType.emplace_back(Value::Type::STRING);
+        values.emplace_back(std::make_tuple(nullValue, Value::Type::STRING,
+                                            IndexKeyUtils::valueLength(Value::Type::STRING, 6)));
         // col_date
         const Date date = {2020, 1, 20};
-        values.emplace_back(Value(date));
-        colsType.emplace_back(Value::Type::DATE);
+        values.emplace_back(std::make_tuple(Value(date), Value::Type::DATE,
+                                            IndexKeyUtils::valueLength(Value::Type::DATE)));
         // col_date_null
-        values.emplace_back(nullValue);
-        colsType.emplace_back(Value::Type::DATE);
+        values.emplace_back(std::make_tuple(nullValue, Value::Type::DATE,
+                                            IndexKeyUtils::valueLength(Value::Type::DATE)));
 
         for (auto partId = 1; partId <= 6; partId++) {
             auto prefix = IndexKeyUtils::indexPrefix(partId, indexId);
             auto indexKey = IndexKeyUtils::vertexIndexKey(vIdLen, partId, indexId,
                                                           convertVertexId(vIdLen, partId),
-                                                          values, colsType);
+                                                          values, true);
             std::unique_ptr<kvstore::KVIterator> iter;
             auto ret = env->kvstore_->prefix(spaceId, partId, prefix, &iter);
             EXPECT_EQ(kvstore::ResultCode::SUCCEEDED, ret);

--- a/src/utils/IndexKeyUtils.cpp
+++ b/src/utils/IndexKeyUtils.cpp
@@ -9,68 +9,40 @@
 namespace nebula {
 
 // static
-void IndexKeyUtils::encodeValues(const std::vector<Value>& values, std::string& raw) {
-    std::vector<int32_t> colsLen;
-    for (auto& value : values) {
-        if (value.type() == Value::Type::STRING) {
-            colsLen.emplace_back(value.getStr().size());
-        }
-        raw.append(encodeValue(value));
-    }
-    for (auto len : colsLen) {
-        raw.append(reinterpret_cast<const char*>(&len), sizeof(int32_t));
-    }
-}
-
-// static
-void IndexKeyUtils::encodeValuesWithNull(const std::vector<Value>& values,
-                                         const std::vector<Value::Type>& colsType,
-                                         std::string& raw) {
-    std::vector<int32_t> colsLen;
+void IndexKeyUtils::encodeValues(const std::vector<IndexValue>& values,
+                                 std::string& raw, bool nullable) {
     // An index has a maximum of 16 columns. 2 byte (16 bit) is enough.
-    u_short nullableBitset = 0;
+    u_short nullableBitset = 0xFFFF;
 
     for (size_t i = 0; i < values.size(); i++) {
         std::string val;
-        // if the value is null, the nullable bit should be '1'.
+        // if the value is null, the nullable bit should be '0', else should be '1'
         // And create a string of a fixed length，filled with 0.
         // if the value is not null, encode value.
-        if (values[i].isNull()) {
-            nullableBitset |= 0x8000 >> i;
-            val = encodeNullValue(colsType[i]);
+        if (nullable && std::get<0>(values[i]).isNull()) {
+            nullableBitset &= ~(0x8000 >> i);
+            val = encodeNullValue(std::get<2>(values[i]));
         } else {
             val = encodeValue(values[i]);
         }
-
-        if (colsType[i] == Value::Type::STRING) {
-            colsLen.emplace_back(val.size());
-        }
         raw.append(val);
     }
-
-    raw.append(reinterpret_cast<const char*>(&nullableBitset), sizeof(u_short));
-
-    for (auto len : colsLen) {
-        raw.append(reinterpret_cast<const char*>(&len), sizeof(int32_t));
+    if (nullable) {
+        raw.append(reinterpret_cast<const char*>(&nullableBitset), sizeof(u_short));
     }
 }
 
 // static
 std::string IndexKeyUtils::vertexIndexKey(size_t vIdLen, PartitionID partId,
                                           IndexID indexId, VertexID vId,
-                                          const std::vector<Value>& values,
-                                          const std::vector<Value::Type>& valueTypes) {
+                                          const std::vector<IndexValue>& values,
+                                          bool nullable) {
     int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kIndex);
     std::string key;
     key.reserve(256);
     key.append(reinterpret_cast<const char*>(&item), sizeof(int32_t))
        .append(reinterpret_cast<const char*>(&indexId), sizeof(IndexID));
-    // If have not nullable columns in the index, the valueTypes is empty.
-    if (valueTypes.empty()) {
-        encodeValues(values, key);
-    } else {
-        encodeValuesWithNull(values, valueTypes, key);
-    }
+    encodeValues(values, key, nullable);
     key.append(vId.data(), vId.size())
        .append(vIdLen - vId.size(), '\0');
     return key;
@@ -80,19 +52,14 @@ std::string IndexKeyUtils::vertexIndexKey(size_t vIdLen, PartitionID partId,
 std::string IndexKeyUtils::edgeIndexKey(size_t vIdLen, PartitionID partId,
                                         IndexID indexId, VertexID srcId,
                                         EdgeRanking rank, VertexID dstId,
-                                        const std::vector<Value>& values,
-                                        const std::vector<Value::Type>& valueTypes) {
+                                        const std::vector<IndexValue>& values,
+                                        bool nullable) {
     int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kIndex);
     std::string key;
     key.reserve(256);
     key.append(reinterpret_cast<const char*>(&item), sizeof(int32_t))
        .append(reinterpret_cast<const char*>(&indexId), sizeof(IndexID));
-    // If have not nullable columns in the index, the valueTypes is empty.
-    if (valueTypes.empty()) {
-        encodeValues(values, key);
-    } else {
-        encodeValuesWithNull(values, valueTypes, key);
-    }
+    encodeValues(values, key, nullable);
     key.append(srcId.data(), srcId.size())
        .append(vIdLen - srcId.size(), '\0')
        .append(reinterpret_cast<const char*>(&rank), sizeof(EdgeRanking))

--- a/src/utils/IndexKeyUtils.h
+++ b/src/utils/IndexKeyUtils.h
@@ -423,10 +423,10 @@ public:
 
     static std::string indexPrefix(PartitionID partId, IndexID indexId);
 
-    static StatusOr<std::vector<Value>>
+    static StatusOr<std::vector<IndexValue>>
     collectIndexValues(RowReader* reader,
                        const std::vector<nebula::meta::cpp2::ColumnDef>& cols,
-                       std::vector<Value::Type>& colsType);
+                       bool& nullable);
 
     static Status checkValue(const Value& v, bool isNullable);
 

--- a/src/utils/test/IndexKeyUtilsTest.cpp
+++ b/src/utils/test/IndexKeyUtilsTest.cpp
@@ -16,72 +16,77 @@ VertexID getStringId(int64_t vId) {
     return id;
 }
 
-std::vector<Value> getIndexValues() {
-    std::vector<Value> values;
-    values.emplace_back(Value("str"));
-    values.emplace_back(Value(true));
-    values.emplace_back(Value(12L));
-    values.emplace_back(Value(12.12f));
+std::vector<IndexValue> getIndexValues() {
+    std::vector<IndexValue> values;
+    values.emplace_back(std::make_tuple(Value("str"), Value::Type::STRING, 20));
+    values.emplace_back(std::make_tuple(Value(true), Value::Type::BOOL,
+        IndexKeyUtils::valueLength(Value::Type::BOOL)));
+    values.emplace_back(std::make_tuple(Value(12L), Value::Type::INT,
+        IndexKeyUtils::valueLength(Value::Type::INT)));
+    values.emplace_back(std::make_tuple(Value(12.12f), Value::Type::FLOAT,
+        IndexKeyUtils::valueLength(Value::Type::FLOAT)));
     Date d = {2020, 1, 20};
-    values.emplace_back(Value(std::move(d)));
+    values.emplace_back(std::make_tuple(Value(d), Value::Type::DATE,
+        IndexKeyUtils::valueLength(Value::Type::DATE)));
 
     DateTime dt = {2020, 4, 11, 12, 30, 22, 1111, 2222};
-    values.emplace_back(std::move(dt));
+    values.emplace_back(std::make_tuple(Value(dt), Value::Type::DATETIME,
+        IndexKeyUtils::valueLength(Value::Type::DATETIME)));
     return values;
 }
 
 bool evalInt64(int64_t val) {
-    Value v(val);
+    IndexValue v = std::make_tuple(Value(val), Value::Type::INT, 0);
     auto str = IndexKeyUtils::encodeValue(v);
     auto res = IndexKeyUtils::decodeValue(str, Value::Type::INT);
 
     EXPECT_EQ(Value::Type::INT, res.type());
-    EXPECT_EQ(v, res);
+    EXPECT_EQ(std::get<0>(v), res);
     return val == res.getInt();
 }
 
 bool evalDouble(double val) {
-    Value v(val);
+    IndexValue v = std::make_tuple(Value(val), Value::Type::FLOAT, 0);
     auto str = IndexKeyUtils::encodeValue(v);
     auto res = IndexKeyUtils::decodeValue(str, Value::Type::FLOAT);
     EXPECT_EQ(Value::Type::FLOAT, res.type());
-    EXPECT_EQ(v, res);
+    EXPECT_EQ(std::get<0>(v), res);
     return val == res.getFloat();
 }
 
 bool evalBool(bool val) {
-    Value v(val);
+    IndexValue v = std::make_tuple(Value(val), Value::Type::BOOL, 0);
     auto str = IndexKeyUtils::encodeValue(v);
     auto res = IndexKeyUtils::decodeValue(str, Value::Type::BOOL);
     EXPECT_EQ(Value::Type::BOOL, res.type());
-    EXPECT_EQ(v, res);
+    EXPECT_EQ(std::get<0>(v), res);
     return val == res.getBool();
 }
 
 bool evalString(std::string val) {
-    Value v(val);
+    IndexValue v = std::make_tuple(Value(val), Value::Type::STRING, 4);
     auto str = IndexKeyUtils::encodeValue(v);
     auto res = IndexKeyUtils::decodeValue(str, Value::Type::STRING);
     EXPECT_EQ(Value::Type::STRING, res.type());
-    EXPECT_EQ(v, res);
+    EXPECT_EQ(std::get<0>(v), res);
     return val == res.getStr();
 }
 
 bool evalDate(nebula::Date val) {
-    Value v(val);
+    IndexValue v = std::make_tuple(Value(val), Value::Type::DATE, 0);
     auto str = IndexKeyUtils::encodeValue(v);
     auto res = IndexKeyUtils::decodeValue(str, Value::Type::DATE);
     EXPECT_EQ(Value::Type::DATE, res.type());
-    EXPECT_EQ(v, res);
+    EXPECT_EQ(std::get<0>(v), res);
     return val == res.getDate();
 }
 
 bool evalDateTime(nebula::DateTime val) {
-    Value v(val);
+    IndexValue v = std::make_tuple(Value(val), Value::Type::DATETIME, 0);
     auto str = IndexKeyUtils::encodeValue(v);
     auto res = IndexKeyUtils::decodeValue(str, Value::Type::DATETIME);
     EXPECT_EQ(Value::Type::DATETIME, res.type());
-    EXPECT_EQ(v, res);
+    EXPECT_EQ(std::get<0>(v), res);
     return val == res.getDateTime();
 }
 
@@ -170,31 +175,18 @@ TEST(IndexKeyUtilsTest, edgeIndexKeyV2) {
 TEST(IndexKeyUtilsTest, nullableValue) {
     {
         std::string raw;
-        std::vector<Value> values;
-        std::vector<Value::Type> colsType;
+        std::vector<IndexValue> values;
         for (int64_t j = 1; j <= 6; j++) {
             auto type = Value::Type(1UL << j);
-            values.emplace_back(Value(NullType::__NULL__));
-            colsType.emplace_back(type);
+            if (type == Value::Type::STRING) {
+                values.emplace_back(std::make_tuple(Value(NullType::__NULL__), type, 0));
+            } else {
+                values.emplace_back(std::make_tuple(Value(NullType::__NULL__), type,
+                                                    IndexKeyUtils::valueLength(type)));
+            }
         }
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
-        u_short s = 0xfc00; /* the binary is '11111100 00000000'*/
-        std::string expected;
-        expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
-        auto result = raw.substr(raw.size() - sizeof(int32_t) - sizeof(u_short), sizeof(u_short));
-        ASSERT_EQ(expected, result);
-    }
-    {
-        std::string raw;
-        std::vector<Value> values;
-        std::vector<Value::Type> colsType;
-        auto type = Value::Type::BOOL;
-        values.emplace_back(Value(true));
-        colsType.emplace_back(type);
-        values.emplace_back(Value(NullType::__NULL__));
-        colsType.emplace_back(type);
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
-        u_short s = 0x4000; /* the binary is '01000000 00000000'*/
+        IndexKeyUtils::encodeValues(std::move(values), raw, true);
+        u_short s = 0x03FF; /* the binary is '00000011 11111111'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
         auto result = raw.substr(raw.size() - sizeof(u_short), sizeof(u_short));
@@ -202,52 +194,78 @@ TEST(IndexKeyUtilsTest, nullableValue) {
     }
     {
         std::string raw;
-        std::vector<Value> values;
-        values.emplace_back(Value(true));
-        values.emplace_back(Value(false));
+        std::vector<IndexValue> values;
+        auto type = Value::Type::BOOL;
+        values.emplace_back(std::make_tuple(Value(true), type,
+            IndexKeyUtils::valueLength(type)));
+        values.emplace_back(std::make_tuple(Value(NullType::__NULL__), type,
+            IndexKeyUtils::valueLength(type)));
+        IndexKeyUtils::encodeValues(std::move(values), raw, true);
+        u_short s = 0xBFFF; /* the binary is '10111111 11111111'*/
+        std::string expected;
+        expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
+        auto result = raw.substr(raw.size() - sizeof(u_short), sizeof(u_short));
+        ASSERT_EQ(expected, result);
+    }
+    {
+        std::string raw;
+        std::vector<IndexValue> values;
+        values.emplace_back(std::make_tuple(Value(true), Value::Type::BOOL,
+            IndexKeyUtils::valueLength(Value::Type::BOOL)));
+        values.emplace_back(std::make_tuple(Value(false), Value::Type::BOOL,
+            IndexKeyUtils::valueLength(Value::Type::BOOL)));
         IndexKeyUtils::encodeValues(std::move(values), raw);
         ASSERT_EQ(2, raw.size());
     }
     {
         std::string raw;
-        std::vector<Value> values;
-        std::vector<Value::Type> colsType;
+        std::vector<IndexValue> values;
         for (int64_t i = 0; i <2; i++) {
             for (int64_t j = 1; j <= 6; j++) {
                 auto type = Value::Type(1UL << j);
-                values.emplace_back(Value(NullType::__NULL__));
-                colsType.emplace_back(type);
+                values.emplace_back(std::make_tuple(Value(NullType::__NULL__), type,
+                                    IndexKeyUtils::valueLength(type)));
             }
         }
 
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
-        u_short s = 0xfff0; /* the binary is '11111111 11110000'*/
+        IndexKeyUtils::encodeValues(std::move(values), raw, true);
+        u_short s = 0x000f; /* the binary is '00000000 00001111'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
-        auto result = raw.substr(raw.size() - sizeof(int32_t) * 2 - sizeof(u_short),
+        auto result = raw.substr(raw.size() - sizeof(u_short),
                                  sizeof(u_short));
         ASSERT_EQ(expected, result);
     }
     {
         std::string raw;
-        std::vector<Value> values;
-        std::unordered_map<Value::Type, Value> mockValues;
+        std::vector<IndexValue> values;
+        std::unordered_map<Value::Type, IndexValue> mockValues;
         {
-            mockValues[Value::Type::BOOL] = Value(true);
-            mockValues[Value::Type::INT] = Value(4L);
-            mockValues[Value::Type::FLOAT] = Value(1.5f);
-            mockValues[Value::Type::STRING] = Value("str");
+            mockValues[Value::Type::BOOL] = std::make_tuple(Value(true), Value::Type::BOOL,
+                IndexKeyUtils::valueLength(Value::Type::BOOL));
+            mockValues[Value::Type::INT] = std::make_tuple(Value(4L), Value::Type::INT,
+                IndexKeyUtils::valueLength(Value::Type::INT));
+            mockValues[Value::Type::FLOAT] = std::make_tuple(Value(1.5f), Value::Type::FLOAT,
+                IndexKeyUtils::valueLength(Value::Type::FLOAT));
+            mockValues[Value::Type::STRING] = std::make_tuple(Value("str"), Value::Type::STRING, 3);
             Date d = {2020, 1, 20};
-            mockValues[Value::Type::DATE] = Value(d);
+            mockValues[Value::Type::DATE] = std::make_tuple(Value(d), Value::Type::DATE,
+                IndexKeyUtils::valueLength(Value::Type::DATE));
             DateTime dt = {2020, 4, 11, 12, 30, 22, 1111, 2222};
-            mockValues[Value::Type::DATETIME] = Value(dt);
+            mockValues[Value::Type::DATETIME] = std::make_tuple(Value(dt), Value::Type::DATETIME,
+                IndexKeyUtils::valueLength(Value::Type::DATETIME));
         }
         std::vector<Value::Type> colsType;
         for (int64_t i = 0; i <2; i++) {
             for (int64_t j = 1; j <= 6; j++) {
                 auto type = Value::Type(1UL << j);
                 if (j%2 == 1) {
-                    values.emplace_back(Value(NullType::__NULL__));
+                    if (type == Value::Type::STRING) {
+                        values.emplace_back(Value(NullType::__NULL__), type, 3);
+                    } else {
+                        values.emplace_back(Value(NullType::__NULL__), type,
+                                            IndexKeyUtils::valueLength(type));
+                    }
                 } else {
                     values.emplace_back(mockValues[type]);
                 }
@@ -255,24 +273,23 @@ TEST(IndexKeyUtilsTest, nullableValue) {
             }
         }
 
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
-        u_short s = 0xaaa0; /* the binary is '10101010 10100000'*/
+        IndexKeyUtils::encodeValues(std::move(values), raw, true);
+        u_short s = 0x555F; /* the binary is '01010101 01011111'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
-        auto result = raw.substr(raw.size() - sizeof(int32_t) * 2 - sizeof(u_short),
+        auto result = raw.substr(raw.size() - sizeof(u_short),
                                  sizeof(u_short));
         ASSERT_EQ(expected, result);
     }
     {
         std::string raw;
-        std::vector<Value> values;
-        std::vector<Value::Type> colsType;
+        std::vector<IndexValue> values;
         for (int64_t i = 0; i <9; i++) {
-            values.emplace_back(Value(NullType::__NULL__));
-            colsType.emplace_back(Value::Type::BOOL);
+            values.emplace_back(std::make_tuple(Value(NullType::__NULL__), Value::Type::BOOL,
+                                                IndexKeyUtils::valueLength(Value::Type::BOOL)));
         }
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
-        u_short s = 0xff80; /* the binary is '11111111 10000000'*/
+        IndexKeyUtils::encodeValues(std::move(values), raw, true);
+        u_short s = 0x007F; /* the binary is '11111111 10000000'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
         auto result = raw.substr(raw.size() - sizeof(u_short), sizeof(u_short));
@@ -283,43 +300,173 @@ TEST(IndexKeyUtilsTest, nullableValue) {
 void verifyDecodeIndexKey(bool isEdge,
                           bool nullable,
                           size_t vIdLen,
-                          const std::vector<std::pair<VertexID, std::vector<Value>>>& data,
+                          size_t fixedStrLen,
+                          const std::vector<std::pair<VertexID, std::vector<IndexValue>>>& data,
                           const std::vector<std::string>& indexKeys,
                           std::vector<std::pair<std::string, Value::Type>> cols) {
     for (size_t j = 0; j < data.size(); j++) {
-        std::vector<Value> actual;
-        actual.emplace_back(IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, 1, indexKeys[j], "col_bool", cols, isEdge, nullable));
-        actual.emplace_back(IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, 1, indexKeys[j], "col_int", cols, isEdge, nullable));
-        actual.emplace_back(IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, 1, indexKeys[j], "col_float", cols, isEdge, nullable));
-        actual.emplace_back(IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, 1, indexKeys[j], "col_string", cols, isEdge, nullable));
-        actual.emplace_back(IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, 1, indexKeys[j], "col_date", cols, isEdge, nullable));
-        actual.emplace_back(IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, 1, indexKeys[j], "col_datetime", cols, isEdge, nullable));
-
-        ASSERT_EQ(data[j].second, actual);
+        ASSERT_EQ(std::get<0>(data[j].second[0]),
+                  IndexKeyUtils::getValueFromIndexKey(
+                      vIdLen, indexKeys[j], "col_bool", cols, fixedStrLen, isEdge, nullable));
+        ASSERT_EQ(std::get<0>(data[j].second[1]),
+                  IndexKeyUtils::getValueFromIndexKey(
+                      vIdLen, indexKeys[j], "col_int", cols, fixedStrLen, isEdge, nullable));
+        ASSERT_EQ(std::get<0>(data[j].second[2]),
+                  IndexKeyUtils::getValueFromIndexKey(
+                      vIdLen, indexKeys[j], "col_float", cols, fixedStrLen, isEdge, nullable));
+        ASSERT_EQ(std::get<0>(data[j].second[3]),
+                  IndexKeyUtils::getValueFromIndexKey(
+                      vIdLen, indexKeys[j], "col_string", cols, fixedStrLen, isEdge, nullable));
+        ASSERT_EQ(std::get<0>(data[j].second[4]),
+                  IndexKeyUtils::getValueFromIndexKey(
+                      vIdLen, indexKeys[j], "col_date", cols, fixedStrLen, isEdge, nullable));
+        ASSERT_EQ(std::get<0>(data[j].second[5]),
+                  IndexKeyUtils::getValueFromIndexKey(
+                      vIdLen, indexKeys[j], "col_datetime", cols, fixedStrLen, isEdge, nullable));
     }
 }
 
+
+std::vector<std::pair<VertexID, std::vector<IndexValue>>> getIndexValuesWithNull() {
+    Date d = {2020, 1, 20};
+    DateTime dt = {2020, 4, 11, 12, 30, 22, 1111, 2222};
+    std::vector<std::pair<VertexID, std::vector<IndexValue>>> datas = {
+        {"1", {std::make_tuple(Value(false), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(1L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(1.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row1"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"2", {std::make_tuple(Value(true), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(2L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(2.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row2"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"3", {std::make_tuple(Value(NullType::__NULL__), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(3L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(3.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row3"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"4", {std::make_tuple(Value(true), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(4.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row4"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"5", {std::make_tuple(Value(false), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(5L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row5"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"6", {std::make_tuple(Value(true), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(6L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(6.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"7", {std::make_tuple(Value(false), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(7L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(7.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row7"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"8", {std::make_tuple(Value(true), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(8L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(8.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row8"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"9", {std::make_tuple(Value(NullType::__NULL__), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::STRING, 4),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(NullType::__NULL__), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+    };
+    return datas;
+}
+
+std::vector<std::pair<VertexID, std::vector<IndexValue>>> getIndexValuesNonNullable() {
+    Date d = {2020, 1, 20};
+    DateTime dt = {2020, 4, 11, 12, 30, 22, 1111, 2222};
+    std::vector<std::pair<VertexID, std::vector<IndexValue>>> data = {
+        {"1", {std::make_tuple(Value(false), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(1L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(1.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row1"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}},
+        {"2", {std::make_tuple(Value(true), Value::Type::BOOL,
+                               IndexKeyUtils::valueLength(Value::Type::BOOL)),
+                  std::make_tuple(Value(2L), Value::Type::INT,
+                                  IndexKeyUtils::valueLength(Value::Type::INT)),
+                  std::make_tuple(Value(2.1f), Value::Type::FLOAT,
+                                  IndexKeyUtils::valueLength(Value::Type::FLOAT)),
+                  std::make_tuple(Value("row2"), Value::Type::STRING, 4),
+                  std::make_tuple(Value(d), Value::Type::DATE,
+                                  IndexKeyUtils::valueLength(Value::Type::DATE)),
+                  std::make_tuple(Value(dt), Value::Type::DATETIME,
+                                  IndexKeyUtils::valueLength(Value::Type::DATETIME))}}
+    };
+    return data;
+}
 TEST(IndexKeyUtilsTest, getValueFromIndexKeyTest) {
     size_t vIdLen = 8;
     PartitionID partId = 1;
     IndexID indexId = 1;
-    Date d = {2020, 1, 20};
-    DateTime dt = {2020, 4, 11, 12, 30, 22, 1111, 2222};
-    auto null = Value(NullType::__NULL__);
-    std::vector<Value::Type> valueTypes = {
-        Value::Type::BOOL,
-        Value::Type::INT,
-        Value::Type::FLOAT,
-        Value::Type::STRING,
-        Value::Type::DATE,
-        Value::Type::DATETIME
-    };
 
     std::vector<std::pair<std::string, Value::Type>> cols = {
         {"col_bool", Value::Type::BOOL},
@@ -332,79 +479,53 @@ TEST(IndexKeyUtilsTest, getValueFromIndexKeyTest) {
 
     // vertices test with nullable
     {
-        std::vector<std::pair<VertexID, std::vector<Value>>> vertices = {
-            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
-            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
-            {"3", {null, Value(3L), Value(3.1f), Value("row3"), Value(d), Value(dt)}},
-            {"4", {Value(true), null, Value(4.1f), Value("row4"), Value(d), Value(dt)}},
-            {"5", {Value(false), Value(5L), null, Value("row5"), Value(d), Value(dt)}},
-            {"6", {Value(true), Value(6L), Value(6.1f), null, Value(d), Value(dt)}},
-            {"7", {Value(false), Value(7L), Value(7.1f), Value("row7"), null, Value(dt)}},
-            {"8", {Value(true), Value(8L), Value(8.1f), Value("row8"), Value(d), null}},
-            {"9", {null, null, null, null, null, null}}
-        };
+        auto vertices = getIndexValuesWithNull();
         std::vector<std::string> indexKeys;
 
         for (const auto& row : vertices) {
             indexKeys.emplace_back(IndexKeyUtils::vertexIndexKey(
-                vIdLen, partId, indexId, row.first, row.second, valueTypes));
+                vIdLen, partId, indexId, row.first, row.second, true));
         }
-        verifyDecodeIndexKey(false, true, vIdLen, vertices, indexKeys, cols);
+        verifyDecodeIndexKey(false, true, vIdLen, 4, vertices, indexKeys, cols);
     }
 
     // vertices test without nullable column
     {
-        std::vector<std::pair<VertexID, std::vector<Value>>> vertices = {
-            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
-            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
-        };
+        auto vertices = getIndexValuesNonNullable();
 
         std::vector<std::string> indexKeys;
         for (const auto& row : vertices) {
             indexKeys.emplace_back(IndexKeyUtils::vertexIndexKey(
-                vIdLen, partId, indexId, row.first, row.second, valueTypes));
+                vIdLen, partId, indexId, row.first, row.second, false));
         }
 
-        verifyDecodeIndexKey(false, false, vIdLen, vertices, indexKeys, cols);
+        verifyDecodeIndexKey(false, false, vIdLen, 4, vertices, indexKeys, cols);
     }
 
     // edges test with nullable
     {
-        std::vector<std::pair<VertexID, std::vector<Value>>> edges = {
-            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
-            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
-            {"3", {null, Value(3L), Value(3.1f), Value("row3"), Value(d), Value(dt)}},
-            {"4", {Value(true), null, Value(4.1f), Value("row4"), Value(d), Value(dt)}},
-            {"5", {Value(false), Value(5L), null, Value("row5"), Value(d), Value(dt)}},
-            {"6", {Value(true), Value(6L), Value(6.1f), null, Value(d), Value(dt)}},
-            {"7", {Value(false), Value(7L), Value(7.1f), Value("row7"), null, Value(dt)}},
-            {"8", {Value(true), Value(8L), Value(8.1f), Value("row8"), Value(d), null}},
-            {"9", {null, null, null, null, null, null}}
-        };
+        auto edges = getIndexValuesWithNull();
         std::vector<std::string> indexKeys;
 
         for (const auto& row : edges) {
             indexKeys.emplace_back(IndexKeyUtils::edgeIndexKey(
-                vIdLen, partId, indexId, row.first, 0, row.first, row.second, valueTypes));
+                vIdLen, partId, indexId, row.first, 0, row.first, row.second, true));
         }
 
-        verifyDecodeIndexKey(true, true, vIdLen, edges, indexKeys, cols);
+        verifyDecodeIndexKey(true, true, vIdLen, 4, edges, indexKeys, cols);
     }
 
     // edges test without nullable column
     {
-        std::vector<std::pair<VertexID, std::vector<Value>>> edges = {
-            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
-            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
-        };
+        auto edges = getIndexValuesNonNullable();
         std::vector<std::string> indexKeys;
 
         for (const auto& row : edges) {
             indexKeys.emplace_back(IndexKeyUtils::edgeIndexKey(
-                vIdLen, partId, indexId, row.first, 0, row.first, row.second, valueTypes));
+                vIdLen, partId, indexId, row.first, 0, row.first, row.second, true));
         }
 
-        verifyDecodeIndexKey(true, false, vIdLen, edges, indexKeys, cols);
+        verifyDecodeIndexKey(true, false, vIdLen, 4, edges, indexKeys, cols);
     }
 }
 }  // namespace nebula


### PR DESCRIPTION
1,  Reject STRING type field when create index. allows index to contain FIXED_STRING type field.
2, The nullable bit in index key, using '0' to indicate null value and using '1' indicate non-null value.