### PR TITLE
Fix storage would return wrong int vid ending with '\0'

### DIFF
--- a/src/kvstore/raftex/test/RaftexTestBase.h
+++ b/src/kvstore/raftex/test/RaftexTestBase.h
@@ -85,9 +85,13 @@ void appendLogs(int start,
                 std::vector<std::string>& msgs,
                 bool waitLastLog = false);
 
-void checkConsensus(std::vector<std::shared_ptr<test::TestShard>>& copies,
+bool checkConsensus(std::vector<std::shared_ptr<test::TestShard>>& copies,
                     size_t start, size_t end,
                     std::vector<std::string>& msgs);
+
+bool checkLog(std::shared_ptr<test::TestShard>& copy,
+              size_t start, size_t end,
+              std::vector<std::string>& msgs);
 
 void killOneCopy(std::vector<std::shared_ptr<RaftexService>>& services,
                  std::vector<std::shared_ptr<test::TestShard>>& copies,

--- a/src/mock/AdHocSchemaManager.cpp
+++ b/src/mock/AdHocSchemaManager.cpp
@@ -252,6 +252,10 @@ StatusOr<int32_t> AdHocSchemaManager::getSpaceVidLen(GraphSpaceID space) {
     return 32;
 }
 
+StatusOr<meta::cpp2::PropertyType> AdHocSchemaManager::getSpaceVidType(GraphSpaceID) {
+    return meta::cpp2::PropertyType::FIXED_STRING;
+}
+
 StatusOr<TagSchemas> AdHocSchemaManager::getAllVerTagSchema(GraphSpaceID space) {
     folly::RWSpinLock::ReadHolder rh(tagLock_);
     auto iter = tagSchemasInVector_.find(space);

--- a/src/mock/AdHocSchemaManager.h
+++ b/src/mock/AdHocSchemaManager.h
@@ -72,6 +72,8 @@ public:
 
     StatusOr<int32_t> getSpaceVidLen(GraphSpaceID) override;
 
+    StatusOr<meta::cpp2::PropertyType> getSpaceVidType(GraphSpaceID) override;
+
     // get all version of all tags
     StatusOr<TagSchemas> getAllVerTagSchema(GraphSpaceID space) override;
 

--- a/src/mock/MockCluster.h
+++ b/src/mock/MockCluster.h
@@ -29,6 +29,21 @@ namespace mock {
 
 class MockCluster {
 public:
+    ~MockCluster() {
+        if (metaClient_) {
+            metaClient_->stop();
+        }
+        if (metaKV_) {
+            metaKV_->stop();
+        }
+        if (storageKV_) {
+            storageKV_->stop();
+        }
+        storageAdminServer_.reset();
+        graphStorageServer_.reset();
+        generalStorageServer_.reset();
+    }
+
     void startAll();
 
     void startMeta(int32_t port, const std::string& rootPath, std::string hostname = "");

--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -61,7 +61,7 @@ protected:
         if (!vIdType.ok()) {
             return cpp2::ErrorCode::E_SPACE_NOT_FOUND;
         }
-        isIntId_ = vIdType.value() == meta::cpp2::PropertyType::INT64 ? true : false;
+        isIntId_ = (vIdType.value() == meta::cpp2::PropertyType::INT64);
 
         return cpp2::ErrorCode::SUCCEEDED;
     }

--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -56,6 +56,13 @@ protected:
             return cpp2::ErrorCode::E_SPACE_NOT_FOUND;
         }
         spaceVidLen_ = len.value();
+
+        auto vIdType = this->env_->schemaMan_->getSpaceVidType(spaceId);
+        if (!vIdType.ok()) {
+            return cpp2::ErrorCode::E_SPACE_NOT_FOUND;
+        }
+        isIntId_ = vIdType.value() == meta::cpp2::PropertyType::INT64 ? true : false;
+
         return cpp2::ErrorCode::SUCCEEDED;
     }
 
@@ -105,6 +112,7 @@ protected:
     std::mutex                                      lock_;
     int32_t                                         callingNum_{0};
     int32_t                                         spaceVidLen_;
+    bool                                            isIntId_;
 };
 
 }  // namespace storage

