### PR TITLE
Feature/collect tags

### DIFF
--- a/src/storage/CommonUtils.cpp
+++ b/src/storage/CommonUtils.cpp
@@ -29,5 +29,10 @@ bool CommonUtils::checkDataExpiredForTTL(const meta::SchemaProviderIf* schema,
     return false;
 }
 
+/*static*/ const std::unordered_set<std::string> PlanContext::reservedVertexProps = {
+    "_tags"
+};
+
+
 }  // namespace storage
 }  // namespace nebula

--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -67,6 +67,8 @@ public:
     bool                                insert_ = false;
 
     ResultStatus                        resultStat_{ResultStatus::NORMAL};
+
+    static const std::unordered_set<std::string> reservedVertexProps;
 };
 
 class CommonUtils final {

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -61,7 +61,7 @@ public:
             return kvstore::ResultCode::ERR_INVALID_DATA;
         }
 
-        result.values.resize(tagColIndexes_.size(), NullType::__NULL__);
+        result.values.resize(tagColIndexes_.size());
         // add result of each tag node to tagResult
         for (auto* tagNode : tagNodes_) {
             const auto& tagName = tagNode->getTagName();

--- a/src/storage/exec/RelNode.h
+++ b/src/storage/exec/RelNode.h
@@ -115,6 +115,10 @@ protected:
             StorageExpressionContext* ctx = nullptr) {
         for (auto& prop : *props) {
             VLOG(2) << "Collect prop " << prop.name_ << ", type " << tagId;
+            if (PlanContext::reservedVertexProps.find(prop.name_) !=
+                PlanContext::reservedVertexProps.end()) {
+                continue;
+            }
             auto status = QueryUtils::readValue(reader, prop.name_, prop.field_);
             if (!status.ok()) {
                 return kvstore::ResultCode::ERR_TAG_PROP_NOT_FOUND;

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -104,8 +104,12 @@ public:
         return nullptr;
     }
 
-    const std::string& getTagName() {
+    const std::string& getTagName() const {
         return tagName_;
+    }
+
+    const std::vector<PropContext>* props() const {
+        return props_;
     }
 
 private:

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -30,11 +30,13 @@ public:
         , expCtx_(expCtx)
         , exp_(exp) {
         UNUSED(expCtx_); UNUSED(exp_);
-        auto schemaIter = tagContext_->schemas_.find(tagId_);
-        CHECK(schemaIter != tagContext_->schemas_.end());
-        CHECK(!schemaIter->second.empty());
-        schemas_ = &(schemaIter->second);
-        ttl_ = QueryUtils::getTagTTLInfo(tagContext_, tagId_);
+        if (tagContext_->tagNames_[tagId] != "__dummy_tag") {
+            auto schemaIter = tagContext_->schemas_.find(tagId_);
+            CHECK(schemaIter != tagContext_->schemas_.end());
+            CHECK(!schemaIter->second.empty());
+            schemas_ = &(schemaIter->second);
+            ttl_ = QueryUtils::getTagTTLInfo(tagContext_, tagId_);
+        }
         tagName_ = tagContext_->tagNames_[tagId_];
     }
 
@@ -70,6 +72,9 @@ public:
 
     kvstore::ResultCode collectTagPropsIfValid(NullHandler nullHandler,
                                                TagPropHandler valueHandler) {
+        if (tagName_ == "__dummy_tag") {
+            return kvstore::ResultCode::SUCCEEDED;
+        }
         if (!iter_ || !iter_->valid()) {
             return nullHandler(props_);
         }

--- a/src/storage/query/GetNeighborsProcessor.h
+++ b/src/storage/query/GetNeighborsProcessor.h
@@ -56,6 +56,7 @@ protected:
 
 private:
     std::unique_ptr<StorageExpressionContext> expCtx_;
+    std::unordered_set<std::string> reservedProps_;
 };
 
 }  // namespace storage

--- a/src/storage/query/GetPropProcessor.h
+++ b/src/storage/query/GetPropProcessor.h
@@ -54,6 +54,7 @@ private:
     bool isEdge_ = false;                   // true for edge, false for tag
     std::unique_ptr<StorageExpressionContext> expCtx_;
     std::vector<std::unique_ptr<Expression>> yields_;
+    std::unordered_set<std::string> reservedProps_;
 };
 
 }  // namespace storage

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -144,9 +144,11 @@ protected:
     cpp2::ErrorCode getSpaceEdgeSchema();
 
     // build tagContexts_ according to return props
-    cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps);
+    cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps,
+                                      const std::vector<cpp2::VertexProp>& dummyTags = {});
     // build edgeContexts_ according to return props
     cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps);
+    static bool completeReservedVertexProps(const std::vector<std::string>& props);
 
     cpp2::ErrorCode buildFilter(const REQ& req);
     cpp2::ErrorCode buildYields(const REQ& req);
@@ -156,6 +158,7 @@ protected:
     void buildEdgeTTLInfo();
 
     std::vector<cpp2::VertexProp> buildAllTagProps();
+    std::vector<cpp2::VertexProp> buildAllTagWithoutProps();
     std::vector<cpp2::EdgeProp> buildAllEdgeProps(const cpp2::EdgeDirection& direction);
 
     cpp2::ErrorCode checkExp(const Expression* exp, bool returned, bool filtered);

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -1589,6 +1589,82 @@ TEST(GetNeighborsTest, FilterTest) {
     }
 }
 
