### PR TITLE
return EMPTY instead of NULL in GetNeighbors and GetProp

### DIFF
--- a/src/storage/exec/AggregateNode.h
+++ b/src/storage/exec/AggregateNode.h
@@ -50,7 +50,7 @@ public:
         if (edgeContext_->statCount_ > 0) {
             initStatValue(edgeContext_);
         }
-        this->result_ = NullType::__NULL__;
+        this->result_ = Value();
         return kvstore::ResultCode::SUCCEEDED;
     }
 

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -49,7 +49,7 @@ public:
         // vertexId is the first column
         row.emplace_back(vId);
         // second column is reserved for stat
-        row.emplace_back(NullType::__NULL__);
+        row.emplace_back(Value());
 
         auto tagResult = hashJoinNode_->result().getList();
         for (auto& value : tagResult.values) {
@@ -57,8 +57,7 @@ public:
         }
 
         // add default null for each edge node and the last column of yield expression
-        row.resize(row.size() + edgeContext_->propContexts_.size() + 1,
-                   NullType::__NULL__);
+        row.resize(row.size() + edgeContext_->propContexts_.size() + 1, Value());
 
         ret = iterateEdges(row);
         if (ret != kvstore::ResultCode::SUCCEEDED) {
@@ -103,7 +102,7 @@ protected:
             }
 
             // add edge prop value to the target column
