### PR TITLE
Support scan in storage

### DIFF
--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -34,6 +34,7 @@ nebula_add_library(
     mutate/UpdateEdgeProcessor.cpp
     query/GetNeighborsProcessor.cpp
     query/GetPropProcessor.cpp
+    query/ScanVertexProcessor.cpp
     index/LookupProcessor.cpp
 )
 

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -35,6 +35,7 @@ nebula_add_library(
     query/GetNeighborsProcessor.cpp
     query/GetPropProcessor.cpp
     query/ScanVertexProcessor.cpp
+    query/ScanEdgeProcessor.cpp
     index/LookupProcessor.cpp
 )
 

--- a/src/storage/GraphStorageServiceHandler.cpp
+++ b/src/storage/GraphStorageServiceHandler.cpp
@@ -13,6 +13,7 @@
 #include "storage/mutate/UpdateEdgeProcessor.h"
 #include "storage/query/GetNeighborsProcessor.h"
 #include "storage/query/GetPropProcessor.h"
+#include "storage/query/ScanVertexProcessor.h"
 #include "storage/index/LookupProcessor.h"
 
 #define RETURN_FUTURE(processor) \
@@ -80,5 +81,12 @@ GraphStorageServiceHandler::future_lookupIndex(const cpp2::LookupIndexRequest& r
     auto* processor = LookupProcessor::instance(env_, &lookupQpsStat_, &vertexCache_);
     RETURN_FUTURE(processor);
 }
+
+folly::Future<cpp2::ScanVertexResponse>
+GraphStorageServiceHandler::future_scanVertex(const cpp2::ScanVertexRequest& req) {
+    auto* processor = ScanVertexProcessor::instance(env_, &scanVertexQpsStat_);
+    RETURN_FUTURE(processor);
+}
+
 }  // namespace storage
 }  // namespace nebula

--- a/src/storage/GraphStorageServiceHandler.cpp
+++ b/src/storage/GraphStorageServiceHandler.cpp
@@ -14,6 +14,7 @@
 #include "storage/query/GetNeighborsProcessor.h"
 #include "storage/query/GetPropProcessor.h"
 #include "storage/query/ScanVertexProcessor.h"
+#include "storage/query/ScanEdgeProcessor.h"
 #include "storage/index/LookupProcessor.h"
 
 #define RETURN_FUTURE(processor) \
@@ -85,6 +86,12 @@ GraphStorageServiceHandler::future_lookupIndex(const cpp2::LookupIndexRequest& r
 folly::Future<cpp2::ScanVertexResponse>
 GraphStorageServiceHandler::future_scanVertex(const cpp2::ScanVertexRequest& req) {
     auto* processor = ScanVertexProcessor::instance(env_, &scanVertexQpsStat_);
+    RETURN_FUTURE(processor);
+}
+
+folly::Future<cpp2::ScanEdgeResponse>
+GraphStorageServiceHandler::future_scanEdge(const cpp2::ScanEdgeRequest& req) {
+    auto* processor = ScanEdgeProcessor::instance(env_, &scanEdgeQpsStat_);
     RETURN_FUTURE(processor);
 }
 

--- a/src/storage/GraphStorageServiceHandler.h
+++ b/src/storage/GraphStorageServiceHandler.h
@@ -47,6 +47,7 @@ public:
         updateEdgeQpsStat_ = stats::Stats("storage", "update_edge");
         getNeighborsQpsStat_ = stats::Stats("storage", "get_neighbors");
         getPropQpsStat_ = stats::Stats("storage", "get_prop");
+        scanVertexQpsStat_ = stats::Stats("storage", "scan_vertex");
     }
 
     // Vertice section
@@ -78,6 +79,9 @@ public:
     folly::Future<cpp2::LookupIndexResp>
     future_lookupIndex(const cpp2::LookupIndexRequest& req) override;
 
+    folly::Future<cpp2::ScanVertexResponse>
+    future_scanVertex(const cpp2::ScanVertexRequest& req) override;
+
 private:
     StorageEnv*                                     env_{nullptr};
     VertexCache                                     vertexCache_;
@@ -92,6 +96,7 @@ private:
     stats::Stats                                    getNeighborsQpsStat_;
     stats::Stats                                    getPropQpsStat_;
     stats::Stats                                    lookupQpsStat_;
+    stats::Stats                                    scanVertexQpsStat_;
 };
 
 }  // namespace storage

--- a/src/storage/GraphStorageServiceHandler.h
+++ b/src/storage/GraphStorageServiceHandler.h
@@ -48,6 +48,7 @@ public:
         getNeighborsQpsStat_ = stats::Stats("storage", "get_neighbors");
         getPropQpsStat_ = stats::Stats("storage", "get_prop");
         scanVertexQpsStat_ = stats::Stats("storage", "scan_vertex");
+        scanEdgeQpsStat_ = stats::Stats("storage", "scan_edge");
     }
 
     // Vertice section
@@ -82,6 +83,9 @@ public:
     folly::Future<cpp2::ScanVertexResponse>
     future_scanVertex(const cpp2::ScanVertexRequest& req) override;
 
+    folly::Future<cpp2::ScanEdgeResponse>
+    future_scanEdge(const cpp2::ScanEdgeRequest& req) override;
+
 private:
     StorageEnv*                                     env_{nullptr};
     VertexCache                                     vertexCache_;
@@ -97,6 +101,7 @@ private:
     stats::Stats                                    getPropQpsStat_;
     stats::Stats                                    lookupQpsStat_;
     stats::Stats                                    scanVertexQpsStat_;
+    stats::Stats                                    scanEdgeQpsStat_;
 };
 
 }  // namespace storage

--- a/src/storage/admin/AdminTask.h
+++ b/src/storage/admin/AdminTask.h
@@ -119,13 +119,13 @@ public:
     }
 
     virtual void subTaskFinish(cpp2::ErrorCode rc) {
-        static cpp2::ErrorCode suc{cpp2::ErrorCode::SUCCEEDED};
+        cpp2::ErrorCode suc{cpp2::ErrorCode::SUCCEEDED};
         rc_.compare_exchange_strong(suc, rc);
     }
 
     virtual void cancel() {
         FLOG_INFO("task(%d, %d) cancelled", ctx_.jobId_, ctx_.taskId_);
-        static cpp2::ErrorCode suc{cpp2::ErrorCode::SUCCEEDED};
+        cpp2::ErrorCode suc{cpp2::ErrorCode::SUCCEEDED};
         rc_.compare_exchange_strong(suc, cpp2::ErrorCode::E_USER_CANCEL);
     }
 

--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -86,6 +86,22 @@ public:
         return Status::Error(folly::stringPrintf("Invalid property %s", prop.name_.c_str()));
     }
 
+    static Status collectPropsInValue(RowReader* reader,
+                                      const std::vector<PropContext>* props,
+                                      nebula::List& list) {
+        for (const auto& prop : *props) {
+            if (prop.returned_ && prop.propInKeyType_ == PropContext::PropInKeyType::NONE) {
+                VLOG(2) << "Collect prop " << prop.name_;
+                auto value = QueryUtils::readValue(reader, prop.name_, prop.field_);
+                if (!value.ok()) {
+                    return value.status();
+                }
+                list.emplace_back(std::move(value).value());
+            }
+        }
+        return Status::OK();
+    }
+
     // return none if no valid ttl, else return the ttl property name and time
     static folly::Optional<std::pair<std::string, int64_t>>
     getEdgeTTLInfo(EdgeContext* edgeContext, EdgeType edgeType) {

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -148,7 +148,8 @@ protected:
     cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps,
                                       bool returnNoProps = false);
     // build edgeContexts_ according to return props
-    cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps);
+    cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps,
+                                    bool returnNoProps = false);
 
     cpp2::ErrorCode buildFilter(const REQ& req);
     cpp2::ErrorCode buildYields(const REQ& req);

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -145,7 +145,8 @@ protected:
     cpp2::ErrorCode getSpaceEdgeSchema();
 
     // build tagContexts_ according to return props