--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -68,14 +68,13 @@ struct PropContext;
 // PlanContext stores some information during the process
 class PlanContext {
 public:
-    PlanContext(StorageEnv* env, GraphSpaceID spaceId, size_t vIdLen)
-        : env_(env)
-        , spaceId_(spaceId)
-        , vIdLen_(vIdLen) {}
+    PlanContext(StorageEnv* env, GraphSpaceID spaceId, size_t vIdLen, bool isIntId)
+        : env_(env), spaceId_(spaceId), vIdLen_(vIdLen) , isIntId_(isIntId) {}
 
     StorageEnv*         env_;
     GraphSpaceID        spaceId_;
     size_t              vIdLen_;
+    bool                isIntId_;
 
     TagID                               tagId_ = 0;
     std::string                         tagName_ = "";

--- a/src/storage/context/StorageExpressionContext.cpp
+++ b/src/storage/context/StorageExpressionContext.cpp
@@ -44,7 +44,8 @@ Value StorageExpressionContext::getTagProp(const std::string& tagName,
             return Value::kNullValue;
         }
         if (prop == kVid) {
-            return NebulaKeyUtils::getVertexId(vIdLen_, key_);
+            auto vId = NebulaKeyUtils::getVertexId(vIdLen_, key_);
+            return isIntId_ ? vId : vId.subpiece(0, vId.find_first_of('\0'));
         } else {
             return readValue(prop);
         }
@@ -67,9 +68,11 @@ Value StorageExpressionContext::getEdgeProp(const std::string& edgeName,
             return Value::kNullValue;
         }
         if (prop == kSrc) {
-            return NebulaKeyUtils::getSrcId(vIdLen_, key_);
+            auto srcId = NebulaKeyUtils::getSrcId(vIdLen_, key_);
+            return isIntId_ ? srcId : srcId.subpiece(0, srcId.find_first_of('\0'));
         } else if (prop == kDst) {
-            return NebulaKeyUtils::getDstId(vIdLen_, key_);
+            auto dstId = NebulaKeyUtils::getDstId(vIdLen_, key_);
+            return isIntId_ ? dstId : dstId.subpiece(0, dstId.find_first_of('\0'));
         } else if (prop == kRank) {
             return NebulaKeyUtils::getRank(vIdLen_, key_);
         } else if (prop == kType) {

--- a/src/storage/context/StorageExpressionContext.h
+++ b/src/storage/context/StorageExpressionContext.h
@@ -29,18 +29,23 @@ If we need to read value from a user defined plase, just set the related value b
 class StorageExpressionContext final : public ExpressionContext {
 public:
     explicit StorageExpressionContext(size_t vIdLen,
+                                      bool isIntId,
                                       const std::string& name = "",
                                       const meta::NebulaSchemaProvider* schema = nullptr,
                                       bool isEdge = false)
         : vIdLen_(vIdLen)
+        , isIntId_(isIntId)
         , name_(name)
         , schema_(schema)
         , isEdge_(isEdge) {}
 
-    StorageExpressionContext(size_t vIdLen, int32_t vColNum,
+    StorageExpressionContext(size_t vIdLen,
+                             bool isIntId,
+                             int32_t vColNum,
                              bool hasNullableCol,
                              const std::vector<std::pair<std::string, Value::Type>>& indexCols)
         : vIdLen_(vIdLen)
+        , isIntId_(isIntId)
         , vColNum_(vColNum)
         , hasNullableCol_(hasNullableCol)
         , indexCols_(indexCols) {
@@ -160,6 +165,7 @@ public:
 
 private:
     size_t                             vIdLen_;
+    bool                               isIntId_;
 
     RowReader                         *reader_;
     std::string                        key_;

--- a/src/storage/exec/AggregateNode.h
+++ b/src/storage/exec/AggregateNode.h
@@ -132,7 +132,8 @@ private:
             if (prop.hasStat_) {
                 for (const auto statIndex : prop.statIndex_) {
                     VLOG(2) << "Collect stat prop " << prop.name_;
-                    auto value = QueryUtils::readEdgeProp(key, planContext_->vIdLen_, reader, prop);
+                    auto value = QueryUtils::readEdgeProp(
+                        key, planContext_->vIdLen_, planContext_->isIntId_, reader, prop);
                     if (!value.ok()) {
                         return kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND;
                     }

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -98,6 +98,7 @@ protected:
             auto ret = collectEdgeProps(reader,
                                         key,
                                         planContext_->vIdLen_,
+                                        planContext_->isIntId_,
                                         props,
                                         list);
             if (ret != kvstore::ResultCode::SUCCEEDED) {
@@ -174,6 +175,7 @@ private:
             auto ret = collectEdgeProps(reader.get(),
                                         std::get<2>(sample),
                                         planContext_->vIdLen_,
+                                        planContext_->isIntId_,
                                         std::get<3>(sample),
                                         list);
             if (ret != kvstore::ResultCode::SUCCEEDED) {

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -93,9 +93,11 @@ public:
 
     GetEdgePropNode(std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes,
                     size_t vIdLen,
+                    bool isIntId,
                     nebula::DataSet* resultDataSet)
         : edgeNodes_(std::move(edgeNodes))
         , vIdLen_(vIdLen)
+        , isIntId_(isIntId)
         , resultDataSet_(resultDataSet) {}
 
     kvstore::ResultCode execute(PartitionID partId, const cpp2::EdgeKey& edgeKey) override {
@@ -125,6 +127,7 @@ public:
                     auto code = collectEdgeProps(reader,
                                                  key,
                                                  vIdLen_,
+                                                 isIntId_,
                                                  props,
                                                  list);
                     if (code != kvstore::ResultCode::SUCCEEDED) {
@@ -146,6 +149,7 @@ public:
 private:
     std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes_;
     size_t vIdLen_;
+    bool isIntId_;
     nebula::DataSet* resultDataSet_;
 };
 

--- a/src/storage/exec/IndexOutputNode.h
+++ b/src/storage/exec/IndexOutputNode.h
@@ -166,7 +166,11 @@ private:
         for (const auto& val : data) {
             Row row;
             auto vId = NebulaKeyUtils::getVertexId(planContext_->vIdLen_, val.first);
-            row.emplace_back(Value(std::move(vId).subpiece(0, vId.find_first_of('\0'))));
+            if (planContext_->isIntId_) {
+                row.emplace_back(vId);
+            } else {
+                row.emplace_back(vId.subpiece(0, vId.find_first_of('\0')));
+            }
             auto reader = RowReaderWrapper::getRowReader(schema, val.second);
             if (!reader) {
                 VLOG(1) << "Can't get tag reader";
@@ -187,7 +191,11 @@ private:
         for (const auto& val : data) {
             Row row;
             auto vId = IndexKeyUtils::getIndexVertexID(planContext_->vIdLen_, val.first);
-            row.emplace_back(Value(std::move(vId).subpiece(0, vId.find_first_of('\0'))));
+            if (planContext_->isIntId_) {
+                row.emplace_back(vId);
+            } else {
+                row.emplace_back(vId.subpiece(0, vId.find_first_of('\0')));
+            }
 
             // skip vertexID
             for (size_t i = 1; i < returnCols.size(); i++) {
@@ -223,9 +231,15 @@ private:
             auto src = NebulaKeyUtils::getSrcId(planContext_->vIdLen_, val.first);
             auto rank = NebulaKeyUtils::getRank(planContext_->vIdLen_, val.first);
             auto dst = NebulaKeyUtils::getDstId(planContext_->vIdLen_, val.first);
-            row.emplace_back(Value(std::move(src).subpiece(0, src.find_first_of('\0'))));
-            row.emplace_back(Value(rank));
-            row.emplace_back(Value(std::move(dst).subpiece(0, dst.find_first_of('\0'))));
+            if (planContext_->isIntId_) {
+                row.emplace_back(src);
+                row.emplace_back(rank);
+                row.emplace_back(dst);
+            } else {
+                row.emplace_back(src.subpiece(0, src.find_first_of('\0')));
+                row.emplace_back(rank);
+                row.emplace_back(dst.subpiece(0, dst.find_first_of('\0')));
+            }
             auto reader = RowReaderWrapper::getRowReader(schema, val.second);
             if (!reader) {
                 VLOG(1) << "Can't get tag reader";

--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -62,6 +62,7 @@ public:
 
     static StatusOr<nebula::Value> readEdgeProp(folly::StringPiece key,
                                                 size_t vIdLen,
+                                                bool isIntId,
                                                 RowReader* reader,
                                                 const PropContext& prop) {
         switch (prop.propInKeyType_) {
@@ -71,7 +72,7 @@ public:
             }
             case PropContext::PropInKeyType::SRC: {
                 auto srcId = NebulaKeyUtils::getSrcId(vIdLen, key);
-                return srcId.subpiece(0, srcId.find_first_of('\0'));
+                return isIntId ? srcId : srcId.subpiece(0, srcId.find_first_of('\0'));
             }
             case PropContext::PropInKeyType::TYPE: {
                 auto edgeType = NebulaKeyUtils::getEdgeType(vIdLen, key);
@@ -83,7 +84,7 @@ public:
             }
             case PropContext::PropInKeyType::DST: {
                 auto dstId = NebulaKeyUtils::getDstId(vIdLen, key);
-                return dstId.subpiece(0, dstId.find_first_of('\0'));
+                return isIntId ? dstId : dstId.subpiece(0, dstId.find_first_of('\0'));
             }
         }
         return Status::Error(folly::stringPrintf("Invalid property %s", prop.name_.c_str()));

--- a/src/storage/exec/RelNode.h
+++ b/src/storage/exec/RelNode.h
@@ -93,12 +93,13 @@ protected:
             RowReader* reader,
             folly::StringPiece key,
             size_t vIdLen,
+            bool isIntId,
             const std::vector<PropContext>* props,
             nebula::List& list) {
         for (const auto& prop : *props) {
             if (prop.returned_) {
                 VLOG(2) << "Collect prop " << prop.name_;
-                auto value = QueryUtils::readEdgeProp(key, vIdLen, reader, prop);
+                auto value = QueryUtils::readEdgeProp(key, vIdLen, isIntId, reader, prop);
                 if (!value.ok()) {
                     return kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND;
                 }

--- a/src/storage/index/LookupBaseProcessor.inl
+++ b/src/storage/index/LookupBaseProcessor.inl
@@ -16,7 +16,8 @@ cpp2::ErrorCode LookupBaseProcessor<REQ, RESP>::requestCheck(const cpp2::LookupI
         return retCode;
     }
 
-    planContext_ = std::make_unique<PlanContext>(this->env_, spaceId_, this->spaceVidLen_);
+    planContext_ = std::make_unique<PlanContext>(
+        this->env_, spaceId_, this->spaceVidLen_, this->isIntId_);
     const auto& indices = req.get_indices();
     planContext_->isEdge_ = indices.get_is_edge();
     if (planContext_->isEdge_) {

--- a/src/storage/index/LookupBaseProcessor.inl
+++ b/src/storage/index/LookupBaseProcessor.inl
@@ -186,6 +186,7 @@ StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan() {
         } else if (!needData && needFilter) {
             auto expr = Expression::decode(ctx.get_filter());
             auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
+                                                                      planContext_->isIntId_,
                                                                       vColNum,
                                                                       hasNullableCol,
                                                                       indexCols);
@@ -197,7 +198,8 @@ StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan() {
             filterId++;
         } else {
             auto expr = Expression::decode(ctx.get_filter());
-            auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_);
+            auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
+                                                                      planContext_->isIntId_);
             filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
             out = buildPlanWithDataAndFilter(ctx,
                                              plan,

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -264,6 +264,7 @@ UpdateEdgeProcessor::buildEdgeContext(const cpp2::UpdateEdgeRequest& req) {
 
     if (expCtx_ == nullptr) {
         expCtx_ = std::make_unique<StorageExpressionContext>(spaceVidLen_,
+                                                             isIntId_,
                                                              planContext_->edgeName_,
                                                              planContext_->edgeSchema_,
                                                              true);

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -41,7 +41,7 @@ void UpdateEdgeProcessor::process(const cpp2::UpdateEdgeRequest& req) {
         return;
     }
 
-    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_);
+    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_, isIntId_);
 
     retCode = checkAndBuildContexts(req);
     if (retCode != cpp2::ErrorCode::SUCCEEDED) {

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -39,7 +39,7 @@ void UpdateVertexProcessor::process(const cpp2::UpdateVertexRequest& req) {
         onFinished();
         return;
     }
-    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_);
+    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_, isIntId_);
 
     retCode = checkAndBuildContexts(req);
     if (retCode != cpp2::ErrorCode::SUCCEEDED) {

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -262,6 +262,7 @@ UpdateVertexProcessor::buildTagContext(const cpp2::UpdateVertexRequest& req) {
 
     if (expCtx_ == nullptr) {
         expCtx_ = std::make_unique<StorageExpressionContext>(spaceVidLen_,
+                                                             isIntId_,
                                                              planContext_->tagName_,
                                                              planContext_->tagSchema_,
                                                              false);

--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -27,7 +27,7 @@ void GetNeighborsProcessor::process(const cpp2::GetNeighborsRequest& req) {
         return;
     }
     planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_, isIntId_);
-    expCtx_ = std::make_unique<StorageExpressionContext>(spaceVidLen_);
+    expCtx_ = std::make_unique<StorageExpressionContext>(spaceVidLen_, isIntId_);
 
     retCode = checkAndBuildContexts(req);
     if (retCode != cpp2::ErrorCode::SUCCEEDED) {

--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -26,7 +26,7 @@ void GetNeighborsProcessor::process(const cpp2::GetNeighborsRequest& req) {
         onFinished();
         return;
     }
-    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_);
+    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_, isIntId_);
     expCtx_ = std::make_unique<StorageExpressionContext>(spaceVidLen_);
 
     retCode = checkAndBuildContexts(req);

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -20,7 +20,7 @@ void GetPropProcessor::process(const cpp2::GetPropRequest& req) {
         onFinished();
         return;
     }
-    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_);
+    planContext_ = std::make_unique<PlanContext>(env_, spaceId_, spaceVidLen_, isIntId_);
 
     retCode = checkAndBuildContexts(req);
     if (retCode != cpp2::ErrorCode::SUCCEEDED) {
@@ -116,7 +116,7 @@ StoragePlan<cpp2::EdgeKey> GetPropProcessor::buildEdgePlan(nebula::DataSet* resu
         edges.emplace_back(edge.get());
         plan.addNode(std::move(edge));
     }
-    auto output = std::make_unique<GetEdgePropNode>(edges, spaceVidLen_, result);
+    auto output = std::make_unique<GetEdgePropNode>(edges, spaceVidLen_, isIntId_, result);
     for (auto* edge : edges) {
         output->addDependency(edge);
     }

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -481,7 +481,8 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::checkExp(const Expression* exp,
         case Expression::Kind::kDstProperty:
         case Expression::Kind::kUUID:
         case Expression::Kind::kVar:
-        case Expression::Kind::kVersionedVar: {
+        case Expression::Kind::kVersionedVar:
+        default: {
             LOG(INFO) << "Unimplemented expression type! kind = " << exp->kind();
             return cpp2::ErrorCode::E_INVALID_FILTER;
         }

--- a/src/storage/test/GetNeighborsBenchmark.cpp
+++ b/src/storage/test/GetNeighborsBenchmark.cpp
@@ -61,7 +61,7 @@ void initContext(std::unique_ptr<nebula::storage::PlanContext>& planCtx,
     nebula::GraphSpaceID spaceId = 1;
     auto* env = gCluster->storageEnv_.get();
     auto vIdLen = env->schemaMan_->getSpaceVidLen(spaceId).value();
-    planCtx = std::make_unique<nebula::storage::PlanContext>(env, spaceId, vIdLen);
+    planCtx = std::make_unique<nebula::storage::PlanContext>(env, spaceId, vIdLen, false);
 
     nebula::EdgeType serve = 101;
     edgeContext.schemas_ = std::move(env->schemaMan_->getAllVerEdgeSchema(spaceId)).value();

--- a/src/storage/test/ScanEdgePropBenchmark.cpp
+++ b/src/storage/test/ScanEdgePropBenchmark.cpp
@@ -98,6 +98,7 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
     PartitionID partId = (hash(vId) % totalParts) + 1;
     EdgeType edgeType = 101;
     auto vIdLen = env->schemaMan_->getSpaceVidLen(spaceId).value();
+    bool isIntId = false;
 
     std::vector<PropContext> props;
     {
@@ -136,7 +137,7 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             ASSERT_TRUE(schema != nullptr);
             auto wrapper = std::make_unique<RowReaderWrapper>();
             ASSERT_TRUE(wrapper->reset(schema.get(), val, readerVer));
-            auto code = node.collectEdgeProps(wrapper.get(), key, vIdLen, &props, list);
+            auto code = node.collectEdgeProps(wrapper.get(), key, vIdLen, isIntId, &props, list);
             ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
             result.mutableList().values.emplace_back(std::move(list));
         }
@@ -162,7 +163,7 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             reader = RowReaderWrapper::getEdgePropReader(env->schemaMan_, spaceId,
                                                          std::abs(edgeType), val);
             ASSERT_TRUE(reader.get() != nullptr);
-            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, &props, list);
+            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, isIntId, &props, list);
             ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
             result.mutableList().values.emplace_back(std::move(list));
         }
@@ -188,7 +189,7 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             reader = RowReaderWrapper::getEdgePropReader(env->schemaMan_, spaceId,
                                                          std::abs(edgeType), val);
             ASSERT_TRUE(reader.get() != nullptr);
-            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, &props, list);
+            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, isIntId, &props, list);
             ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
             result.mutableList().values.emplace_back(std::move(list));
         }
@@ -226,7 +227,7 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             } else {
                 ASSERT_TRUE(reader->reset(schemas, val));
             }
-            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, &props, list);
+            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, isIntId, &props, list);
             ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
             result.mutableList().values.emplace_back(std::move(list));
         }


### PR DESCRIPTION
Rely on https://github.com/vesoft-inc/nebula-common/pull/263.

When the vid is integer, it could end with '\0', we can't simply discard them. So we need to be aware of vid type. It involves as follows:
1. GetNeighbors/GetProp/Update
2. StorageExpressionContext
3. Index, (not done, wait https://github.com/vesoft-inc/nebula-storage/pull/171 merge at first)

Fix unstable ut in ci as well.

close #170, #166, #161