-            if (row[columnIdx].type() == Value::Type::NULLVALUE) {
+            if (row[columnIdx].type() == Value::Type::__EMPTY__) {
                 row[columnIdx].setList(nebula::List());
             }
             auto& cell = row[columnIdx].mutableList();
@@ -155,7 +154,7 @@ private:
         for (auto& sample : samples) {
             auto columnIdx = std::get<4>(sample);
             // add edge prop value to the target column
-            if (row[columnIdx].type() == Value::Type::NULLVALUE) {
+            if (row[columnIdx].type() == Value::Type::__EMPTY__) {
                 row[columnIdx].setList(nebula::List());
             }
 

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -102,7 +102,7 @@ protected:
             }
 
             // add edge prop value to the target column
-            if (row[columnIdx].type() == Value::Type::__EMPTY__) {
+            if (row[columnIdx].empty()) {
                 row[columnIdx].setList(nebula::List());
             }
             auto& cell = row[columnIdx].mutableList();
@@ -154,7 +154,7 @@ private:
         for (auto& sample : samples) {
             auto columnIdx = std::get<4>(sample);
             // add edge prop value to the target column
-            if (row[columnIdx].type() == Value::Type::__EMPTY__) {
+            if (row[columnIdx].empty()) {
                 row[columnIdx].setList(nebula::List());
             }
 

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -36,7 +36,7 @@ public:
                 [&row] (const std::vector<PropContext>* props) -> kvstore::ResultCode {
                     for (const auto& prop : *props) {
                         if (prop.returned_) {
-                            row.emplace_back(NullType::__NULL__);
+                            row.emplace_back(Value());
                         }
                     }
                     return kvstore::ResultCode::SUCCEEDED;
@@ -93,7 +93,7 @@ public:
                 [&row] (const std::vector<PropContext>* props) -> kvstore::ResultCode {
                     for (const auto& prop : *props) {
                         if (prop.returned_) {
-                            row.emplace_back(NullType::__NULL__);
+                            row.emplace_back(Value());
                         }
                     }
                     return kvstore::ResultCode::SUCCEEDED;

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -19,7 +19,7 @@ namespace storage {
 // HashJoinNode has input of serveral TagNode and EdgeNode, the EdgeNode is several
 // SingleEdgeNode of different edge types all edges of a vertex.
 // The output would be the result of tag, it is a List, each cell save a list of property values,
-// if tag not found, it will be a NullType::__NULL__.
+// if tag not found, it will be a empty value.
 // Also it will return a iterator of edges which can pass ttl check and ready to be read.
 class HashJoinNode : public IterateNode<VertexID> {
 public:
@@ -58,7 +58,7 @@ public:
             const auto& tagName = tagNode->getTagName();
             ret = tagNode->collectTagPropsIfValid(
                 [&result] (const std::vector<PropContext>*) -> kvstore::ResultCode {
-                    result.values.emplace_back(NullType::__NULL__);
+                    result.values.emplace_back(Value());
                     return kvstore::ResultCode::SUCCEEDED;
                 },
                 [this, &result, &tagName] (TagID tagId,

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -581,7 +581,7 @@ TEST(GetNeighborsTest, LimitSampleTest) {
         ASSERT_EQ(1, resp.vertices.rows.size());
         ASSERT_EQ(6, resp.vertices.rows[0].values.size());
         ASSERT_EQ(4, resp.vertices.rows[0].values[3].getList().values.size());
-        ASSERT_EQ(NullType::__NULL__, resp.vertices.rows[0].values[4].getNull());
+        ASSERT_EQ(Value::Type::__EMPTY__, resp.vertices.rows[0].values[4].type());
     }
     {
         LOG(INFO) << "SingleEdgeTypeSample";
@@ -791,10 +791,10 @@ TEST(GetNeighborsTest, TtlTest) {
         // vId, stat, player, serve, expr
         ASSERT_EQ(5, resp.vertices.rows[0].values.size());
         ASSERT_EQ("Tim Duncan", resp.vertices.rows[0].values[0].getStr());
-        ASSERT_EQ(NullType::__NULL__, resp.vertices.rows[0].values[1].getNull());
-        ASSERT_EQ(NullType::__NULL__, resp.vertices.rows[0].values[2].getNull());
-        ASSERT_EQ(NullType::__NULL__, resp.vertices.rows[0].values[3].getNull());
-        ASSERT_EQ(NullType::__NULL__, resp.vertices.rows[0].values[4].getNull());
+        ASSERT_EQ(Value::Type::__EMPTY__, resp.vertices.rows[0].values[1].type());
+        ASSERT_EQ(Value::Type::__EMPTY__, resp.vertices.rows[0].values[2].type());
+        ASSERT_EQ(Value::Type::__EMPTY__, resp.vertices.rows[0].values[3].type());
+        ASSERT_EQ(Value::Type::__EMPTY__, resp.vertices.rows[0].values[4].type());
     }
     {
         LOG(INFO) << "GoFromPlayerOverAll";
@@ -815,15 +815,15 @@ TEST(GetNeighborsTest, TtlTest) {
         ASSERT_EQ(1, resp.vertices.rows.size());
         ASSERT_EQ(10, resp.vertices.rows[0].values.size());
         ASSERT_EQ("Tim Duncan", resp.vertices.rows[0].values[0].getStr());
-        ASSERT_TRUE(resp.vertices.rows[0].values[1].isNull());     // stat
-        ASSERT_TRUE(resp.vertices.rows[0].values[2].isNull());     // player expired
-        ASSERT_TRUE(resp.vertices.rows[0].values[3].isNull());     // team not exists
-        ASSERT_TRUE(resp.vertices.rows[0].values[4].isNull());     // general tag not exists
+        ASSERT_TRUE(resp.vertices.rows[0].values[1].empty());      // stat
+        ASSERT_TRUE(resp.vertices.rows[0].values[2].empty());      // player expired
+        ASSERT_TRUE(resp.vertices.rows[0].values[3].empty());      // team not exists
+        ASSERT_TRUE(resp.vertices.rows[0].values[4].empty());      // general tag not exists
         ASSERT_TRUE(resp.vertices.rows[0].values[5].isList());     // - teammate valid
-        ASSERT_TRUE(resp.vertices.rows[0].values[6].isNull());     // - serve expired
-        ASSERT_TRUE(resp.vertices.rows[0].values[7].isNull());     // + serve expired
+        ASSERT_TRUE(resp.vertices.rows[0].values[6].empty());      // - serve expired
+        ASSERT_TRUE(resp.vertices.rows[0].values[7].empty());      // + serve expired
         ASSERT_TRUE(resp.vertices.rows[0].values[8].isList());     // + teammate valid
-        ASSERT_TRUE(resp.vertices.rows[0].values[9].isNull());     // expr
+        ASSERT_TRUE(resp.vertices.rows[0].values[9].empty());      // expr
     }
     FLAGS_mock_ttl_col = false;
 }
@@ -1182,11 +1182,11 @@ TEST(GetNeighborsTest, FilterTest) {
                              "_edge:+101:teamName:startYear:endYear",
                              "_expr"};
         nebula::Row row({"Tracy McGrady",
-                         NullType::__NULL__,
+                         Value(),
                          nebula::List({"Tracy McGrady", 41, 19.6}),
                          nebula::List({nebula::List({"Magic", 2000, 2004}),
                                        nebula::List({"Rockets", 2004, 2010})}),
-                         NullType::__NULL__});
+                         Value()});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.vertices);
     }
@@ -1230,10 +1230,10 @@ TEST(GetNeighborsTest, FilterTest) {
         auto serveEdges = nebula::List();
         serveEdges.values.emplace_back(nebula::List({"Rockets", 2004, 2010}));
         nebula::Row row({"Tracy McGrady",
-                         NullType::__NULL__,
+                         Value(),
                          nebula::List({"Tracy McGrady", 41, 19.6}),
                          serveEdges,
-                         NullType::__NULL__});
+                         Value()});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.vertices);
     }
@@ -1282,10 +1282,10 @@ TEST(GetNeighborsTest, FilterTest) {
         auto serveEdges = nebula::List();
         serveEdges.values.emplace_back(nebula::List({"Magic", 2000, 2004}));
         nebula::Row row({"Tracy McGrady",
-                         NullType::__NULL__,
+                         Value(),
                          nebula::List({"Tracy McGrady", 41, 19.6}),
                          serveEdges,
-                         NullType::__NULL__});
+                         Value()});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.vertices);
     }
@@ -1331,11 +1331,11 @@ TEST(GetNeighborsTest, FilterTest) {
                              "_edge:+101:teamName:startYear:endYear",
                              "_expr"};
         nebula::Row row({"Tracy McGrady",
-                         NullType::__NULL__,
+                         Value(),
                          nebula::List({"Tracy McGrady", 41, 19.6}),
                          nebula::List({nebula::List({"Magic", 2000, 2004}),
                                        nebula::List({"Rockets", 2004, 2010})}),
-                         NullType::__NULL__});
+                         Value()});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.vertices);
     }