-    cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps);
+    cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps,
+                                      bool returnNoProps = false);
     // build edgeContexts_ according to return props
     cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps);
 

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -62,7 +62,8 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleVertexProps(
 
 template<typename REQ, typename RESP>
 cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleEdgeProps(
-        std::vector<cpp2::EdgeProp>& edgeProps) {
+        std::vector<cpp2::EdgeProp>& edgeProps,
+        bool returnNoProps) {
     for (auto& edgeProp : edgeProps) {
         auto edgeType = edgeProp.type;
         auto iter = edgeContext_.schemas_.find(std::abs(edgeType));
@@ -79,7 +80,9 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleEdgeProps(
         }
 
         std::vector<PropContext> ctxs;
-        if (!edgeProp.props.empty()) {
+        if (returnNoProps) {
+            // just add the edgeType into edgeContext_
+        } else if (!edgeProp.props.empty()) {
             for (const auto& name : edgeProp.props) {
                 if (name != kSrc && name != kType && name != kRank && name != kDst) {
                     auto field = edgeSchema->field(name);

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -13,7 +13,8 @@ namespace storage {
 
 template<typename REQ, typename RESP>
 cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleVertexProps(
-        std::vector<cpp2::VertexProp>& vertexProps) {
+        std::vector<cpp2::VertexProp>& vertexProps,
+        bool returnNoProps) {
     for (auto& vertexProp : vertexProps) {
         auto tagId = vertexProp.tag;
         auto iter = tagContext_.schemas_.find(tagId);
@@ -30,7 +31,9 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleVertexProps(
         }
 
         std::vector<PropContext> ctxs;
-        if (!vertexProp.props.empty()) {
+        if (returnNoProps) {
+            // just add the tagId into tagContext_
+        } else if (!vertexProp.props.empty()) {
             for (const auto& name : vertexProp.props) {
                 auto field = tagSchema->field(name);
                 if (field == nullptr) {

--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -1,16 +1,13 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
-#include "storage/query/ScanEdgeProcessor.h"
-#include "common/time/WallClock.h"
-#include "common/meta/NebulaSchemaProvider.h"
-#include "utils/NebulaKeyUtils.h"
-#include <algorithm>
-#include "kvstore/RocksEngine.h"
 
-DEFINE_int32(max_scan_block_size, 4 * 1024 * 1024, "Max size of a respsonse block");
+#include "storage/query/ScanEdgeProcessor.h"
+#include "utils/NebulaKeyUtils.h"
+#include "storage/StorageFlags.h"
+#include "storage/exec/QueryUtils.h"
 
 namespace nebula {
 namespace storage {
@@ -18,17 +15,24 @@ namespace storage {
 void ScanEdgeProcessor::process(const cpp2::ScanEdgeRequest& req) {
     spaceId_ = req.get_space_id();
     partId_ = req.get_part_id();
-    returnAllColumns_ = req.get_all_columns();
+    returnNoProps_ = req.get_no_columns();
 
-    auto retCode = checkAndBuildContexts(req);
+    auto retCode = getSpaceVidLen(spaceId_);
     if (retCode != cpp2::ErrorCode::SUCCEEDED) {
-        this->pushResultCode(retCode, partId_);
-        this->onFinished();
+        pushResultCode(retCode, partId_);
+        onFinished();
+        return;
+    }
+
+    retCode = checkAndBuildContexts(req);
+    if (retCode != cpp2::ErrorCode::SUCCEEDED) {
+        pushResultCode(retCode, partId_);
+        onFinished();
         return;
     }
 
     std::string start;
-    std::string prefix = NebulaKeyUtils::prefix(partId_);
+    std::string prefix = NebulaKeyUtils::partPrefix(partId_);
     if (req.get_cursor() == nullptr || req.get_cursor()->empty()) {
         start = prefix;
     } else {
@@ -36,15 +40,13 @@ void ScanEdgeProcessor::process(const cpp2::ScanEdgeRequest& req) {
     }
 
     std::unique_ptr<kvstore::KVIterator> iter;
-    auto kvRet = doRangeWithPrefix(spaceId_, partId_, start, prefix, &iter);
+    auto kvRet = env_->kvstore_->rangeWithPrefix(spaceId_, partId_, start, prefix, &iter);
     if (kvRet != kvstore::ResultCode::SUCCEEDED) {
         pushResultCode(to(kvRet), partId_);
         onFinished();
         return;
     }
 
-    std::vector<cpp2::ScanEdge> edgeData;
-    int32_t rowCount = 0;
     int32_t rowLimit = req.get_limit();
     int64_t startTime = 0, endTime = std::numeric_limits<int64_t>::max();
     if (req.__isset.start_time) {
@@ -55,126 +57,77 @@ void ScanEdgeProcessor::process(const cpp2::ScanEdgeRequest& req) {
     }
     RowReaderWrapper reader;
 
-    for (; iter->valid() && rowCount < rowLimit && blockSize < FLAGS_max_scan_block_size;
-         iter->next()) {
+    for (int32_t rowCount = 0; iter->valid() && rowCount < rowLimit; iter->next()) {
         auto key = iter->key();
-        if (!NebulaKeyUtils::isEdge(key)) {
-            continue;
-        }
-
-        EdgeType edgeType = NebulaKeyUtils::getEdgeType(key);
-        if (edgeType < 0) {
+        if (!NebulaKeyUtils::isEdge(spaceVidLen_, key)) {
             continue;
         }
 
         // only return data within time range [start, end)
-        EdgeVersion version = folly::Endian::big(NebulaKeyUtils::getVersion(key));
+        auto version = folly::Endian::big(NebulaKeyUtils::getVersion(spaceVidLen_, key));
         int64_t ts = std::numeric_limits<int64_t>::max() - version;
-        if (ts < startTime || ts >= endTime) {
+        if (FLAGS_enable_multi_versions && (ts < startTime || ts >= endTime)) {
             continue;
         }
 
-        auto ctxIter = edgeContexts_.find(edgeType);
-        if (ctxIter == edgeContexts_.end()) {
+        auto edgeType = NebulaKeyUtils::getEdgeType(spaceVidLen_, key);
+        auto edgeIter = edgeContext_.indexMap_.find(edgeType);
+        if (edgeIter == edgeContext_.indexMap_.end()) {
             continue;
         }
 
-        auto srcId = NebulaKeyUtils::getSrcId(key);
-        auto dstId = NebulaKeyUtils::getDstId(key);
-        cpp2::ScanEdge data;
-        data.set_src(srcId);
-        data.set_type(edgeType);
-        data.set_dst(dstId);
-        auto value = iter->val();
-        if (returnAllColumns_) {
-            // return all columns
-            data.set_value(value.str());
-        } else if (!ctxIter->second.empty()) {
-            // only return specified columns
-            auto reader = RowReaderWrapper::getEdgePropReader(
-                schemaMan_, value, spaceId_, edgeType);
-            if (reader == nullptr) {
-                LOG(WARNING) << "Skip the bad format row";
+        auto val = iter->val();
+        auto schemaIter = edgeContext_.schemas_.find(std::abs(edgeType));
+        CHECK(schemaIter != edgeContext_.schemas_.end());
+        reader.reset(schemaIter->second, val);
+        if (!reader) {
+            continue;
+        }
+
+        nebula::List list;
+        auto srcId = NebulaKeyUtils::getSrcId(spaceVidLen_, key);
+        auto rank = NebulaKeyUtils::getRank(spaceVidLen_, key);
+        auto dstId = NebulaKeyUtils::getDstId(spaceVidLen_, key);
+        auto src = srcId.subpiece(0, srcId.find_first_of('\0'));
+        auto dst = dstId.subpiece(0, dstId.find_first_of('\0'));
+        list.emplace_back(std::move(src));
+        list.emplace_back(edgeType);
+        list.emplace_back(rank);
+        list.emplace_back(std::move(dst));
+
+        if (!returnNoProps_) {
+            auto idx = edgeIter->second;
+            auto props = &(edgeContext_.propContexts_[idx].second);
+            if (!QueryUtils::collectPropsInValue(reader.get(), props, list).ok()) {
                 continue;
             }
-            RowWriter writer;
-            PropsCollector collector(&writer);
-            auto& props = ctxIter->second;
-            collectProps(reader.get(), props, &collector);
-            data.set_value(writer.encode());
         }
-
-        edgeData.emplace_back(std::move(data));
+        resultDataSet_.rows.emplace_back(std::move(list));
         rowCount++;
-        blockSize += key.size() + value.size();
     }
 
-    resp_.set_edge_schema(std::move(edgeSchema_));
-    resp_.set_edge_data(std::move(edgeData));
     if (iter->valid()) {
         resp_.set_has_next(true);
         resp_.set_next_cursor(iter->key().str());
     } else {
         resp_.set_has_next(false);
     }
+    onProcessFinished();
     onFinished();
 }
 
 cpp2::ErrorCode ScanEdgeProcessor::checkAndBuildContexts(const cpp2::ScanEdgeRequest& req) {
-    for (const auto& edgeIter : req.get_return_columns()) {
-        int32_t index = 0;
-        EdgeType edgeType = edgeIter.first;
-        std::vector<PropContext> propContexts;
-        auto schema = this->schemaMan_->getEdgeSchema(spaceId_, edgeType);
-        if (!schema) {
-            return cpp2::ErrorCode::E_EDGE_NOT_FOUND;
-        }
-
-        if (returnAllColumns_) {
-            // return all columns
-            edgeContexts_.emplace(edgeType, std::move(propContexts));
-            edgeSchema_.emplace(edgeType, schema->toSchema());
-            continue;
-        } else if (edgeIter.second.empty()) {
-            // return none columns
-            edgeContexts_.emplace(edgeType, std::move(propContexts));
-            continue;
-        }
-
-        // return specified columns
-        meta::NebulaSchemaProvider retSchema(schema->getVersion());
-        // return specifid columns
-        for (const auto& col : edgeIter.second) {
-            PropContext prop;
-            switch (col.owner) {
-                case cpp2::PropOwner::EDGE: {
-                    if (col.id.get_edge_type() > 0) {
-                        // Only outBound have properties on edge.
-                        auto ftype = schema->getFieldType(col.name);
-                        if (UNLIKELY(ftype == CommonConstants::kInvalidValueType())) {
-                            return cpp2::ErrorCode::E_IMPROPER_DATA_TYPE;
-                        }
-                        prop.type_ = ftype;
-                        retSchema.addField(col.name, std::move(ftype));
-                    } else {
-                        VLOG(3) << "InBound has none props, skip it!";
-                        break;
-                    }
-                    prop.retIndex_ = index++;
-                    prop.prop_ = std::move(col);
-                    prop.returned_ = true;
-                    propContexts.emplace_back(std::move(prop));
-                    break;
-                }
-                default: {
-                    continue;
-                }
-            }
-        }
-        edgeContexts_.emplace(edgeType, std::move(propContexts));
-        edgeSchema_.emplace(edgeType, retSchema.toSchema());
+    auto ret = getSpaceEdgeSchema();
+    if (ret != cpp2::ErrorCode::SUCCEEDED) {
+        return ret;
     }
-    return cpp2::ErrorCode::SUCCEEDED;
+
+    auto returnProps = std::move(req.return_columns);
+    return handleEdgeProps(returnProps, returnNoProps_);
+}
+
+void ScanEdgeProcessor::onProcessFinished() {
+    resp_.set_edge_data(std::move(resultDataSet_));
 }
 
 }  // namespace storage

--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -46,8 +46,14 @@ void ScanEdgeProcessor::process(const cpp2::ScanEdgeRequest& req) {
     std::vector<cpp2::ScanEdge> edgeData;
     int32_t rowCount = 0;
     int32_t rowLimit = req.get_limit();
-    int64_t startTime = req.get_start_time(), endTime = req.get_end_time();
-    int32_t blockSize = 0;
+    int64_t startTime = 0, endTime = std::numeric_limits<int64_t>::max();
+    if (req.__isset.start_time) {
+        startTime = *req.get_start_time();
+    }
+    if (req.__isset.end_time) {
+        endTime = *req.get_end_time();
+    }
+    RowReaderWrapper reader;
 
     for (; iter->valid() && rowCount < rowLimit && blockSize < FLAGS_max_scan_block_size;
          iter->next()) {

--- a/src/storage/query/ScanEdgeProcessor.h
+++ b/src/storage/query/ScanEdgeProcessor.h
@@ -1,44 +1,41 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.:
+/* Copyright (c) 2020 vesoft inc. All rights reserved.:
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef STORAGE_SCANEDGEPROCESSOR_H_
-#define STORAGE_SCANEDGEPROCESSOR_H_
+#ifndef STORAGE_QUERY_SCANEDGEPROCESSOR_H_
+#define STORAGE_QUERY_SCANEDGEPROCESSOR_H_
 
 #include "common/base/Base.h"
-#include "storage/BaseProcessor.h"
+#include "storage/query/QueryBaseProcessor.h"
 
 namespace nebula {
 namespace storage {
 
 class ScanEdgeProcessor
-    : public BaseProcessor<cpp2::ScanEdgeResponse> {
+    : public QueryBaseProcessor<cpp2::ScanEdgeRequest, cpp2::ScanEdgeResponse> {
 public:
-    static ScanEdgeProcessor* instance(kvstore::KVStore* kvstore,
-                                       meta::SchemaManager* schemaMan,
+    static ScanEdgeProcessor* instance(StorageEnv* env,
                                        stats::Stats* stats) {
-        return new ScanEdgeProcessor(kvstore, schemaMan, stats);
+        return new ScanEdgeProcessor(env, stats);
     }
 
-    void process(const cpp2::ScanEdgeRequest& req);
+    void process(const cpp2::ScanEdgeRequest& req) override;
 
 private:
-    explicit ScanEdgeProcessor(kvstore::KVStore* kvstore,
-                               meta::SchemaManager* schemaMan,
-                               stats::Stats* stats)
-            : BaseProcessor<cpp2::ScanEdgeResponse>(kvstore, schemaMan, stats) {}
+    ScanEdgeProcessor(StorageEnv* env, stats::Stats* stats)
+        : QueryBaseProcessor<cpp2::ScanEdgeRequest, cpp2::ScanEdgeResponse>(env, stats) {
+    }
 
-    cpp2::ErrorCode checkAndBuildContexts(const cpp2::ScanEdgeRequest& req);
+    cpp2::ErrorCode checkAndBuildContexts(const cpp2::ScanEdgeRequest& req) override;
 
-    std::unordered_map<EdgeType, std::vector<PropContext>> edgeContexts_;
-    std::unordered_map<EdgeType, nebula::cpp2::Schema> edgeSchema_;
-    bool returnAllColumns_{false};
-    GraphSpaceID spaceId_;
+    void onProcessFinished() override;
+
+    bool returnNoProps_{false};
     PartitionID partId_;
 };
 
 }  // namespace storage
 }  // namespace nebula
-#endif  // STORAGE_SCANEDGEPROCESSOR_H_
+#endif  // STORAGE_QUERY_SCANEDGEPROCESSOR_H_

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -48,7 +48,13 @@ void ScanVertexProcessor::process(const cpp2::ScanVertexRequest& req) {
     }
 
     int32_t rowLimit = req.get_limit();
-    int64_t startTime = req.get_start_time(), endTime = req.get_end_time();
+    int64_t startTime = 0, endTime = std::numeric_limits<int64_t>::max();
+    if (req.__isset.start_time) {
+        startTime = *req.get_start_time();
+    }
+    if (req.__isset.end_time) {
+        endTime = *req.get_end_time();
+    }
     RowReaderWrapper reader;
 
     for (int32_t rowCount = 0; iter->valid() && rowCount < rowLimit; iter->next()) {

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -1,17 +1,13 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
 #include "storage/query/ScanVertexProcessor.h"
-#include "comon/time/WallClock.h"
-#include "common/meta/NebulaSchemaProvider.h"
 #include "utils/NebulaKeyUtils.h"
-#include <algorithm>
-#include "kvstore/RocksEngine.h"
-
-DECLARE_int32(max_scan_block_size);
+#include "storage/StorageFlags.h"
+#include "storage/exec/QueryUtils.h"
 
 namespace nebula {
 namespace storage {
@@ -19,17 +15,24 @@ namespace storage {
 void ScanVertexProcessor::process(const cpp2::ScanVertexRequest& req) {
     spaceId_ = req.get_space_id();
     partId_ = req.get_part_id();
-    returnAllColumns_ = req.get_all_columns();
+    returnNoProps_ = req.get_no_columns();
 
-    auto retCode = checkAndBuildContexts(req);
+    auto retCode = getSpaceVidLen(spaceId_);
     if (retCode != cpp2::ErrorCode::SUCCEEDED) {
-        this->pushResultCode(retCode, partId_);
-        this->onFinished();
+        pushResultCode(retCode, partId_);
+        onFinished();
+        return;
+    }
+
+    retCode = checkAndBuildContexts(req);
+    if (retCode != cpp2::ErrorCode::SUCCEEDED) {
+        pushResultCode(retCode, partId_);
+        onFinished();
         return;
     }
 
     std::string start;
-    std::string prefix = NebulaKeyUtils::prefix(partId_);
+    std::string prefix = NebulaKeyUtils::partPrefix(partId_);
     if (req.get_cursor() == nullptr || req.get_cursor()->empty()) {
         start = prefix;
     } else {
@@ -37,126 +40,83 @@ void ScanVertexProcessor::process(const cpp2::ScanVertexRequest& req) {
     }
 
     std::unique_ptr<kvstore::KVIterator> iter;
-    auto kvRet = doRangeWithPrefix(spaceId_, partId_, start, prefix, &iter);
+    auto kvRet = env_->kvstore_->rangeWithPrefix(spaceId_, partId_, start, prefix, &iter);
     if (kvRet != kvstore::ResultCode::SUCCEEDED) {
         pushResultCode(to(kvRet), partId_);
         onFinished();
         return;
     }
 
-    std::vector<cpp2::ScanVertex> vertexData;
-    int32_t rowCount = 0;
     int32_t rowLimit = req.get_limit();
     int64_t startTime = req.get_start_time(), endTime = req.get_end_time();
-    int32_t blockSize = 0;
+    RowReaderWrapper reader;
 
-    for (; iter->valid() && rowCount < rowLimit && blockSize < FLAGS_max_scan_block_size;
-         iter->next()) {
+    for (int32_t rowCount = 0; iter->valid() && rowCount < rowLimit; iter->next()) {
         auto key = iter->key();
-        if (!NebulaKeyUtils::isVertex(key)) {
+        if (!NebulaKeyUtils::isVertex(spaceVidLen_, key)) {
             continue;
         }
 
         // only return data within time range [start, end)
-        TagVersion version = folly::Endian::big(NebulaKeyUtils::getVersion(key));
+        auto version = folly::Endian::big(NebulaKeyUtils::getVersion(spaceVidLen_, key));
         int64_t ts = std::numeric_limits<int64_t>::max() - version;
-        if (ts < startTime || ts >= endTime) {
+        if (FLAGS_enable_multi_versions && (ts < startTime || ts >= endTime)) {
             continue;
         }
 
-        TagID tagId = NebulaKeyUtils::getTagId(key);
-        auto ctxIter = tagContexts_.find(tagId);
-        if (ctxIter == tagContexts_.end()) {
+        auto tagId = NebulaKeyUtils::getTagId(spaceVidLen_, key);
+        auto tagIter = tagContext_.indexMap_.find(tagId);
+        if (tagIter == tagContext_.indexMap_.end()) {
             continue;
         }
 
-        VertexID vId = NebulaKeyUtils::getVertexId(key);
-        cpp2::ScanVertex data;
-        data.set_vertexId(vId);
-        data.set_tagId(tagId);
-        auto value = iter->val();
-        if (returnAllColumns_) {
-            // return all columns
-            data.set_value(value.str());
-        } else if (!ctxIter->second.empty()) {
-            // only return specified columns
-            auto reader = RowReaderWrapper::getTagPropReader(schemaMan_, value, spaceId_, tagId);
-            if (reader == nullptr) {
+        auto val = iter->val();
+        auto schemaIter = tagContext_.schemas_.find(tagId);
+        CHECK(schemaIter != tagContext_.schemas_.end());
+        reader.reset(schemaIter->second, val);
+        if (!reader) {
+            continue;
+        }
+
+        nebula::List list;
+        auto vId = NebulaKeyUtils::getVertexId(spaceVidLen_, key);
+        auto id = vId.subpiece(0, vId.find_first_of('\0'));
+        list.emplace_back(std::move(id));
+        list.emplace_back(tagId);
+
+        if (!returnNoProps_) {
+            auto idx = tagIter->second;
+            auto props = &(tagContext_.propContexts_[idx].second);
+            if (!QueryUtils::collectPropsInValue(reader.get(), props, list).ok()) {
                 continue;
             }
-            RowWriter writer;
-            PropsCollector collector(&writer);
-            auto& props = ctxIter->second;
-            collectProps(reader.get(), props, &collector);
-            data.set_value(writer.encode());
         }
-
-        vertexData.emplace_back(std::move(data));
+        resultDataSet_.rows.emplace_back(std::move(list));
         rowCount++;
-        blockSize += key.size() + value.size();
     }
 
-    resp_.set_vertex_schema(std::move(tagSchema_));
-    resp_.set_vertex_data(std::move(vertexData));
     if (iter->valid()) {
         resp_.set_has_next(true);
         resp_.set_next_cursor(iter->key().str());
     } else {
         resp_.set_has_next(false);
     }
+    onProcessFinished();
     onFinished();
 }
 
 cpp2::ErrorCode ScanVertexProcessor::checkAndBuildContexts(const cpp2::ScanVertexRequest& req) {
-    for (const auto& tagIter : req.get_return_columns()) {
-        int32_t index = 0;
-        TagID tagId = tagIter.first;
-        std::vector<PropContext> propContexts;
-        auto schema = this->schemaMan_->getTagSchema(spaceId_, tagId);
-        if (!schema) {
-            return cpp2::ErrorCode::E_TAG_NOT_FOUND;
-        }
-
-        if (returnAllColumns_) {
-            // return all columns
-            tagContexts_.emplace(tagId, std::move(propContexts));
-            tagSchema_.emplace(tagId, schema->toSchema());
-            continue;
-        } else if (tagIter.second.empty()) {
-            // return none columns
-            tagContexts_.emplace(tagId, std::move(propContexts));
-            continue;
-        }
-
-        // return specified columns
-        meta::NebulaSchemaProvider retSchema(schema->getVersion());
-        // return specifid columns
-        for (const auto& col : tagIter.second) {
-            PropContext prop;
-            switch (col.owner) {
-                case cpp2::PropOwner::SOURCE: {
-                    auto ftype = schema->getFieldType(col.name);
-                    if (UNLIKELY(ftype == CommonConstants::kInvalidValueType())) {
-                        return cpp2::ErrorCode::E_IMPROPER_DATA_TYPE;
-                    }
-                    prop.type_ = ftype;
-                    retSchema.addField(col.name, std::move(ftype));
-
-                    prop.retIndex_ = index++;
-                    prop.prop_ = std::move(col);
-                    prop.returned_ = true;
-                    propContexts.emplace_back(std::move(prop));
-                    break;
-                }
-                default: {
-                    continue;
-                }
-            }
-        }
-        tagContexts_.emplace(tagId, std::move(propContexts));
-        tagSchema_.emplace(tagId, retSchema.toSchema());
+    auto ret = getSpaceVertexSchema();
+    if (ret != cpp2::ErrorCode::SUCCEEDED) {
+        return ret;
     }
-    return cpp2::ErrorCode::SUCCEEDED;
+
+    auto returnProps = std::move(req.return_columns);
+    return handleVertexProps(returnProps, returnNoProps_);
+}
+
+void ScanVertexProcessor::onProcessFinished() {
+    resp_.set_vertex_data(std::move(resultDataSet_));
 }
 
 }  // namespace storage

--- a/src/storage/query/ScanVertexProcessor.h
+++ b/src/storage/query/ScanVertexProcessor.h
@@ -1,44 +1,41 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.:
+/* Copyright (c) 2020 vesoft inc. All rights reserved.:
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef STORAGE_SCANVERTEXPROCESSOR_H_
-#define STORAGE_SCANVERTEXPROCESSOR_H_
+#ifndef STORAGE_QUERY_SCANVERTEXPROCESSOR_H_
+#define STORAGE_QUERY_SCANVERTEXPROCESSOR_H_
 
 #include "common/base/Base.h"
-#include "storage/BaseProcessor.h"
+#include "storage/query/QueryBaseProcessor.h"
 
 namespace nebula {
 namespace storage {
 
 class ScanVertexProcessor
-    : public BaseProcessor<cpp2::ScanVertexResponse> {
+    : public QueryBaseProcessor<cpp2::ScanVertexRequest, cpp2::ScanVertexResponse> {
 public:
-    static ScanVertexProcessor* instance(kvstore::KVStore* kvstore,
-                                         meta::SchemaManager* schemaMan,
+    static ScanVertexProcessor* instance(StorageEnv* env,
                                          stats::Stats* stats) {
-        return new ScanVertexProcessor(kvstore, schemaMan, stats);
+        return new ScanVertexProcessor(env, stats);
     }
 
-    void process(const cpp2::ScanVertexRequest& req);
+    void process(const cpp2::ScanVertexRequest& req) override;
 
 private:
-    explicit ScanVertexProcessor(kvstore::KVStore* kvstore,
-                                 meta::SchemaManager* schemaMan,
-                                 stats::Stats* stats)
-            : BaseProcessor<cpp2::ScanVertexResponse>(kvstore, schemaMan, stats) {}
+    ScanVertexProcessor(StorageEnv* env, stats::Stats* stats)
+        : QueryBaseProcessor<cpp2::ScanVertexRequest, cpp2::ScanVertexResponse>(env, stats) {
+    }
 
-    cpp2::ErrorCode checkAndBuildContexts(const cpp2::ScanVertexRequest& req);
+    cpp2::ErrorCode checkAndBuildContexts(const cpp2::ScanVertexRequest& req) override;
 
-    std::unordered_map<TagID, std::vector<PropContext>> tagContexts_;
-    std::unordered_map<TagID, nebula::cpp2::Schema> tagSchema_;
-    bool returnAllColumns_{false};
-    GraphSpaceID spaceId_;
+    void onProcessFinished() override;
+
+    bool returnNoProps_{false};
     PartitionID partId_;
 };
 
 }  // namespace storage
 }  // namespace nebula
-#endif  // STORAGE_SCANVERTEXPROCESSOR_H_
+#endif  // STORAGE_QUERY_SCANVERTEXPROCESSOR_H_

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -505,21 +505,20 @@ nebula_add_executable(
 #        gtest
 #)
 
-#
-#nebula_add_test(
-#    NAME
-#        scan_edge_test
-#    SOURCES
-#        ScanEdgeTest.cpp
-#    OBJECTS
-#        ${storage_test_deps}
-#    LIBRARIES
-#        ${ROCKSDB_LIBRARIES}
-#        ${THRIFT_LIBRARIES}
-#        wangle
-#        gtest
-#)
-#
+nebula_add_test(
+    NAME
+        scan_edge_test
+    SOURCES
+        ScanEdgeTest.cpp
+    OBJECTS
+        ${storage_test_deps}
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
 nebula_add_test(
     NAME
         scan_vertex_test

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -520,20 +520,20 @@ nebula_add_executable(
 #        gtest
 #)
 #
-#nebula_add_test(
-#    NAME
-#        scan_vertex_test
-#    SOURCES
-#        ScanVertexTest.cpp
-#    OBJECTS
-#        ${storage_test_deps}
-#    LIBRARIES
-#        ${ROCKSDB_LIBRARIES}
-#        ${THRIFT_LIBRARIES}
-#        wangle
-#        gtest
-#)
-#
+nebula_add_test(
+    NAME
+        scan_vertex_test
+    SOURCES
+        ScanVertexTest.cpp
+    OBJECTS
+        ${storage_test_deps}
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
 #nebula_add_executable(
 #    NAME
 #        storage_index_write_bm

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -127,6 +127,25 @@ TEST(GetNeighborsTest, PropertyTest) {
         QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 6);
     }
     {
+        LOG(INFO) << "OneOutEdgeMultiProperty";
+        std::vector<VertexID> vertices = {"Tim Duncan"};
+        std::vector<EdgeType> over = {serve};
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        tags.emplace_back(player, std::vector<std::string>{});
+        edges.emplace_back(serve, std::vector<std::string>{});
+        auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+
+        auto* processor = GetNeighborsProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+
+        ASSERT_EQ(0, resp.result.failed_parts.size());
+        // vId, stat, player, serve, expr
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 5);
+    }
+    {
         LOG(INFO) << "OutEdgeReturnAllProperty";
         std::vector<VertexID> vertices = {"Tim Duncan"};
         std::vector<EdgeType> over = {};

--- a/src/storage/test/QueryTestUtils.h
+++ b/src/storage/test/QueryTestUtils.h
@@ -403,6 +403,9 @@ public:
         ASSERT_EQ(0, colNames[colNames.size() - 1].find("_expr"));
 
         for (size_t i = 0; i < tags.size(); i++) {
+            if (tags[i].second.empty()) {
+                continue;
+            }
             auto expected = "_tag:" + folly::to<std::string>(tags[i].first);
             for (const auto& prop : tags[i].second) {
                 expected += ":" + prop;
@@ -410,6 +413,9 @@ public:
             ASSERT_EQ(expected, colNames[i + 2]);
         }
         for (size_t i = 0; i < edges.size(); i++) {
+            if (edges[i].second.empty()) {
+                continue;
+            }
             std::string expected = "_edge:";
             expected.append(edges[i].first > 0 ? "+" : "-")
                     .append(folly::to<std::string>(std::abs(edges[i].first)));

--- a/src/storage/test/ScanEdgeTest.cpp
+++ b/src/storage/test/ScanEdgeTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
@@ -6,433 +6,353 @@
 
 #include "common/base/Base.h"
 #include "common/fs/TempDir.h"
-#include "utils/NebulaKeyUtils.h"
 #include <gtest/gtest.h>
-#include <rocksdb/db.h>
-#include "storage/test/TestUtils.h"
 #include "storage/query/ScanEdgeProcessor.h"
-#include "codec/RowReader.h"
+#include "storage/test/QueryTestUtils.h"
 
 namespace nebula {
 namespace storage {
 
-void mockData(kvstore::KVStore* kv, int32_t partCount = 10) {
-    // we have 10srcId * 10dstId * 10part = 1000 edges of one edgeType,
-    // and 10vId * 9tagId * 10part = 900 tags
-    for (auto partId = 0; partId < partCount; partId++) {
-        std::vector<kvstore::KV> data;
-        for (auto vertexId = partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
-            // Generate 9 tag for each vertex
-            for (auto tagId = 3001; tagId < 3010; tagId++) {
-                auto key = NebulaKeyUtils::vertexKey(partId, vertexId, tagId, 0);
-                RowWriter writer;
-                for (uint64_t numInt = 0; numInt < 3; numInt++) {
-                    writer << (vertexId + tagId + numInt);
-                }
-                for (auto numString = 3; numString < 6; numString++) {
-                    writer << folly::stringPrintf("tag_string_col_%d", numString);
-                }
-                auto val = writer.encode();
-                data.emplace_back(std::move(key), std::move(val));
-            }
-            for (EdgeType edgeType = 101; edgeType <= 103; edgeType++) {
-                // Generate 100 edges for each source vertex id
-                for (auto dstId = 10001; dstId <= 10100; dstId++) {
-                    VLOG(3) << "Write part " << partId << ", vertex "
-                        << vertexId << ", dst " << dstId;
-                    int64_t ts = std::numeric_limits<int64_t>::max() -
-                        time::WallClock::fastNowInMicroSec();
-                    int64_t version = folly::Endian::big(ts);
-                    auto key = NebulaKeyUtils::edgeKey(partId, vertexId, edgeType, dstId - 10001,
-                            dstId, version);
-                    RowWriter writer(nullptr);
-                    for (int64_t numInt = 0; numInt < 10; numInt++) {
-                        writer << numInt;
-                    }
-                    for (auto numString = 10; numString < 20; numString++) {
-                        writer << folly::stringPrintf("string_col_%d", numString);
-                    }
-                    auto val = writer.encode();
-                    data.emplace_back(std::move(key), std::move(val));
-                }
-                // Generate 5 in-edges for each edgeType, the edgeType is negative
-                for (auto srcId = 20001; srcId <= 20005; srcId++) {
-                    VLOG(3) << "Write part " << partId << ", vertex "
-                        << vertexId << ", src " << srcId;
-                    auto key = NebulaKeyUtils::edgeKey(partId, vertexId, -edgeType, 0, srcId, 0);
-                    data.emplace_back(std::move(key), "");
-                }
-            }
-            folly::Baton<true, std::atomic> baton;
-            kv->asyncMultiPut(
-                    0, partId, std::move(data),
-                    [&](kvstore::ResultCode code) {
-                    EXPECT_EQ(code, kvstore::ResultCode::SUCCEEDED);
-                    baton.post();
-                    });
-            baton.wait();
-        }
-    }
-}
-
-cpp2::ScanEdgeRequest buildRequest(PartitionID partId, const std::string& cursor,
-                                   int32_t rowLimit,
-                                   bool returnAllColumns = false,
-                                   bool returnNoneColumns = false,
-                                   std::unordered_set<EdgeType> edgeTypes = {101},
-                                   int64_t startTime = 0,
-                                   int64_t endTime = std::numeric_limits<int64_t>::max()) {
+cpp2::ScanEdgeRequest buildRequest(
+        PartitionID partId,
+        const std::string& cursor,
+        const std::vector<std::pair<EdgeType, std::vector<std::string>>>& edges,
+        int32_t rowLimit = 100,
+        bool returnNoColumns = false,
+        int64_t startTime = 0,
+        int64_t endTime = std::numeric_limits<int64_t>::max()) {
     cpp2::ScanEdgeRequest req;
-    req.set_space_id(0);
+    req.set_space_id(1);
     req.set_part_id(partId);
     req.set_cursor(cursor);
-    std::unordered_map<EdgeType, std::vector<cpp2::PropDef>> returnColumns;
-    for (EdgeType edgeType : edgeTypes) {
-        std::vector<cpp2::PropDef> props;
-        if (returnNoneColumns) {
-            returnColumns.emplace(edgeType, std::move(props));
-            continue;
+    std::vector<cpp2::EdgeProp> returnColumns;
+    for (const auto& edge : edges) {
+        EdgeType edgeType = edge.first;
+        cpp2::EdgeProp edgeProp;
+        edgeProp.type = edgeType;
+        for (const auto& prop : edge.second) {
+            edgeProp.props.emplace_back(std::move(prop));
         }
-
-        if (!returnAllColumns) {
-            // return the even int/string properties in zip order
-            for (int i = 0; i < 10; i += 2) {
-                {
-                    cpp2::PropDef prop;
-                    prop.owner = cpp2::PropOwner::EDGE;
-                    prop.id.set_edge_type(edgeType);
-                    prop.name = folly::stringPrintf("col_%d", i);
-                    props.emplace_back(std::move(prop));
-                }
-                {
-                    cpp2::PropDef prop;
-                    prop.owner = cpp2::PropOwner::EDGE;
-                    prop.id.set_edge_type(edgeType);
-                    prop.name = folly::stringPrintf("col_%d", i + 10);
-                    props.emplace_back(std::move(prop));
-                }
-            }
-        } else {
-            // if return all columns we don't need to specify any propery
-        }
-        returnColumns.emplace(edgeType, std::move(props));
+        returnColumns.emplace_back(std::move(edgeProp));
     }
     req.set_return_columns(std::move(returnColumns));
-    req.set_all_columns(returnAllColumns);
+    req.set_no_columns(returnNoColumns);
     req.set_limit(rowLimit);
     req.set_start_time(startTime);
     req.set_end_time(endTime);
     return req;
 }
 
-
-void checkResponse(PartitionID partId, cpp2::ScanEdgeResponse& resp, std::string& cursor,
-                   int32_t& totalRowCount, int32_t expectedRowNum, int32_t expectedColumnsNum,
-                   bool returnAllColumns = false,
-                   bool returnNoneColumns = false,
-                   std::unordered_set<EdgeType> edgeTypes = {101}) {
-    EXPECT_EQ(0, resp.result.failed_codes.size());
-    for (const auto& schemaIter : resp.edge_schema) {
-        EXPECT_EQ(expectedColumnsNum, schemaIter.second.columns.size());
-    }
-
-    if (!resp.edge_data.empty()) {
-        int32_t rowNum = 0;
-        for (const auto& scanEdge : resp.edge_data) {
-            auto srcId = scanEdge.src;
-            EXPECT_TRUE(partId * 10 <= srcId && srcId < (partId + 1) * 10);
-            auto edgeType = scanEdge.type;
-            EXPECT_TRUE(edgeTypes.count(edgeType));
-            auto dstId = scanEdge.dst;
-            EXPECT_TRUE(10001 <= dstId && dstId <= 10100);
-
-            if (returnNoneColumns) {
-                EXPECT_TRUE(scanEdge.value.empty());
-            } else {
-                auto schemaIter = resp.edge_schema.find(edgeType);
-                EXPECT_TRUE(schemaIter != resp.edge_schema.end());
-                auto provider = std::make_shared<ResultSchemaProvider>(schemaIter->second);
-                auto reader = RowReaderWrapper::getRowReader(scanEdge.value, provider);
-
-                if (!returnAllColumns) {
-                    for (int64_t i = 0; i < 10; i += 2) {
-                        int64_t value;
-                        reader->getInt(i, value);
-                        EXPECT_EQ(i, value);
+void checkResponse(const nebula::DataSet& dataSet,
+                   const std::vector<std::pair<EdgeType, std::vector<std::string>>>& edges,
+                   std::unordered_map<TagID, size_t>& expectColumnCount,
+                   size_t& totalRowCount) {
+    totalRowCount += dataSet.rows.size();
+    for (const auto& row : dataSet.rows) {
+        auto srcId = row.values[0].getStr();
+        auto edgeType = row.values[1].getInt();
+        auto expectCol = expectColumnCount[edgeType];
+        ASSERT_EQ(expectCol, row.values.size());
+        auto props = QueryTestUtils::findExpectProps(edgeType, {}, edges);
+        switch (edgeType) {
+            case 101: {
+                // out edge serve
+                auto iter = mock::MockData::playerServes_.find(srcId);
+                CHECK(iter != mock::MockData::playerServes_.end());
+                std::vector<Value> values;
+                if (expectCol == 4 + 9) {
+                    // return all columns, collect all columns
+                    for (size_t i = 0; i < row.values.size(); i++) {
+                        values.emplace_back(std::move(row.values[i]));
                     }
-                    for (auto i = 1; i < 10; i += 2) {
-                        folly::StringPiece value;
-                        reader->getString(i, value);
-                        EXPECT_EQ(folly::stringPrintf("string_col_%d", i + 10 - 1), value);
+                    QueryTestUtils::checkOutServe(edgeType, props, iter->second, values);
+                } else if (expectCol > 4) {
+                    // return some properties, collect properites starting from fifth column
+                    for (size_t i = 4; i < row.values.size(); i++) {
+                        values.emplace_back(std::move(row.values[i]));
                     }
-                } else {
-                    for (int64_t i = 0; i < 10; i += 1) {
-                        int64_t value;
-                        reader->getInt(i, value);
-                        EXPECT_EQ(i, value);
-                    }
-                    for (auto i = 10; i < 20; i += 1) {
-                        folly::StringPiece value;
-                        reader->getString(i, value);
-                        EXPECT_EQ(folly::stringPrintf("string_col_%d", i), value);
-                    }
+                    QueryTestUtils::checkOutServe(edgeType, props, iter->second, values);
                 }
+                break;
             }
-            rowNum++;
+            case -101: {
+                // in edge teammates
+                auto iter = mock::MockData::teamServes_.find(srcId);
+                CHECK(iter != mock::MockData::teamServes_.end());
+                std::vector<Value> values;
+                if (expectCol == 4 + 9) {
+                    // return all columns, collect all columns
+                    for (size_t i = 0; i < row.values.size(); i++) {
+                        values.emplace_back(std::move(row.values[i]));
+                    }
+                    QueryTestUtils::checkInServe(edgeType, props, iter->second, values);
+                } else if (expectCol > 4) {
+                    // return some properties, collect properites starting from fifth column
+                    for (size_t i = 4; i < row.values.size(); i++) {
+                        values.emplace_back(std::move(row.values[i]));
+                    }
+                    QueryTestUtils::checkInServe(edgeType, props, iter->second, values);
+                }
+                break;
+            }
+            default:
+                LOG(FATAL) << "Should not reach here";
         }
-        EXPECT_EQ(expectedRowNum, rowNum);
-        totalRowCount += rowNum;
-    }
-
-    if (resp.has_next) {
-        EXPECT_TRUE(!resp.next_cursor.empty());
-        cursor = resp.next_cursor;
-    } else {
-        EXPECT_TRUE(resp.next_cursor.empty());
-        cursor = "";
-        return;
     }
 }
 
-TEST(ScanEdgeTest, RetrieveAllPropertyTest) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
 
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", 100, true);
+TEST(ScanEdgeTest, PropertyTest) {
+    fs::TempDir rootPath("/tmp/GetNeighborsTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path());
+    auto* env = cluster.storageEnv_.get();
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_EQ(true, QueryTestUtils::mockVertexData(env, totalParts));
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env, totalParts));
 
-    auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
+    EdgeType serve = 101;
 
-    LOG(INFO) << "Check the results...";
-    std::string cursor = "";
-    int32_t rowCount = 0, expectRowCount = 100;
-    checkResponse(partId, resp, cursor, rowCount, expectRowCount, 20, true);
-    EXPECT_EQ(rowCount, 100);
-}
-
-TEST(ScanEdgeTest, RetrieveSomePropertyTest) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", 100);
-
-    auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-
-    LOG(INFO) << "Check the results...";
-    std::string cursor = "";
-    int32_t rowCount = 0, expectRowCount = 100;
-    checkResponse(partId, resp, cursor, rowCount, expectRowCount, 10);
-    EXPECT_EQ(rowCount, 100);
-}
-
-TEST(ScanEdgeTest, RetrieveNonePropertyTest) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", 100, false, true);
-
-    auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-
-    LOG(INFO) << "Check the results...";
-    std::string cursor = "";
-    int32_t rowCount = 0, expectRowCount = 100;
-    checkResponse(partId, resp, cursor, rowCount, expectRowCount, 0, false, true);
-    EXPECT_EQ(rowCount, 100);
-}
-
-// Retrive edges of all property in a part
-TEST(ScanEdgeTest, RetrieveConsecutiveBlockTest1) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    int32_t rowCount = 0, rowLimit = 100, expectRowCount = 100;
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", rowLimit, true);
-    int32_t batchCount = 0;
-
-    while (true) {
-        auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        ++batchCount;
-
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 20, true);
-        if (cursor.empty()) {
-            break;
-        }
-
-        req = buildRequest(partId, cursor, rowLimit, true);
-    }
-    EXPECT_EQ(rowCount, 1000);
-}
-
-// Retrive edges of some property in a part
-TEST(ScanEdgeTest, RetrieveConsecutiveBlockTest2) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    // fetch 1000 rows in total within 11 blocks, first 10 blocks will get 99 rows,
-    // last block will get 10 row, 99 * 10 + 10 = 1000
-    int32_t rowCount = 0, rowLimit = 99, expectRowCount = 99;
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", rowLimit);
-    int32_t batchCount = 0;
-
-    while (true) {
-        auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        ++batchCount;
-        if (batchCount == 11) {
-            expectRowCount = 10;
-        }
-
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 10);
-        if (cursor.empty()) {
-            break;
-        }
-        req = buildRequest(partId, cursor, rowLimit);
-    }
-    EXPECT_EQ(rowCount, 1000);
-}
-
-// Retrive edges of none property in a part
-TEST(ScanEdgeTest, RetrieveConsecutiveBlockTest3) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    // fetch 1000 rows one by one
-    int32_t rowCount = 0, rowLimit = 1, expectRowCount = 1;
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", rowLimit, false, true);
-    int32_t batchCount = 0;
-
-    while (true) {
-        auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        ++batchCount;
-
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 0, false, true);
-        if (cursor.empty()) {
-            break;
-        }
-        req = buildRequest(partId, cursor, rowLimit, false, true);
-    }
-    EXPECT_EQ(rowCount, 1000);
-}
-
-// Retrive multiple edges of all property in a part
-TEST(ScanEdgeTest, RetrieveMultiEdgeTest) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    int32_t rowCount = 0, rowLimit = 100, expectRowCount = 100;
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", rowLimit, true, false, {101, 103});
-    int32_t batchCount = 0;
-
-    while (true) {
-        auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        ++batchCount;
-
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 20, true, false,
-                      {101, 103});
-        if (cursor.empty()) {
-            break;
-        }
-
-        req = buildRequest(partId, cursor, rowLimit, true, false, {101, 103});
-    }
-    EXPECT_EQ(rowCount, 2000);
-}
-
-TEST(ScanEdgeTest, RetrieveManyPartsTest) {
-    fs::TempDir rootPath("/tmp/ScanEdgeTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    int32_t partCount = 10;
-    mockData(kv.get(), partCount);
-
-    // scan through all partition
-    int32_t totalRowCount = 0;
-    for (PartitionID partId = 0; partId  < partCount; partId++) {
-        std::string cursor = "";
-        int32_t rowCount = 0, rowLimit = 100, expectRowCount = 100;
-        auto req = buildRequest(partId, "", rowLimit);
-
-        while (true) {
-            auto* processor = ScanEdgeProcessor::instance(kv.get(), schemaMan.get(), nullptr);
+    {
+        LOG(INFO) << "Scan one edge with some properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
             auto f = processor->getFuture();
             processor->process(req);
             auto resp = std::move(f).get();
-            checkResponse(partId, resp, cursor, rowCount, expectRowCount, 10);
-            if (cursor.empty()) {
-                break;
-            }
 
-            req = buildRequest(partId, cursor, rowLimit);
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
         }
-        EXPECT_EQ(rowCount, 1000);
-        totalRowCount += rowCount;
+        CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
     }
-    EXPECT_EQ(totalRowCount, 10000);
+    {
+        LOG(INFO) << "Scan one edge with all properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 9);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan one edge with no properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 0);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges, 100, true);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi edge with some properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        edges.emplace_back(-serve, std::vector<std::string>{"playerName", "startYear", "endYear"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 3);
+        expectColumnCount.emplace(-serve, 4 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::serves_.size() * 2, totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi edge with all properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{});
+        edges.emplace_back(-serve, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 9);
+        expectColumnCount.emplace(-serve, 4 + 9);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::serves_.size() * 2, totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi edge with no properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{});
+        edges.emplace_back(-serve, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 0);
+        expectColumnCount.emplace(-serve, 4 + 0);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges, 100, true);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::serves_.size() * 2, totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi edge misc properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{});
+        edges.emplace_back(-serve, std::vector<std::string>{"playerName", "startYear", "endYear"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 9);
+        expectColumnCount.emplace(-serve, 4 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", edges);
+            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::serves_.size() * 2, totalRowCount);
+    }
+}
+
+TEST(ScanEdgeTest, CursorTest) {
+    fs::TempDir rootPath("/tmp/GetNeighborsTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path());
+    auto* env = cluster.storageEnv_.get();
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_EQ(true, QueryTestUtils::mockVertexData(env, totalParts));
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env, totalParts));
+
+    EdgeType serve = 101;
+
+    {
+        LOG(INFO) << "Scan one edge with some properties with limit = 5";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            bool hasNext = true;
+            std::string cursor = "";
+            while (hasNext) {
+                auto req = buildRequest(partId, cursor, edges, 5);
+                auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+                auto f = processor->getFuture();
+                processor->process(req);
+                auto resp = std::move(f).get();
+
+                ASSERT_EQ(0, resp.result.failed_parts.size());
+                checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+                hasNext = resp.get_has_next();
+                if (hasNext) {
+                    CHECK(resp.__isset.next_cursor);
+                    cursor = *resp.get_next_cursor();
+                }
+            }
+        }
+        CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan one edge with some properties with limit = 1";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            bool hasNext = true;
+            std::string cursor = "";
+            while (hasNext) {
+                auto req = buildRequest(partId, cursor, edges, 1);
+                auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+                auto f = processor->getFuture();
+                processor->process(req);
+                auto resp = std::move(f).get();
+
+                ASSERT_EQ(0, resp.result.failed_parts.size());
+                checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+                hasNext = resp.get_has_next();
+                if (hasNext) {
+                    CHECK(resp.__isset.next_cursor);
+                    cursor = *resp.get_next_cursor();
+                }
+            }
+        }
+        CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi edge misc properties with limit = 1";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+        edges.emplace_back(serve, std::vector<std::string>{});
+        edges.emplace_back(-serve, std::vector<std::string>{"playerName", "startYear", "endYear"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(serve, 4 + 9);
+        expectColumnCount.emplace(-serve, 4 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            bool hasNext = true;
+            std::string cursor = "";
+            while (hasNext) {
+                auto req = buildRequest(partId, cursor, edges, 1);
+                auto* processor = ScanEdgeProcessor::instance(env, nullptr);
+                auto f = processor->getFuture();
+                processor->process(req);
+                auto resp = std::move(f).get();
+
+                ASSERT_EQ(0, resp.result.failed_parts.size());
+                checkResponse(resp.edge_data, edges, expectColumnCount, totalRowCount);
+                hasNext = resp.get_has_next();
+                if (hasNext) {
+                    CHECK(resp.__isset.next_cursor);
+                    cursor = *resp.get_next_cursor();
+                }
+            }
+        }
+        CHECK_EQ(mock::MockData::serves_.size() * 2, totalRowCount);
+    }
 }
 
 }  // namespace storage

--- a/src/storage/test/ScanVertexTest.cpp
+++ b/src/storage/test/ScanVertexTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2019 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
@@ -6,418 +6,349 @@
 
 #include "common/base/Base.h"
 #include "common/fs/TempDir.h"
-#include "utils/NebulaKeyUtils.h"
 #include <gtest/gtest.h>
-#include <rocksdb/db.h>
-#include "storage/test/TestUtils.h"
 #include "storage/query/ScanVertexProcessor.h"
-#include "codec/RowReader.h"
+#include "storage/test/QueryTestUtils.h"
 
 namespace nebula {
 namespace storage {
 
-void mockData(kvstore::KVStore* kv, int32_t partCount = 10) {
-    // we have 10srcId * 10dstId * 10part = 1000 edges of one edgeType,
-    // and 10vId * 9tagId * 10part = 900 tags
-    for (auto partId = 0; partId < partCount; partId++) {
-        std::vector<kvstore::KV> data;
-        for (auto vertexId = partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
-            // Generate 9 tag for each vertex
-            for (auto tagId = 3001; tagId < 3010; tagId++) {
-                int64_t ts = std::numeric_limits<int64_t>::max() -
-                                  time::WallClock::fastNowInMicroSec();
-                int64_t version = folly::Endian::big(ts);
-                auto key = NebulaKeyUtils::vertexKey(partId, vertexId, tagId, version);
-                RowWriter writer;
-                for (uint64_t numInt = 0; numInt < 3; numInt++) {
-                    writer << (vertexId + tagId + numInt);
-                }
-                for (auto numString = 3; numString < 6; numString++) {
-                    writer << folly::stringPrintf("tag_string_col_%d", numString);
-                }
-                auto val = writer.encode();
-                data.emplace_back(std::move(key), std::move(val));
-            }
-            for (EdgeType edgeType = 101; edgeType <= 103; edgeType++) {
-                // Generate 100 edges for each source vertex id
-                for (auto dstId = 10001; dstId <= 10100; dstId++) {
-                    VLOG(3) << "Write part " << partId << ", vertex "
-                        << vertexId << ", dst " << dstId;
-                    int64_t ts = std::numeric_limits<int64_t>::max() -
-                        time::WallClock::fastNowInMicroSec();
-                    int64_t version = folly::Endian::big(ts);
-                    auto key = NebulaKeyUtils::edgeKey(partId, vertexId, edgeType, dstId - 10001,
-                            dstId, version);
-                    RowWriter writer(nullptr);
-                    for (int64_t numInt = 0; numInt < 10; numInt++) {
-                        writer << numInt;
-                    }
-                    for (auto numString = 10; numString < 20; numString++) {
-                        writer << folly::stringPrintf("string_col_%d", numString);
-                    }
-                    auto val = writer.encode();
-                    data.emplace_back(std::move(key), std::move(val));
-                }
-                // Generate 5 in-edges for each edgeType, the edgeType is negative
-                for (auto srcId = 20001; srcId <= 20005; srcId++) {
-                    VLOG(3) << "Write part " << partId << ", vertex "
-                        << vertexId << ", src " << srcId;
-                    auto key = NebulaKeyUtils::edgeKey(partId, vertexId, -edgeType, 0, srcId, 0);
-                    data.emplace_back(std::move(key), "");
-                }
-            }
-        }
-        folly::Baton<true, std::atomic> baton;
-        kv->asyncMultiPut(
-            0, partId, std::move(data),
-            [&](kvstore::ResultCode code) {
-                EXPECT_EQ(code, kvstore::ResultCode::SUCCEEDED);
-                baton.post();
-            });
-        baton.wait();
-    }
-}
-
-
-cpp2::ScanVertexRequest buildRequest(PartitionID partId, const std::string& cursor,
-                                     int32_t rowLimit,
-                                     bool returnAllColumns = false,
-                                     bool returnNoneColumns = false,
-                                     std::unordered_set<TagID> tagIds = {3001},
-                                     int64_t startTime = 0,
-                                     int64_t endTime = std::numeric_limits<int64_t>::max()) {
+cpp2::ScanVertexRequest buildRequest(
+        PartitionID partId,
+        const std::string& cursor,
+        const std::vector<std::pair<TagID, std::vector<std::string>>>& tags,
+        int32_t rowLimit = 100,
+        bool returnNoColumns = false,
+        int64_t startTime = 0,
+        int64_t endTime = std::numeric_limits<int64_t>::max()) {
     cpp2::ScanVertexRequest req;
-    req.set_space_id(0);
+    req.set_space_id(1);
     req.set_part_id(partId);
     req.set_cursor(cursor);
-    std::unordered_map<EdgeType, std::vector<cpp2::PropDef>> returnColumns;
-    for (TagID tagId : tagIds) {
-        std::vector<cpp2::PropDef> props;
-        if (returnNoneColumns) {
-            returnColumns.emplace(tagId, std::move(props));
-            continue;
+    std::vector<cpp2::VertexProp> returnColumns;
+    for (const auto& tag : tags) {
+        TagID tagId = tag.first;
+        cpp2::VertexProp vertexProp;
+        vertexProp.tag = tagId;
+        for (const auto& prop : tag.second) {
+            vertexProp.props.emplace_back(std::move(prop));
         }
-
-        if (!returnAllColumns) {
-            // return col_4 and col_1
-            {
-                cpp2::PropDef prop;
-                prop.owner = cpp2::PropOwner::SOURCE;
-                prop.id.set_tag_id(tagId);
-                prop.name = folly::stringPrintf("tag_%d_col_%d", tagId, 4);
-                props.emplace_back(std::move(prop));
-            }
-            {
-                cpp2::PropDef prop;
-                prop.owner = cpp2::PropOwner::SOURCE;
-                prop.id.set_tag_id(tagId);
-                prop.name = folly::stringPrintf("tag_%d_col_%d", tagId, 1);
-                props.emplace_back(std::move(prop));
-            }
-        } else {
-            // if return all columns we don't need to specify any propery
-        }
-        returnColumns.emplace(tagId, std::move(props));
+        returnColumns.emplace_back(std::move(vertexProp));
     }
     req.set_return_columns(std::move(returnColumns));
-    req.set_all_columns(returnAllColumns);
+    req.set_no_columns(returnNoColumns);
     req.set_limit(rowLimit);
     req.set_start_time(startTime);
     req.set_end_time(endTime);
     return req;
 }
 
-
-void checkResponse(PartitionID partId, cpp2::ScanVertexResponse& resp, std::string& cursor,
-                   int32_t& totalRowCount, int32_t expectedRowNum, int32_t expectedColumnsNum,
-                   bool returnAllColumns = false,
-                   bool returnNoneColumns = false,
-                   std::unordered_set<TagID> tagIds = {3001}) {
-    EXPECT_EQ(0, resp.result.failed_codes.size());
-    for (const auto& schemaIter : resp.vertex_schema) {
-        EXPECT_EQ(expectedColumnsNum, schemaIter.second.columns.size());
-    }
-
-    if (!resp.vertex_data.empty()) {
-        int32_t rowNum = 0;
-        for (const auto& scanVertex : resp.vertex_data) {
-            auto vertexId = scanVertex.vertexId;
-            EXPECT_TRUE(partId * 10 <= vertexId && vertexId < (partId + 1) * 10);
-            auto tagId = scanVertex.tagId;
-            EXPECT_TRUE(tagIds.count(tagId));
-
-            if (returnNoneColumns) {
-                EXPECT_TRUE(scanVertex.value.empty());
-            } else {
-                auto schemaIter = resp.vertex_schema.find(tagId);
-                EXPECT_TRUE(schemaIter != resp.vertex_schema.end());
-                auto provider = std::make_shared<ResultSchemaProvider>(schemaIter->second);
-                auto reader = RowReaderWrapper::getRowReader(scanVertex.value, provider);
-
-                if (!returnAllColumns) {
-                    {
-                        folly::StringPiece value;
-                        reader->getString(0, value);
-                        EXPECT_EQ(folly::stringPrintf("tag_string_col_%d", 4), value);
+void checkResponse(const nebula::DataSet& dataSet,
+                   const std::vector<std::pair<TagID, std::vector<std::string>>>& tags,
+                   std::unordered_map<TagID, size_t>& expectColumnCount,
+                   size_t& totalRowCount) {
+    totalRowCount += dataSet.rows.size();
+    for (const auto& row : dataSet.rows) {
+        auto vId = row.values[0].getStr();
+        auto tagId = row.values[1].getInt();
+        auto expectCol = expectColumnCount[tagId];
+        ASSERT_EQ(expectCol, row.values.size());
+        auto props = QueryTestUtils::findExpectProps(tagId, tags, {});
+        switch (tagId) {
+            case 1: {
+                // tag player
+                auto iter = std::find_if(mock::MockData::players_.begin(),
+                                         mock::MockData::players_.end(),
+                                         [&] (const auto& player) { return player.name_ == vId; });
+                CHECK(iter != mock::MockData::players_.end());
+                if (expectCol > 2) {
+                    std::vector<Value> values;
+                    // properties starts from the third column
+                    for (size_t i = 2; i < row.values.size(); i++) {
+                        values.emplace_back(std::move(row.values[i]));
                     }
-                    {
-                        int64_t value;
-                        reader->getInt(1, value);
-                        EXPECT_EQ(vertexId + tagId + 1, value);
-                    }
-                } else {
-                    for (uint64_t i = 0; i < 3; i++) {
-                        int64_t value;
-                        reader->getInt(i, value);
-                        EXPECT_EQ(vertexId + tagId + i, value);
-                    }
-                    for (auto i = 3; i < 6; i++) {
-                        folly::StringPiece value;
-                        reader->getString(i, value);
-                        EXPECT_EQ(folly::stringPrintf("tag_string_col_%d", i), value);
-                    }
+                    QueryTestUtils::checkPlayer(props, *iter, values);
                 }
+                break;
             }
-            rowNum++;
+            case 2: {
+                // tag team
+                auto iter = std::find(mock::MockData::teams_.begin(),
+                                      mock::MockData::teams_.end(),
+                                      vId);
+                CHECK(iter != mock::MockData::teams_.end());
+                if (expectCol > 2) {
+                    std::vector<Value> values;
+                    // properties starts from the third column
+                    for (size_t i = 2; i < row.values.size(); i++) {
+                        values.emplace_back(std::move(row.values[i]));
+                    }
+                    ASSERT_EQ(1, values.size());
+                    ASSERT_EQ(*iter, values[0].getStr());
+                }
+                break;
+            }
+            default:
+                LOG(FATAL) << "Should not reach here";
         }
-        EXPECT_EQ(expectedRowNum, rowNum);
-        totalRowCount += rowNum;
-    }
-
-    if (resp.has_next) {
-        EXPECT_TRUE(!resp.next_cursor.empty());
-        cursor = resp.next_cursor;
-    } else {
-        EXPECT_TRUE(resp.next_cursor.empty());
-        cursor = "";
-        return;
     }
 }
 
-// Retrieve all tags 3001 with all property
-TEST(ScanVertexTest, RetrieveAllPropertyTest) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
+TEST(ScanVertexTest, PropertyTest) {
+    fs::TempDir rootPath("/tmp/GetNeighborsTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path());
+    auto* env = cluster.storageEnv_.get();
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_EQ(true, QueryTestUtils::mockVertexData(env, totalParts));
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env, totalParts));
 
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", 10, true);
+    TagID player = 1;
+    TagID team = 2;
 
-    auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-
-    LOG(INFO) << "Check the results...";
-    std::string cursor = "";
-    int32_t rowCount = 0, expectRowCount = 10;
-    checkResponse(partId, resp, cursor, rowCount, expectRowCount, 6, true);
-    EXPECT_EQ(rowCount, 10);
-}
-
-// Retrieve all tags 3001 with some property
-TEST(ScanVertexTest, RetrieveSomePropertyTest) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", 10);
-
-    auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-
-    LOG(INFO) << "Check the results...";
-    std::string cursor = "";
-    int32_t rowCount = 0, expectRowCount = 10;
-    checkResponse(partId, resp, cursor, rowCount, expectRowCount, 2);
-    EXPECT_EQ(rowCount, 10);
-}
-
-// Retrieve all tags 3001 with none property
-TEST(ScanVertexTest, RetrieveNonePropertyTest) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    PartitionID partId = 1;
-    auto req = buildRequest(partId, "", 10, false, true);
-
-    auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-
-    LOG(INFO) << "Check the results...";
-    std::string cursor = "";
-    int32_t rowCount = 0, expectRowCount = 10;
-    checkResponse(partId, resp, cursor, rowCount, expectRowCount, 0, false, true);
-    EXPECT_EQ(rowCount, 10);
-}
-
-// Retrive vertices of all property in a part
-TEST(ScanVertexTest, RetrieveConsecutiveBlockTest1) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    int32_t rowCount = 0, rowLimit = 10, expectRowCount = 10;
-    PartitionID partId = 1;
-    std::unordered_set<TagID> tagIds;
-    for (TagID tagId = 3001; tagId < 3010; tagId++) {
-        tagIds.emplace(tagId);
-    }
-    auto req = buildRequest(partId, "", rowLimit, true, false, tagIds);
-
-    while (true) {
-        auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 6, true, false, tagIds);
-        if (cursor.empty()) {
-            break;
-        }
-
-        req = buildRequest(partId, cursor, rowLimit, true, false, tagIds);
-    }
-    EXPECT_EQ(rowCount, 90);
-}
-
-// Retrive vertices of some property in a part
-TEST(ScanVertexTest, RetrieveConsecutiveBlockTest2) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    // fetch 90 rows in total within 9 blocks, first 8 blocks will get 8 * 11 = 88 rows,
-    // last block will get 2 row, 11 * 8 + 2 = 90
-    int32_t rowCount = 0, rowLimit = 11, expectRowCount = 11;
-    PartitionID partId = 1;
-    std::unordered_set<TagID> tagIds;
-    for (TagID tagId = 3001; tagId < 3010; tagId++) {
-        tagIds.emplace(tagId);
-    }
-    auto req = buildRequest(partId, "", rowLimit, false, false, tagIds);
-    int32_t batchCount = 0;
-
-    while (true) {
-        auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        ++batchCount;
-        if (batchCount == 9) {
-            expectRowCount = 2;
-        }
-
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 2, false, false, tagIds);
-        if (cursor.empty()) {
-            break;
-        }
-        req = buildRequest(partId, cursor, rowLimit, false, false, tagIds);
-    }
-    EXPECT_EQ(rowCount, 90);
-}
-
-// Retrive vertices of none property in a part
-TEST(ScanVertexTest, RetrieveConsecutiveBlockTest3) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-
-    std::string cursor = "";
-    // fetch 900 rows one by one
-    int32_t rowCount = 0, rowLimit = 1, expectRowCount = 1;
-    PartitionID partId = 1;
-    std::unordered_set<TagID> tagIds;
-    for (TagID tagId = 3001; tagId < 3010; tagId++) {
-        tagIds.emplace(tagId);
-    }
-    auto req = buildRequest(partId, "", rowLimit, false, true, tagIds);
-    int32_t batchCount = 0;
-
-    while (true) {
-        auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
-        auto f = processor->getFuture();
-        processor->process(req);
-        auto resp = std::move(f).get();
-        ++batchCount;
-
-        checkResponse(partId, resp, cursor, rowCount, expectRowCount, 0, false, true, tagIds);
-        if (cursor.empty()) {
-            break;
-        }
-        req = buildRequest(partId, cursor, rowLimit, false, true, tagIds);
-    }
-    EXPECT_EQ(rowCount, 90);
-}
-
-TEST(ScanVertexTest, RetrieveManyPartsTest) {
-    fs::TempDir rootPath("/tmp/ScanVertexTest.XXXXXX");
-    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
-
-    LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
-    LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
-    // 10vId * 5tag * 10part = 500 rows
-    std::unordered_set<TagID> tagIds;
-    for (TagID tagId = 3001; tagId < 3010; tagId += 2) {
-        tagIds.emplace(tagId);
-    }
-
-    // scan through all partition
-    int32_t totalRowCount = 0;
-    for (PartitionID partId = 0; partId < 10; partId++) {
-        std::string cursor = "";
-        int32_t rowCount = 0, rowLimit = 10, expectRowCount = 10;
-        auto req = buildRequest(partId, "", rowLimit, false, false, tagIds);
-        int32_t batchCount = 0;
-
-        while (true) {
-            auto* processor = ScanVertexProcessor::instance(kv.get(), schemaMan.get(), nullptr);
+    {
+        LOG(INFO) << "Scan one tag with some properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
             auto f = processor->getFuture();
             processor->process(req);
             auto resp = std::move(f).get();
-            ++batchCount;
 
-            checkResponse(partId, resp, cursor, rowCount, expectRowCount, 2, false, false, tagIds);
-            if (cursor.empty()) {
-                break;
-            }
-            req = buildRequest(partId, cursor, rowLimit, false, false, tagIds);
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
         }
-        EXPECT_EQ(rowCount, 50);
-        totalRowCount += rowCount;
+        CHECK_EQ(mock::MockData::players_.size(), totalRowCount);
     }
-    EXPECT_EQ(totalRowCount, 500);
+    {
+        LOG(INFO) << "Scan one tag with all properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 11);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::players_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan one tag with no properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 0);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags, 100, true);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::players_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi tag with some properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        tags.emplace_back(team, std::vector<std::string>{"name"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 3);
+        expectColumnCount.emplace(team, 2 + 1);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::players_.size() + mock::MockData::teams_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi tag with all properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{});
+        tags.emplace_back(team, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 11);
+        expectColumnCount.emplace(team, 2 + 1);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::players_.size() + mock::MockData::teams_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi tag with no properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{});
+        tags.emplace_back(team, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 0);
+        expectColumnCount.emplace(team, 2 + 0);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags, 100, true);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::players_.size() + mock::MockData::teams_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi tag misc properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        tags.emplace_back(team, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 3);
+        expectColumnCount.emplace(team, 2 + 1);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            auto req = buildRequest(partId, "", tags, 100);
+            auto* processor = ScanVertexProcessor::instance(env, nullptr);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+
+            ASSERT_EQ(0, resp.result.failed_parts.size());
+            checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+        }
+        CHECK_EQ(mock::MockData::players_.size() + mock::MockData::teams_.size(), totalRowCount);
+    }
 }
+
+TEST(ScanVertexTest, CursorTest) {
+    fs::TempDir rootPath("/tmp/GetNeighborsTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path());
+    auto* env = cluster.storageEnv_.get();
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_EQ(true, QueryTestUtils::mockVertexData(env, totalParts));
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env, totalParts));
+
+    TagID player = 1;
+    TagID team = 2;
+
+    {
+        LOG(INFO) << "Scan one tag with some properties with limit = 5";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            bool hasNext = true;
+            std::string cursor = "";
+            while (hasNext) {
+                auto req = buildRequest(partId, cursor, tags, 5);
+                auto* processor = ScanVertexProcessor::instance(env, nullptr);
+                auto f = processor->getFuture();
+                processor->process(req);
+                auto resp = std::move(f).get();
+
+                ASSERT_EQ(0, resp.result.failed_parts.size());
+                checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+                hasNext = resp.get_has_next();
+                if (hasNext) {
+                    CHECK(resp.__isset.next_cursor);
+                    cursor = *resp.get_next_cursor();
+                }
+            }
+        }
+        CHECK_EQ(mock::MockData::players_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan one tag with some properties with limit = 1";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 3);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            bool hasNext = true;
+            std::string cursor = "";
+            while (hasNext) {
+                auto req = buildRequest(partId, cursor, tags, 1);
+                auto* processor = ScanVertexProcessor::instance(env, nullptr);
+                auto f = processor->getFuture();
+                processor->process(req);
+                auto resp = std::move(f).get();
+
+                ASSERT_EQ(0, resp.result.failed_parts.size());
+                checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+                hasNext = resp.get_has_next();
+                if (hasNext) {
+                    CHECK(resp.__isset.next_cursor);
+                    cursor = *resp.get_next_cursor();
+                }
+            }
+        }
+        CHECK_EQ(mock::MockData::players_.size(), totalRowCount);
+    }
+    {
+        LOG(INFO) << "Scan multi tag misc properties in one batch";
+        size_t totalRowCount = 0;
+        std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        tags.emplace_back(team, std::vector<std::string>{});
+        std::unordered_map<TagID, size_t> expectColumnCount;
+        expectColumnCount.emplace(player, 2 + 3);
+        expectColumnCount.emplace(team, 2 + 1);
+        for (PartitionID partId = 1; partId <= totalParts; partId++) {
+            bool hasNext = true;
+            std::string cursor = "";
+            while (hasNext) {
+                auto req = buildRequest(partId, cursor, tags, 1);
+                auto* processor = ScanVertexProcessor::instance(env, nullptr);
+                auto f = processor->getFuture();
+                processor->process(req);
+                auto resp = std::move(f).get();
+
+                ASSERT_EQ(0, resp.result.failed_parts.size());
+                checkResponse(resp.vertex_data, tags, expectColumnCount, totalRowCount);
+                hasNext = resp.get_has_next();
+                if (hasNext) {
+                    CHECK(resp.__isset.next_cursor);
+                    cursor = *resp.get_next_cursor();
+                }
+            }
+        }
+        CHECK_EQ(mock::MockData::players_.size() + mock::MockData::teams_.size(), totalRowCount);
+    }
+}
+
 
 }  // namespace storage
 }  // namespace nebula


### PR DESCRIPTION
Based on https://github.com/vesoft-inc/nebula-common/pull/246. Support scan data from storage within specified partition. Almost same as what we did in 1.0, except that we don't need to return the encoded value, just return the decoded value instead.

Could just review the new code, the existing code has expired which is from 1.0.