+TEST(GetNeighborsTest, GetTagsTest) {
+    fs::TempDir rootPath("/tmp/GetNeighborsTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path());
+    auto* env = cluster.storageEnv_.get();
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_EQ(true, QueryTestUtils::mockVertexData(env, totalParts));
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env, totalParts));
+
+    TagID player = 1;
+    EdgeType serve = 101;
+
+    {
+        LOG(INFO) << "OneOutEdgeMultiProperty";
+        std::vector<VertexID> vertices = {"Tim Duncan"};
+        std::vector<EdgeType> over = {serve};
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        tags.emplace_back(-1, std::vector<std::string>{"_tags"});
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+
+        auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+
+        ASSERT_EQ(0, resp.result.failed_parts.size());
+        // vId, stat, player, serve, expr
+        QueryTestUtils::checkResponse(resp.vertices,
+                                      vertices,
+                                      over,
+                                      tags,
+                                      edges,
+                                      1, 6, nullptr, List({"1"}));
+    }
+    // mix reserved properties and normal properties
+    {
+        LOG(INFO) << "OneOutEdgeMultiProperty";
+        std::vector<VertexID> vertices = {"Tim Duncan"};
+        std::vector<EdgeType> over = {serve};
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        tags.emplace_back(-1, std::vector<std::string>{"_tags", "name"});
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+
+        auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+
+        ASSERT_EQ(1, resp.result.failed_parts.size());
+    }
+    // mix reserved properties and normal properties
+    {
+        LOG(INFO) << "OneOutEdgeMultiProperty";
+        std::vector<VertexID> vertices = {"Tim Duncan"};
+        std::vector<EdgeType> over = {serve};
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore", "_tags"});
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+
+        auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+
+        ASSERT_EQ(1, resp.result.failed_parts.size());
+    }
+}
+
 }  // namespace storage
 }  // namespace nebula
 

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -421,6 +421,23 @@ TEST(GetPropTest, GetTagsTest) {
             verifyResultWithoutOrder(expected, resp.props);
         }
     }
+
+    // mix reserved properties and normal properties
+    {
+        LOG(INFO) << "GetVertexProp";
+        std::vector<VertexID> vertices = {"Tim Duncan"};
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(std::make_pair(23333/*ignore*/,
+                                         std::vector<std::string>{"_tags", "age"}));
+        auto req = buildVertexRequest(totalParts, vertices, tags);
+
+        auto* processor = GetPropProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+
+        ASSERT_EQ(1, resp.result.failed_parts.size());
+    }
 }
 
 }  // namespace storage

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -372,7 +372,7 @@ TEST(GetPropTest, GetTagsTest) {
         LOG(INFO) << "GetVertexProp";
         std::vector<VertexID> vertices = {"Tim Duncan"};
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
-        tags.emplace_back(std::make_pair(233333/*ignore*/,
+        tags.emplace_back(std::make_pair(-1/*ignore*/,
                                          std::vector<std::string>{"_tags"}));
         auto req = buildVertexRequest(totalParts, vertices, tags);
 
@@ -398,7 +398,7 @@ TEST(GetPropTest, GetTagsTest) {
         LOG(INFO) << "GetVertexProp";
         std::vector<VertexID> vertices = {"Tim Duncan", "Tony Parker"};
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
-        tags.emplace_back(std::make_pair(23333/*ignore*/,
+        tags.emplace_back(std::make_pair(-1/*ignore*/,
                                          std::vector<std::string>{"_tags"}));
         tags.emplace_back(std::make_pair(1, std::vector<std::string>{"age"}));
         auto req = buildVertexRequest(totalParts, vertices, tags);
@@ -427,7 +427,7 @@ TEST(GetPropTest, GetTagsTest) {
         LOG(INFO) << "GetVertexProp";
         std::vector<VertexID> vertices = {"Tim Duncan"};
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
-        tags.emplace_back(std::make_pair(23333/*ignore*/,
+        tags.emplace_back(std::make_pair(-1/*ignore*/,
                                          std::vector<std::string>{"_tags", "age"}));
         auto req = buildVertexRequest(totalParts, vertices, tags);
 

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -438,6 +438,22 @@ TEST(GetPropTest, GetTagsTest) {
 
         ASSERT_EQ(1, resp.result.failed_parts.size());
     }
+    // mix reserved properties and normal properties
+    {
+        LOG(INFO) << "GetVertexProp";
+        std::vector<VertexID> vertices = {"Tim Duncan"};
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(std::make_pair(1/*ignore*/,
+                                         std::vector<std::string>{"_tags", "age"}));
+        auto req = buildVertexRequest(totalParts, vertices, tags);
+
+        auto* processor = GetPropProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+
+        ASSERT_EQ(1, resp.result.failed_parts.size());
+    }
 }
 
 }  // namespace storage


### PR DESCRIPTION
[NG-181] Add a reserved property `_tags` to get tags of one vertex which typed `List<string>`. To implement it I add a implicit rule for getProps RPC that the properties format like `_LABEL` is reserved properties that will ignore the tag in process.