@@ -1385,11 +1385,11 @@ TEST(GetNeighborsTest, FilterTest) {
         ASSERT_EQ(4, resp.vertices.rows.size());
         {
             nebula::Row row({"Tracy McGrady",
-                            NullType::__NULL__,
+                            Value(),
                             nebula::List({"Tracy McGrady", 41, 19.6}),
                             nebula::List({nebula::List({"Magic", 2000, 2004}),
                                           nebula::List({"Rockets", 2004, 2010})}),
-                            NullType::__NULL__});
+                            Value()});
             for (size_t i = 0; i < 4; i++) {
                 if (resp.vertices.rows[i].values[0].getStr() == "Tracy McGrady") {
                     ASSERT_EQ(row, resp.vertices.rows[i]);
@@ -1401,10 +1401,10 @@ TEST(GetNeighborsTest, FilterTest) {
             auto serveEdges = nebula::List();
             serveEdges.values.emplace_back(nebula::List({"Spurs", 1997, 2016}));
             nebula::Row row({"Tim Duncan",
-                            NullType::__NULL__,
+                            Value(),
                             nebula::List({"Tim Duncan", 44, 19.0}),
                             serveEdges,
-                            NullType::__NULL__});
+                            Value()});
             for (size_t i = 0; i < 4; i++) {
                 if (resp.vertices.rows[i].values[0].getStr() == "Tim Duncan") {
                     ASSERT_EQ(row, resp.vertices.rows[i]);
@@ -1416,10 +1416,10 @@ TEST(GetNeighborsTest, FilterTest) {
             // same as 1.0, tag data is returned even if can't pass the filter.
             // no edge satisfies the filter
             nebula::Row row({"Tony Parker",
-                            NullType::__NULL__,
+                            Value(),
                             nebula::List({"Tony Parker", 38, 15.5}),
-                            NullType::__NULL__,
-                            NullType::__NULL__});
+                            Value(),
+                            Value()});
             for (size_t i = 0; i < 4; i++) {
                 if (resp.vertices.rows[i].values[0].getStr() == "Tony Parker") {
                     ASSERT_EQ(row, resp.vertices.rows[i]);
@@ -1431,10 +1431,10 @@ TEST(GetNeighborsTest, FilterTest) {
             // same as 1.0, tag data is returned even if can't pass the filter.
             // no edge satisfies the filter
             nebula::Row row({"Manu Ginobili",
-                            NullType::__NULL__,
+                            Value(),
                             nebula::List({"Manu Ginobili", 42, 13.3}),
-                            NullType::__NULL__,
-                            NullType::__NULL__});
+                            Value(),
+                            Value()});
             for (size_t i = 0; i < 4; i++) {
                 if (resp.vertices.rows[i].values[0].getStr() == "Manu Ginobili") {
                     ASSERT_EQ(row, resp.vertices.rows[i]);
@@ -1483,11 +1483,11 @@ TEST(GetNeighborsTest, FilterTest) {
         // This will only get the edge of serve, which does not make sense
         // see https://github.com/vesoft-inc/nebula/issues/2166
         nebula::Row row({"Tim Duncan",
-                         NullType::__NULL__,
+                         Value(),
                          nebula::List({"Tim Duncan", 44, 19.0}),
                          serveEdges,
-                         NullType::__NULL__,
-                         NullType::__NULL__});
+                         Value(),
+                         Value()});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.vertices);
     }
@@ -1529,12 +1529,12 @@ TEST(GetNeighborsTest, FilterTest) {
             "_expr"};
         nebula::Row row({
             "Spurs",
-            NullType::__NULL__,
+            Value(),
             nebula::List({"Spurs"}),
             nebula::List({nebula::List({"Spurs", 1997, 2016, "Spurs", "Tim Duncan"}),
                             nebula::List({"Spurs", 2001, 2018, "Spurs", "Tony Parker"}),
                             nebula::List({"Spurs", 2015, 2020, "Spurs", "LaMarcus Aldridge"})}),
-            NullType::__NULL__});
+            Value()});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.vertices);
     }
