### PR TITLE
hot fix remove offline label when building index

### DIFF
--- a/src/meta/processors/indexMan/RebuildIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/RebuildIndexProcessor.cpp
@@ -17,13 +17,6 @@ void RebuildIndexProcessor::processInternal(const cpp2::RebuildIndexReq& req) {
     auto space = req.get_space_id();
     CHECK_SPACE_ID_AND_RETURN(space);
     const auto &indexName = req.get_index_name();
-    auto isOffline = req.get_is_offline();
-    if (!isOffline) {
-        LOG(ERROR) << "Currently not support online rebuild index";
-        resp_.set_code(cpp2::ErrorCode::E_UNSUPPORTED);
-        onFinished();
-        return;
-    }
 
     LOG(INFO) << "Rebuild Index Space " << space << ", Index Name " << indexName;
     const auto& hostPrefix = MetaServiceUtils::leaderPrefix();
@@ -67,7 +60,7 @@ void RebuildIndexProcessor::processInternal(const cpp2::RebuildIndexReq& req) {
         if (std::find(activeHosts.begin(), activeHosts.end(), hostAddr) != activeHosts.end()) {
             auto leaderParts = MetaServiceUtils::parseLeaderVal(leaderIter->val());
             auto& partIds = leaderParts[space];
-            auto future = caller(hostAddr, space, indexID, std::move(partIds), isOffline);
+            auto future = caller(hostAddr, space, indexID, std::move(partIds), true);
             results.emplace_back(std::move(future));
         }
         leaderIter->next();


### PR DESCRIPTION
After [Remove offline when building index](https://github.com/vesoft-inc-private/nebula-common/pull/159/files) is merged, seems `nebula storage` can not pass the `CI`. 

It will block the nebula graph. So I released this one. 

Actually it's part of [Support online mode](https://github.com/vesoft-inc-private/nebula-storage/pull/26)