### PR TITLE
Index write benchmark

### DIFF
--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -177,6 +177,22 @@ nebula_add_test(
         gtest
 )
 
+nebula_add_executable(
+    NAME
+        storage_index_write_bm
+    SOURCES
+        StorageIndexWriteBenchmark.cpp
+    OBJECTS
+        ${storage_test_deps}
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        follybenchmark
+        boost_regex
+        wangle
+        gtest
+)
+
 nebula_add_test(
     NAME
         checkpoint_test

--- a/src/storage/test/StorageIndexWriteBenchmark.cpp
+++ b/src/storage/test/StorageIndexWriteBenchmark.cpp
@@ -1,108 +1,207 @@
-/* Copyright (c) 2018 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
 #include "common/base/Base.h"
-#include "common/fs/FileUtils.h"
-#include "common/client/storage/GraphStorageClient.h"
-#include "common/meta/ServerBasedSchemaManager.h"
 #include "kvstore/KVStore.h"
 #include "kvstore/NebulaStore.h"
-#include "storage/test/AdHocSchemaManager.h"
-#include "storage/test/TestUtils.h"
+#include "common/fs/FileUtils.h"
 #include "storage/mutate/AddVerticesProcessor.h"
-#include "storage/StorageFlags.h"
-#include "codec/RowWriterV2.h"
+#include "mock/MockCluster.h"
+#include "mock/MockData.h"
 #include <folly/Benchmark.h>
+#include "common/interface/gen-cpp2/storage_types.h"
+#include "common/interface/gen-cpp2/common_types.h"
+#include "utils/NebulaKeyUtils.h"
+#include "mock/AdHocIndexManager.h"
+#include "mock/AdHocSchemaManager.h"
+
 
 DEFINE_int32(bulk_insert_size, 1000, "The number of vertices by bulk insert");
-DEFINE_int32(total_vertices_size, 1000000, "The number of vertices");
-DEFINE_string(root_data_path, "/tmp/IndexWritePref", "Engine data path");
+DEFINE_int32(total_vertices_size, 1000, "The number of vertices");
+DEFINE_string(root_data_path, "/home/bright2star/IndexWritePref", "Engine data path");
 
 namespace nebula {
 namespace storage {
 
-std::vector<storage::cpp2::Vertex> genVertices(VertexID &vId, TagID tagId) {
-    std::vector<storage::cpp2::Vertex> vertices;
+using NewVertex = nebula::storage::cpp2::NewVertex;
+using NewTag = nebula::storage::cpp2::NewTag;
+
+enum class IndexENV : uint8_t {
+    NO_INDEX       = 1,
+    ONE_INDEX      = 2,
+    MULITPLE_INDEX = 3,
+    INVALID_INDEX  = 4,
+};
+
+GraphSpaceID spaceId = 1;
+TagID tagId = 1;
+IndexID indexId = 1;
+
+std::string toVertexId(size_t vIdLen, int32_t vId) {
+    std::string id;
+    id.reserve(vIdLen);
+    id.append(reinterpret_cast<const char*>(&vId), sizeof(vId))
+        .append(vIdLen - sizeof(vId), '\0');
+    return id;
+}
+
+std::unique_ptr<kvstore::MemPartManager> memPartMan(const std::vector<PartitionID>& parts) {
+    auto memPartMan = std::make_unique<kvstore::MemPartManager>();
+    // GraphSpaceID =>  {PartitionIDs}
+    auto& partsMap = memPartMan->partsMap();
+    for (auto partId : parts) {
+        partsMap[spaceId][partId] = meta::PartHosts();
+    }
+    return memPartMan;
+}
+
+std::vector<nebula::meta::cpp2::ColumnDef> mockTagIndexColumns() {
+    std::vector<nebula::meta::cpp2::ColumnDef> cols;
+    for (int32_t i = 0; i < 3; i++) {
+        nebula::meta::cpp2::ColumnDef col;
+        col.name = folly::stringPrintf("col_%d", i);
+        col.type = meta::cpp2::PropertyType::INT64;
+        cols.emplace_back(std::move(col));
+    }
+    return cols;
+}
+
+std::shared_ptr<meta::NebulaSchemaProvider> mockTagSchema() {
+    std::shared_ptr<meta::NebulaSchemaProvider> schema(new meta::NebulaSchemaProvider(0));
+    for (int32_t i = 0; i < 3; i++) {
+        nebula::meta::cpp2::ColumnDef col;
+        col.name = folly::stringPrintf("col_%d", i);
+        col.type = meta::cpp2::PropertyType::INT64;
+        schema->addField(col.name, col.type);
+    }
+    return schema;
+}
+
+std::unique_ptr<meta::SchemaManager> memSchemaMan() {
+    auto schemaMan = std::make_unique<mock::AdHocSchemaManager>();
+    schemaMan->addTagSchema(spaceId, tagId, mockTagSchema());
+    return schemaMan;
+}
+
+std::unique_ptr<meta::IndexManager> memIndexMan(IndexENV type) {
+    auto indexMan = std::make_unique<mock::AdHocIndexManager>();
+    switch (type) {
+        case IndexENV::NO_INDEX :
+            break;
+        case IndexENV::ONE_INDEX : {
+            indexMan->addTagIndex(spaceId, indexId, tagId, mockTagIndexColumns());
+            break;
+        }
+        case IndexENV::INVALID_INDEX : {
+            indexMan->addTagIndex(spaceId, indexId, -1, mockTagIndexColumns());
+            break;
+        }
+        case IndexENV::MULITPLE_INDEX : {
+            indexMan->addTagIndex(spaceId, indexId, tagId, mockTagIndexColumns());
+            indexMan->addTagIndex(spaceId, indexId + 1, tagId, mockTagIndexColumns());
+            indexMan->addTagIndex(spaceId, indexId + 2, tagId, mockTagIndexColumns());
+            break;
+        }
+    }
+    return indexMan;
+}
+
+std::vector<NewVertex> genVertices(size_t vLen, int32_t &vId) {
+    std::vector<NewVertex> vertices;
     for (auto i = 0; i < FLAGS_bulk_insert_size; i++) {
-        storage::cpp2::Vertex v;
-        v.set_id(++vId);
-        decltype(v.tags) tags;
-        storage::cpp2::Tag tag;
-        tag.set_tag_id(tagId);
-        auto props = TestUtils::setupEncode();
-        tag.set_props(std::move(props));
-        tags.emplace_back(std::move(tag));
-        v.set_tags(std::move(tags));
-        vertices.emplace_back(std::move(v));
+        NewVertex newVertex;
+        NewTag newTag;
+        newTag.set_tag_id(tagId);
+        std::vector<Value>  props;
+        props.emplace_back(Value(1L + i));
+        props.emplace_back(Value(2L + i));
+        props.emplace_back(Value(3L + i));
+        newTag.set_props(std::move(props));
+        std::vector<nebula::storage::cpp2::NewTag> newTags;
+        newTags.push_back(std::move(newTag));
+        newVertex.set_id(toVertexId(vLen, vId++));
+        newVertex.set_tags(std::move(newTags));
+        vertices.emplace_back(std::move(newVertex));
     }
     return vertices;
 }
 
-bool processVertices(kvstore::KVStore* kv,
-                     meta::SchemaManager* schemaMan,
-                     meta::IndexManager* indexMan,
-                     VertexID &vId) {
+bool processVertices(StorageEnv* env, int32_t &vId) {
     cpp2::AddVerticesRequest req;
     BENCHMARK_SUSPEND {
-        req.space_id = 0;
-        req.overwritable = true;
-        std::vector<cpp2::Vertex> vertices;
-        auto v = genVertices(vId, 1);
-        vertices.insert(vertices.end(), v.begin(), v.end());
-        req.parts.emplace(0, std::move(vertices));
+        req.set_space_id(1);
+        req.set_overwritable(true);
+        auto newVertex = genVertices(32, vId);
+        req.parts[1] = std::move(newVertex);
     };
 
-    auto* processor = AddVerticesProcessor::instance(kv, schemaMan, indexMan, nullptr);
+    auto* processor = AddVerticesProcessor::instance(env, nullptr);
     auto fut = processor->getFuture();
-    processor->process(std::move(req));
+    processor->process(req);
     auto resp = std::move(fut).get();
     BENCHMARK_SUSPEND {
-        if (resp.result.failed_codes.size() > 0) {
+        if (!resp.result.failed_parts.empty()) {
             return false;
         }
     };
     return true;
 }
 
+void initEnv(IndexENV type,
+             const std::string& dataPath,
+             std::unique_ptr<storage::StorageEnv>& env,
+             std::unique_ptr<kvstore::NebulaStore>& kv,
+             std::unique_ptr<meta::SchemaManager>& sm,
+             std::unique_ptr<meta::IndexManager>& im) {
+    env = std::make_unique<StorageEnv>();
+    const std::vector<PartitionID> parts{1};
+    kvstore::KVOptions options;
+    HostAddr localHost = HostAddr("0", 0);
+    LOG(INFO) << "Use meta in memory!";
+    options.partMan_ = memPartMan(parts);
+    std::vector<std::string> paths;
+    paths.emplace_back(folly::stringPrintf("%s/disk1", dataPath.c_str()));
+    paths.emplace_back(folly::stringPrintf("%s/disk2", dataPath.c_str()));
+    options.dataPaths_ = std::move(paths);
+    kv = mock::MockCluster::initKV(std::move(options), localHost);
+    mock::MockCluster::waitUntilAllElected(kv.get(), 1, parts);
+    sm = memSchemaMan();
+    im = memIndexMan(type);
+    env->schemaMan_ = std::move(sm).get();
+    env->indexMan_ = std::move(im).get();
+    env->kvstore_ = std::move(kv).get();
+}
+
 void insertVertices(bool withoutIndex) {
-    std::unique_ptr<kvstore::KVStore> kv;
-    std::unique_ptr<meta::SchemaManager> schemaMan;
-    std::unique_ptr<meta::IndexManager> indexMan;
-    VertexID vId = 0;
+    std::unique_ptr<storage::StorageEnv> env;
+    std::unique_ptr<kvstore::NebulaStore> kv;
+    std::unique_ptr<meta::SchemaManager> sm;
+    std::unique_ptr<meta::IndexManager> im;
+    int32_t vId = 0;
     BENCHMARK_SUSPEND {
-        std::string rootPath;
-        if (withoutIndex) {
-            rootPath = folly::stringPrintf("%s/%s",
-                                           FLAGS_root_data_path.c_str(),
-                                           "withoutIndex");
-        } else {
-            rootPath = folly::stringPrintf("%s/%s",
-                                           FLAGS_root_data_path.c_str(),
-                                           "attachIndex");
-        }
-        kv = TestUtils::initKV(std::move(rootPath).c_str());
-        if (withoutIndex) {
-            indexMan = std::make_unique<nebula::storage::AdHocIndexManager>();
-            schemaMan = TestUtils::mockSchemaMan();
-        } else {
-            indexMan = TestUtils::mockIndexMan(0, 3001, 3002);
-            schemaMan = TestUtils::mockSchemaMan();
-        }
+        std::string dataPath = withoutIndex
+                               ? folly::stringPrintf("%s/%s", FLAGS_root_data_path.c_str(),
+                                                     "withoutIndex")
+                               : folly::stringPrintf("%s/%s", FLAGS_root_data_path.c_str(),
+                                                     "attachIndex");
+        auto type = withoutIndex ? IndexENV::NO_INDEX : IndexENV::ONE_INDEX;
+        initEnv(type, dataPath, env, kv, sm, im);
     };
+
     while (vId < FLAGS_total_vertices_size) {
-        if (!processVertices(kv.get(), schemaMan.get(), indexMan.get(), vId)) {
+        if (!processVertices(env.get(), vId)) {
             LOG(ERROR) << "Vertices bulk insert error";
             return;
         }
     }
     BENCHMARK_SUSPEND {
         if (withoutIndex) {
-            auto prefix = NebulaKeyUtils::prefix(0);
+            auto prefix = NebulaKeyUtils::partPrefix(1);
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -119,9 +218,9 @@ void insertVertices(bool withoutIndex) {
             }
         } else {
             {
-                auto prefix = NebulaKeyUtils::prefix(0);
+                auto prefix = NebulaKeyUtils::partPrefix(1);
                 std::unique_ptr<kvstore::KVIterator> iter;
-                auto status = kv->prefix(0, 0, prefix, &iter);
+                auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
                 if (status != kvstore::ResultCode::SUCCEEDED) {
                     LOG(ERROR) << "Index scan error";
                     return;
@@ -139,9 +238,9 @@ void insertVertices(bool withoutIndex) {
                 }
             }
             {
-                auto prefix = NebulaKeyUtils::indexPrefix(0, 1);
+                auto prefix = IndexKeyUtils::indexPrefix(1, 1);
                 std::unique_ptr<kvstore::KVIterator> iter;
-                auto status = kv->prefix(0, 0, prefix, &iter);
+                auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
                 if (status != kvstore::ResultCode::SUCCEEDED) {
                     LOG(ERROR) << "Index scan error";
                     return;
@@ -161,34 +260,37 @@ void insertVertices(bool withoutIndex) {
         }
     };
     BENCHMARK_SUSPEND {
-        schemaMan.release();
-        kv.release();
+        im.reset();
+        kv.reset();
+        sm.reset();
+        env.reset();
         fs::FileUtils::remove(FLAGS_root_data_path.c_str(), true);
     };
 }
 
 void insertUnmatchIndex() {
-    std::unique_ptr<kvstore::KVStore> kv;
-    std::unique_ptr<meta::SchemaManager> schemaMan;
-    std::unique_ptr<meta::IndexManager> indexMan;
-    VertexID vId = 0;
+    std::unique_ptr<storage::StorageEnv> env;
+    std::unique_ptr<kvstore::NebulaStore> kv;
+    std::unique_ptr<meta::SchemaManager> sm;
+    std::unique_ptr<meta::IndexManager> im;
+    int32_t vId = 0;
     BENCHMARK_SUSPEND {
-        auto rootPath = folly::stringPrintf("%s/%s", FLAGS_root_data_path.c_str(), "unmatchIndex");
-        kv = TestUtils::initKV(std::move(rootPath).c_str());
-        indexMan = TestUtils::mockIndexMan(0, 2001, 2002);
-        schemaMan = TestUtils::mockSchemaMan(0);
+        std::string dataPath = folly::stringPrintf("%s/%s", FLAGS_root_data_path.c_str(),
+                                                   "unmatchIndex");
+        initEnv(IndexENV::INVALID_INDEX, dataPath, env, kv, sm, im);
     };
+
     while (vId < FLAGS_total_vertices_size) {
-        if (!processVertices(kv.get(), schemaMan.get(), indexMan.get(), vId)) {
+        if (!processVertices(env.get(), vId)) {
             LOG(ERROR) << "Vertices bulk insert error";
             return;
         }
     }
     BENCHMARK_SUSPEND {
         {
-            auto prefix = NebulaKeyUtils::prefix(0);
+            auto prefix = NebulaKeyUtils::partPrefix(1);
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -206,9 +308,9 @@ void insertUnmatchIndex() {
             }
         }
         {
-            auto prefix = NebulaKeyUtils::indexPrefix(0, 1);
+            auto prefix = IndexKeyUtils::indexPrefix(spaceId, 1);
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -227,29 +329,37 @@ void insertUnmatchIndex() {
         }
     };
     BENCHMARK_SUSPEND {
-        schemaMan.release();
-        kv.release();
+        im.reset();
+        kv.reset();
+        sm.reset();
+        env.reset();
         fs::FileUtils::remove(FLAGS_root_data_path.c_str(), true);
     };
 }
 
 void insertDupVertices() {
-    std::unique_ptr<kvstore::KVStore> kv;
-    std::unique_ptr<meta::SchemaManager> schemaMan;
-    std::unique_ptr<meta::IndexManager> indexMan;
-    VertexID vId = 0;
+    std::unique_ptr<storage::StorageEnv> env;
+    std::unique_ptr<kvstore::NebulaStore> kv;
+    std::unique_ptr<meta::SchemaManager> sm;
+    std::unique_ptr<meta::IndexManager> im;
+    int32_t vId = 0;
     BENCHMARK_SUSPEND {
-        auto rootPath = folly::stringPrintf("%s/%s",
-                                            FLAGS_root_data_path.c_str(),
-                                            "duplicateIndex");
-        kv = TestUtils::initKV(std::move(rootPath).c_str());
-        schemaMan = TestUtils::mockSchemaMan();
-        indexMan = TestUtils::mockIndexMan(0, 3001, 3002);
+        std::string dataPath = folly::stringPrintf("%s/%s",
+                                                   FLAGS_root_data_path.c_str(),
+                                                   "duplicateIndex");
+        initEnv(IndexENV::ONE_INDEX, dataPath, env, kv, sm, im);
     };
 
     while (vId < FLAGS_total_vertices_size) {
-        if (!processVertices(kv.get(), schemaMan.get(), indexMan.get(), vId) ||
-                !processVertices(kv.get(), schemaMan.get(), indexMan.get(), vId)) {
+        if (!processVertices(env.get(), vId)) {
+            LOG(ERROR) << "Vertices bulk insert error";
+            return;
+        }
+    }
+
+    vId = 0;
+    while (vId < FLAGS_total_vertices_size) {
+        if (!processVertices(env.get(), vId)) {
             LOG(ERROR) << "Vertices bulk insert error";
             return;
         }
@@ -257,9 +367,9 @@ void insertDupVertices() {
 
     BENCHMARK_SUSPEND {
         {
-            auto prefix = NebulaKeyUtils::prefix(0);
+            auto prefix = NebulaKeyUtils::partPrefix(1);
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -277,9 +387,9 @@ void insertDupVertices() {
             }
         }
         {
-            auto prefix = NebulaKeyUtils::indexPrefix(0, 1);
+            auto prefix = IndexKeyUtils::indexPrefix(1, 1);
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -298,29 +408,29 @@ void insertDupVertices() {
         }
     };
     BENCHMARK_SUSPEND {
-        schemaMan.release();
-        kv.release();
+        im.reset();
+        kv.reset();
+        sm.reset();
+        env.reset();
         fs::FileUtils::remove(FLAGS_root_data_path.c_str(), true);
     };
 }
 
 void insertVerticesMultIndex() {
-    std::unique_ptr<kvstore::KVStore> kv;
-    std::unique_ptr<meta::SchemaManager> schemaMan;
-    std::unique_ptr<meta::IndexManager> indexMan;
-    VertexID vId = 0;
+    std::unique_ptr<storage::StorageEnv> env;
+    std::unique_ptr<kvstore::NebulaStore> kv;
+    std::unique_ptr<meta::SchemaManager> sm;
+    std::unique_ptr<meta::IndexManager> im;
+    int32_t vId = 0;
     BENCHMARK_SUSPEND {
-        std::string rootPath;
-        rootPath = folly::stringPrintf("%s/%s",
-                                       FLAGS_root_data_path.c_str(),
-                                       "multIndex");
-
-        kv = TestUtils::initKV(std::move(rootPath).c_str());
-        indexMan = TestUtils::mockMultiIndexMan(0, 3001, 3002);
-        schemaMan = TestUtils::mockSchemaMan(0);
+        std::string dataPath = folly::stringPrintf("%s/%s",
+                                                   FLAGS_root_data_path.c_str(),
+                                                   "multIndex");
+        initEnv(IndexENV::MULITPLE_INDEX, dataPath, env, kv, sm, im);
     };
+
     while (vId < FLAGS_total_vertices_size) {
-        if (!processVertices(kv.get(), schemaMan.get(), indexMan.get(), vId)) {
+        if (!processVertices(env.get(), vId)) {
             LOG(ERROR) << "Vertices bulk insert error";
             return;
         }
@@ -328,9 +438,9 @@ void insertVerticesMultIndex() {
 
     BENCHMARK_SUSPEND {
         {
-            auto prefix = NebulaKeyUtils::prefix(0);
+            auto prefix = NebulaKeyUtils::partPrefix(1);
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -348,13 +458,13 @@ void insertVerticesMultIndex() {
             }
         }
         {
-            PartitionID partId = 0;
+            PartitionID partId = 1;
             PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kIndex);
             std::string prefix;
             prefix.reserve(sizeof(PartitionID));
             prefix.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID));
             std::unique_ptr<kvstore::KVIterator> iter;
-            auto status = kv->prefix(0, 0, prefix, &iter);
+            auto status = env->kvstore_->prefix(spaceId, 1, prefix, &iter);
             if (status != kvstore::ResultCode::SUCCEEDED) {
                 LOG(ERROR) << "Index scan error";
                 return;
@@ -373,8 +483,10 @@ void insertVerticesMultIndex() {
         }
     };
     BENCHMARK_SUSPEND {
-        schemaMan.release();
-        kv.release();
+        im.reset();
+        kv.reset();
+        sm.reset();
+        env.reset();
         fs::FileUtils::remove(FLAGS_root_data_path.c_str(), true);
     };
 }
@@ -414,60 +526,107 @@ unmatchIndex: Without match index, and through asyncAtomicOp.
 attachIndex: One index, the index contains all the columns of tag.
 duplicateVerticesIndex: One index, and insert deplicate vertices.
 multipleIndex: Three indexes by one tag.
-
-
+V 1.0
 --total_vertices_size=2000000
 ============================================================================
 src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
 ============================================================================
-withoutIndex                                                  3.00s  333.45m
-unmatchIndex                                                  4.72s  212.02m
-attachIndex                                                  40.56s   24.66m
-duplicateVerticesIndex                                       46.14s   21.67m
-multipleIndex                                               1.19min   14.00m
+withoutIndex                                                  7.06s  141.71m
+unmatchIndex                                                  9.50s  105.25m
+attachIndex                                                  57.87s   17.28m
+duplicateVerticesIndex                                      2.82min    5.92m
+multipleIndex                                               1.96min    8.51m
 ============================================================================
-
 --total_vertices_size=1000000
 ============================================================================
 src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
 ============================================================================
-withoutIndex                                                  1.49s  672.17m
-unmatchIndex                                                  2.40s  415.88m
-attachIndex                                                  19.57s   51.11m
-duplicateVerticesIndex                                       21.22s   47.12m
-multipleIndex                                                33.55s   29.81m
+withoutIndex                                                  3.42s  292.08m
+unmatchIndex                                                  4.64s  215.37m
+attachIndex                                                  26.83s   37.27m
+duplicateVerticesIndex                                      1.35min   12.37m
+multipleIndex                                                57.88s   17.28m
 ============================================================================
-
 --total_vertices_size=100000
 ============================================================================
 src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
 ============================================================================
-withoutIndex                                               136.06ms     7.35
-unmatchIndex                                               207.66ms     4.82
-attachIndex                                                   1.53s  651.66m
-duplicateVerticesIndex                                        1.55s  647.09m
-multipleIndex                                                 2.41s  414.81m
+withoutIndex                                               302.34ms     3.31
+unmatchIndex                                               411.87ms     2.43
+attachIndex                                                   2.24s  447.23m
+duplicateVerticesIndex                                        5.95s  167.96m
+multipleIndex                                                 3.36s  297.95m
 ============================================================================
-
 --total_vertices_size=10000
 ============================================================================
 src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
 ============================================================================
-withoutIndex                                                13.07ms    76.50
-unmatchIndex                                                20.58ms    48.59
-attachIndex                                                148.69ms     6.73
-duplicateVerticesIndex                                     140.48ms     7.12
-multipleIndex                                              214.98ms     4.65
+withoutIndex                                                28.02ms    35.69
+unmatchIndex                                                42.00ms    23.81
+attachIndex                                                233.70ms     4.28
+duplicateVerticesIndex                                     578.98ms     1.73
+multipleIndex                                              438.78ms     2.28
 ============================================================================
-
 --total_vertices_size=1000
 ============================================================================
 src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
 ============================================================================
-withoutIndex                                                 1.42ms   702.73
-unmatchIndex                                                 3.00ms   333.57
-attachIndex                                                 13.92ms    71.85
-duplicateVerticesIndex                                      13.94ms    71.72
-multipleIndex                                               20.45ms    48.91
+withoutIndex                                                 2.80ms   357.39
+unmatchIndex                                                 4.93ms   202.65
+attachIndex                                                 29.17ms    34.28
+duplicateVerticesIndex                                      75.71ms    13.21
+multipleIndex                                               42.66ms    23.44
+============================================================================
+
+V 2.0
+--total_vertices_size=2000000
+============================================================================
+src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
+============================================================================
+withoutIndex                                                  5.85s  170.92m
+unmatchIndex                                                  6.23s  160.60m
+attachIndex                                                  20.57s   48.61m
+duplicateVerticesIndex                                      1.01min   16.56m
+multipleIndex                                               1.03min   16.20m
+============================================================================
+--total_vertices_size=1000000
+============================================================================
+src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
+============================================================================
+withoutIndex                                                  2.75s  364.19m
+unmatchIndex                                                  3.52s  284.10m
+attachIndex                                                   8.39s  119.24m
+duplicateVerticesIndex                                       23.06s   43.37m
+multipleIndex                                                26.67s   37.50m
+============================================================================
+--total_vertices_size=100000
+============================================================================
+src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
+============================================================================
+withoutIndex                                               249.19ms     4.01
+unmatchIndex                                               262.50ms     3.81
+attachIndex                                                755.14ms     1.32
+duplicateVerticesIndex                                        1.77s  564.09m
+multipleIndex                                                 1.23s  813.10m
+============================================================================
+--total_vertices_size=10000
+============================================================================
+src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
+============================================================================
+withoutIndex                                                24.60ms    40.65
+unmatchIndex                                                28.94ms    34.55
+attachIndex                                                 70.85ms    14.11
+duplicateVerticesIndex                                     162.35ms     6.16
+multipleIndex                                              142.78ms     7.00
+============================================================================
+--total_vertices_size=1000
+============================================================================
+src/storage/test/StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
+============================================================================
+withoutIndex                                                 2.97ms   336.30
+unmatchIndex                                                 4.19ms   238.76
+attachIndex                                                 10.24ms    97.65
+duplicateVerticesIndex                                      19.40ms    51.55
+multipleIndex                                               19.13ms    52.29
 ============================================================================
 **/


### PR DESCRIPTION
This PR from PR #46 , Because repo changed to public. using this one instead of #46 .

Compared with nebula1.0, nebula2.0 performance has been greatly improved.
Performance improvement reasons:

Implement a wait-free AtomicLogBuffer PR #16

- RowWriter decode and encode
- Performance compared with nebula1.0:

```
V1.0
--total_vertices_size=1000000
============================================
StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
============================================
withoutIndex                                                  3.42s  292.08m
unmatchIndex                                                  4.64s  215.37m
attachIndex                                                  26.83s   37.27m
duplicateVerticesIndex                                      1.35min   12.37m
multipleIndex                                                57.88s   17.28m
============================================

V2.0
--total_vertices_size=1000000
=============================================
StorageIndexWriteBenchmark.cpprelative  time/iter  iters/s
=============================================
withoutIndex                                                  2.75s  364.19m
unmatchIndex                                                  3.52s  284.10m
attachIndex                                                   8.39s  119.24m
duplicateVerticesIndex                                       23.06s   43.37m
multipleIndex                                                26.67s   37.50m
=============================================
```