@@ -1580,12 +1580,12 @@ TEST(GetNeighborsTest, FilterTest) {
             "_expr"};
         nebula::Row row({
             "Tim Duncan",
-            NullType::__NULL__,
+            Value(),
             nebula::List({"Tim Duncan", 44, 19.0}),
             nebula::List(nebula::List({"Tim Duncan", 102, "Tony Parker", "Spurs", 2001, 2016})),
             nebula::List(nebula::List({"Tim Duncan", -102, "Tony Parker", "Spurs", 2001, 2016})),
-            NullType::__NULL__,
-            NullType::__NULL__});
+            Value(),
+            Value()});
     }
 }
 

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -254,7 +254,7 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
             std::vector<Value> values {  // player
                 "Tim Duncan", "Tim Duncan", 44, false, 19, 1997, 2016, 1392, 19.0, 1, "America", 5};
             for (size_t i = 0; i < 1 + 11; i++) {  // team and tag3
-                values.emplace_back(NullType::__NULL__);
+                values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));
@@ -288,11 +288,11 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
             std::vector<Value> values;
             // -teammate
             for (size_t i = 0; i < 5 + 4; i++) {
-                values.emplace_back(NullType::__NULL__);
+                values.emplace_back(Value());
             }
             // -serve
             for (size_t i = 0; i < 9 + 4; i++) {
-                values.emplace_back(NullType::__NULL__);
+                values.emplace_back(Value());
             }
             // serve
             values.emplace_back("Tim Duncan");    // src
@@ -310,7 +310,7 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
             values.emplace_back(5);
             // teammate
             for (size_t i = 0; i < 5 + 4; i++) {
-                values.emplace_back(NullType::__NULL__);
+                values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));
@@ -336,7 +336,7 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
             std::vector<Value> values;
             values.emplace_back("Not existed");
             for (size_t i = 0; i < 1 + 11 + 11; i++) {
-                values.emplace_back(NullType::__NULL__);
+                values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));

--- a/src/storage/test/QueryTestUtils.h
+++ b/src/storage/test/QueryTestUtils.h
@@ -252,7 +252,7 @@ public:
                     ASSERT_EQ(expect[i], actual[i]);
                 }
             } else {
-                ASSERT_EQ(NullType::__NULL__, row.values[1].getNull());
+                ASSERT_EQ(Value::Type::__EMPTY__, row.values[1].type());
             }
             checkRowProps(row, dataSet.colNames, tags, edges);
         }
@@ -272,9 +272,9 @@ public:
             auto iter = std::find(vertices.begin(), vertices.end(), vId);
             ASSERT_TRUE(iter != vertices.end());
             // the second column is stats
-            ASSERT_EQ(NullType::__NULL__, row.values[1].getNull());
+            ASSERT_EQ(Value::Type::__EMPTY__, row.values[1].type());
             // the last column is yeild expression
-            ASSERT_EQ(NullType::__NULL__, row.values[expectColumnCount - 1].getNull());
+            ASSERT_EQ(Value::Type::__EMPTY__, row.values[expectColumnCount - 1].type());
             checkRowProps(row, dataSet.colNames, {}, {});
         }
     }
@@ -609,7 +609,7 @@ public:
                         auto tagCell = row.values[i].getList();
                         checkPlayer(props, *iter, tagCell.values);
                     } else {
-                        ASSERT_EQ(NullType::__NULL__, row.values[i].getNull());
+                        ASSERT_EQ(Value::Type::__EMPTY__, row.values[i].type());
                     }
                     break;
                 }
@@ -623,7 +623,7 @@ public:
                         ASSERT_EQ(1, tagCell.values.size());
                         ASSERT_EQ(*iter, tagCell.values[0].getStr());
                     } else {
-                        ASSERT_EQ(NullType::__NULL__, row.values[i].getNull());
+                        ASSERT_EQ(Value::Type::__EMPTY__, row.values[i].type());
                     }
                     break;
                 }
@@ -638,7 +638,7 @@ public:
                             checkOutServe(entryId, props, iter->second, values);
                         }
                     } else {
-                        ASSERT_EQ(NullType::__NULL__, row.values[i].getNull());
+                        ASSERT_EQ(Value::Type::__EMPTY__, row.values[i].type());
                     }
                     break;
                 }
@@ -653,7 +653,7 @@ public:
                             checkInServe(entryId, props, iter->second, values);
                         }
                     } else {
-                        ASSERT_EQ(NullType::__NULL__, row.values[i].getNull());
+                        ASSERT_EQ(Value::Type::__EMPTY__, row.values[i].type());
                     }
                     break;
                 }
@@ -672,7 +672,7 @@ public:
                             checkTeammate(entryId, props, values);
                         }
                     } else {
-                        ASSERT_EQ(NullType::__NULL__, row.values[i].getNull());
+                        ASSERT_EQ(Value::Type::__EMPTY__, row.values[i].type());
                     }
                     break;
                 }


### PR DESCRIPTION
The problem of NULL is that when trying to get multiple tag/edge, it is hard to tell whether the value is really NULL or the vertex doesn't have given tag/edge. For example, `fetch prop on * "Duncan"`.

@nevermore3, all NULL has been changed to EMPTY, including the stat column and expr column in GetNeighbors.