### PR TITLE
support get all vertices on tag, get all edges on edgetype

### DIFF
--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -385,9 +385,9 @@ cpp2::Schema MetaServiceUtils::parseSchema(folly::StringPiece rawData) {
 
 std::string MetaServiceUtils::indexKey(GraphSpaceID spaceID, IndexID indexID) {
     std::string key;
-    key.reserve(sizeof(GraphSpaceID) + sizeof(IndexID));
-    key.append(kIndexesTable.data(), kIndexesTable.size());
-    key.append(reinterpret_cast<const char*>(&spaceID), sizeof(GraphSpaceID))
+    key.reserve(kIndexesTable.size() + sizeof(GraphSpaceID) + sizeof(IndexID));
+    key.append(kIndexesTable.data(), kIndexesTable.size())
+       .append(reinterpret_cast<const char*>(&spaceID), sizeof(GraphSpaceID))
        .append(reinterpret_cast<const char*>(&indexID), sizeof(IndexID));
     return key;
 }

--- a/src/meta/processors/BaseProcessor.inl
+++ b/src/meta/processors/BaseProcessor.inl
@@ -438,7 +438,7 @@ bool BaseProcessor<RESP>::checkIndexExist(const std::vector<std::string>& fields
         }
 
         if (i == fields.size() - 1) {
-            LOG(ERROR) << "Index " << item.get_index_name() << " have existed";
+            LOG(ERROR) << "Index " << item.get_index_name() << " has existed";
             return true;
         }
     }

--- a/src/meta/processors/BaseProcessor.inl
+++ b/src/meta/processors/BaseProcessor.inl
@@ -432,6 +432,11 @@ BaseProcessor<RESP>::indexCheck(const std::vector<cpp2::IndexItem>& items,
 template<typename RESP>
 bool BaseProcessor<RESP>::checkIndexExist(const std::vector<std::string>& fields,
                                           const cpp2::IndexItem& item) {
+    if (fields.size() == 0) {
+        LOG(ERROR) << "Index " << item.get_index_name() << " has existed";
+        return true;
+    }
+
     for (size_t i = 0; i < fields.size(); i++) {
         if (fields[i] != item.get_fields()[i].get_name()) {
             break;

--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -15,12 +15,6 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
     const auto &indexName = req.get_index_name();
     auto &edgeName = req.get_edge_name();
     auto &fieldNames = req.get_fields();
-    if (fieldNames.empty()) {
-        LOG(ERROR) << "The index field of an edge type should not be empty.";
-        handleErrorCode(cpp2::ErrorCode::E_INVALID_PARM);
-        onFinished();
-        return;
-    }
 
     std::set<std::string> columnSet(fieldNames.begin(), fieldNames.end());
     if (fieldNames.size() != columnSet.size()) {
@@ -80,6 +74,17 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
             continue;
         }
 
+        if (fieldNames.size() == 0) {
+            if (item.get_fields().size() != 0) {
+                checkIter->next();
+                continue;
+            } else {
+                LOG(ERROR) << "Index " << item.get_index_name() << " has existed";
+                resp_.set_code(cpp2::ErrorCode::E_EXISTED);
+                onFinished();
+                return;
+            }
+        }
         if (checkIndexExist(fieldNames, item)) {
             resp_.set_code(cpp2::ErrorCode::E_EXISTED);
             onFinished();

--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -35,7 +35,7 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
     folly::SharedMutex::WriteHolder wHolder(LockUtils::edgeIndexLock());
     auto ret = getIndexID(space, indexName);
     if (ret.ok()) {
-        LOG(ERROR) << "Create Edge Index Failed: " << indexName << " have existed";
+        LOG(ERROR) << "Create Edge Index Failed: " << indexName << " has existed";
         if (req.get_if_not_exists()) {
             resp_.set_id(to(ret.value(), EntryType::INDEX));
             handleErrorCode(cpp2::ErrorCode::SUCCEEDED);

--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -74,17 +74,6 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
             continue;
         }
 
-        if (fieldNames.size() == 0) {
-            if (item.get_fields().size() != 0) {
-                checkIter->next();
-                continue;
-            } else {
-                LOG(ERROR) << "Index " << item.get_index_name() << " has existed";
-                resp_.set_code(cpp2::ErrorCode::E_EXISTED);
-                onFinished();
-                return;
-            }
-        }
         if (checkIndexExist(fieldNames, item)) {
             resp_.set_code(cpp2::ErrorCode::E_EXISTED);
             onFinished();

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -85,7 +85,7 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
                 return;
             }
         }
-                
+
         if (checkIndexExist(fieldNames, item)) {
             resp_.set_code(cpp2::ErrorCode::E_EXISTED);
             onFinished();

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -15,12 +15,7 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
     const auto &indexName = req.get_index_name();
     auto &tagName = req.get_tag_name();
     auto &fieldNames = req.get_fields();
-    if (fieldNames.empty()) {
-        LOG(ERROR) << "The index field of an tag should not be empty.";
-        handleErrorCode(cpp2::ErrorCode::E_INVALID_PARM);
-        onFinished();
-        return;
-    }
+
     std::set<std::string> columnSet(fieldNames.begin(), fieldNames.end());
     if (fieldNames.size() != columnSet.size()) {
         LOG(ERROR) << "Conflict field in the tag index.";
@@ -40,7 +35,7 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
     folly::SharedMutex::WriteHolder wHolder(LockUtils::tagIndexLock());
     auto ret = getIndexID(space, indexName);
     if (ret.ok()) {
-        LOG(ERROR) << "Create Tag Index Failed: " << indexName << " have existed";
+        LOG(ERROR) << "Create Tag Index Failed: " << indexName << " has existed";
         if (req.get_if_not_exists()) {
             resp_.set_id(to(ret.value(), EntryType::INDEX));
             handleErrorCode(cpp2::ErrorCode::SUCCEEDED);
@@ -79,6 +74,18 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
             continue;
         }
 
+        if (fieldNames.size() == 0) {
+            if (item.get_fields().size() != 0) {
+                checkIter->next();
+                continue;
+            } else {
+                LOG(ERROR) << "Index " << item.get_index_name() << " has existed";
+                resp_.set_code(cpp2::ErrorCode::E_EXISTED);
+                onFinished();
+                return;
+            }
+        }
+                
         if (checkIndexExist(fieldNames, item)) {
             resp_.set_code(cpp2::ErrorCode::E_EXISTED);
             onFinished();

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -74,18 +74,6 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
             continue;
         }
 
-        if (fieldNames.size() == 0) {
-            if (item.get_fields().size() != 0) {
-                checkIter->next();
-                continue;
-            } else {
-                LOG(ERROR) << "Index " << item.get_index_name() << " has existed";
-                resp_.set_code(cpp2::ErrorCode::E_EXISTED);
-                onFinished();
-                return;
-            }
-        }
-
         if (checkIndexExist(fieldNames, item)) {
             resp_.set_code(cpp2::ErrorCode::E_EXISTED);
             onFinished();

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -2275,6 +2275,30 @@ TEST(ProcessorTest, TagIndexTest) {
         ASSERT_EQ(cpp2::ErrorCode::E_EXISTED, resp.get_code());
     }
     {
+        cpp2::DropTagIndexReq req;
+        req.set_space_id(1);
+        req.set_index_name("no_field_index");
+        auto* processor = DropTagIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
+    {
+        // Allow to create tag index on no fields
+        cpp2::CreateTagIndexReq req;
+        req.set_space_id(1);
+        req.set_tag_name("tag_0");
+        std::vector<std::string> fields{};
+        req.set_fields(std::move(fields));
+        req.set_index_name("no_field_index");
+        auto* processor = CreateTagIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
+    {
         cpp2::CreateTagIndexReq req;
         req.set_space_id(1);
         req.set_tag_name("tag_0");
@@ -2389,14 +2413,7 @@ TEST(ProcessorTest, TagIndexTest) {
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
         auto items = resp.get_items();
 
-        ASSERT_EQ(4, items.size());
-        {
-            auto zeroItem = items[0];
-            ASSERT_EQ(1, zeroItem.get_index_id());
-            ASSERT_EQ("no_field_index", zeroItem.get_index_name());
-            auto zeroFieldResult = zeroItem.get_fields();
-            ASSERT_EQ(0, zeroFieldResult.size());
-        }
+        ASSERT_EQ(3, items.size());
         {
             cpp2::ColumnDef column;
             column.set_name("tag_0_col_0");
@@ -2404,7 +2421,7 @@ TEST(ProcessorTest, TagIndexTest) {
             std::vector<cpp2::ColumnDef> columns;
             columns.emplace_back(std::move(column));
 
-            auto singleItem = items[1];
+            auto singleItem = items[0];
             ASSERT_EQ(2, singleItem.get_index_id());
             ASSERT_EQ("single_field_index", singleItem.get_index_name());
             auto singleFieldResult = singleItem.get_fields();
@@ -2422,7 +2439,7 @@ TEST(ProcessorTest, TagIndexTest) {
             stringColumn.type.set_type(PropertyType::STRING);
             columns.emplace_back(std::move(stringColumn));
 
-            auto multiItem = items[2];
+            auto multiItem = items[1];
             ASSERT_EQ(3, multiItem.get_index_id());
             auto multiFieldResult = multiItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, multiFieldResult));
@@ -2438,7 +2455,7 @@ TEST(ProcessorTest, TagIndexTest) {
             intColumn.type.set_type(PropertyType::INT64);
             columns.emplace_back(std::move(intColumn));
 
-            auto disorderItem = items[3];
+            auto disorderItem = items[2];
             ASSERT_EQ(4, disorderItem.get_index_id());
             auto disorderFieldResult = disorderItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, disorderFieldResult));
@@ -2572,7 +2589,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
         req.set_edge_name("edge_0");
         std::vector<std::string> fields{};
         req.set_fields(std::move(fields));
-        req.set_index_name("no_field_index");
+        req.set_index_name("no_field_index_1");
         auto* processor = CreateEdgeIndexProcessor::instance(kv.get());
         auto f = processor->getFuture();
         processor->process(req);
@@ -2604,6 +2621,30 @@ TEST(ProcessorTest, EdgeIndexTest) {
         processor->process(req);
         auto resp = std::move(f).get();
         ASSERT_EQ(cpp2::ErrorCode::E_EXISTED, resp.get_code());
+    }
+    {
+        cpp2::DropEdgeIndexReq req;
+        req.set_space_id(1);
+        req.set_index_name("no_field_index");
+        auto* processor = DropEdgeIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
+    {
+        // Allow to create edge index on no fields
+        cpp2::CreateEdgeIndexReq req;
+        req.set_space_id(1);
+        req.set_edge_name("edge_0");
+        std::vector<std::string> fields{};
+        req.set_fields(std::move(fields));
+        req.set_index_name("no_field_index");
+        auto* processor = CreateEdgeIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
     }
     {
         cpp2::CreateEdgeIndexReq req;
@@ -2718,14 +2759,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
         auto resp = std::move(f).get();
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
         auto items = resp.get_items();
-        ASSERT_EQ(4, items.size());
-
-        {
-            auto zeroItem = items[0];
-            ASSERT_EQ(1, zeroItem.get_index_id());
-            auto zeroFieldResult = zeroItem.get_fields();
-            ASSERT_EQ(0, zeroFieldResult.size());
-        }
+        ASSERT_EQ(3, items.size());
         {
             cpp2::ColumnDef column;
             column.set_name("edge_0_col_0");
@@ -2733,7 +2767,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
             std::vector<cpp2::ColumnDef> columns;
             columns.emplace_back(std::move(column));
 
-            auto singleItem = items[1];
+            auto singleItem = items[0];
             ASSERT_EQ(2, singleItem.get_index_id());
             auto singleFieldResult = singleItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, singleFieldResult));
@@ -2750,7 +2784,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
             stringColumn.type.set_type(PropertyType::STRING);
             columns.emplace_back(std::move(stringColumn));
 
-            auto multiItem = items[2];
+            auto multiItem = items[1];
             ASSERT_EQ(3, multiItem.get_index_id());
             auto multiFieldResult = multiItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, multiFieldResult));
@@ -2766,7 +2800,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
             intColumn.type.set_type(PropertyType::INT64);
             columns.emplace_back(std::move(intColumn));
 
-            auto disorderItem = items[3];
+            auto disorderItem = items[2];
             ASSERT_EQ(4, disorderItem.get_index_id());
             auto disorderFieldResult = disorderItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, disorderFieldResult));

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -2221,6 +2221,34 @@ TEST(ProcessorTest, TagIndexTest) {
     ASSERT_TRUE(TestUtils::assembleSpace(kv.get(), 1, 1));
     TestUtils::mockTag(kv.get(), 2);
     {
+        // Allow to create tag index on no fields
+        cpp2::CreateTagIndexReq req;
+        req.set_space_id(1);
+        req.set_tag_name("tag_0");
+        std::vector<std::string> fields{};
+        req.set_fields(std::move(fields));
+        req.set_index_name("no_field_index");
+        auto* processor = CreateTagIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
+    {
+        // Duplicate tag index on no fields
+        cpp2::CreateTagIndexReq req;
+        req.set_space_id(1);
+        req.set_tag_name("tag_0");
+        std::vector<std::string> fields{};
+        req.set_fields(std::move(fields));
+        req.set_index_name("no_field_index_1");
+        auto* processor = CreateTagIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
+    {
         cpp2::CreateTagIndexReq req;
         req.set_space_id(1);
         req.set_tag_name("tag_0");
@@ -2361,7 +2389,14 @@ TEST(ProcessorTest, TagIndexTest) {
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
         auto items = resp.get_items();
 
-        ASSERT_EQ(3, items.size());
+        ASSERT_EQ(4, items.size());
+        {
+            auto zeroItem = items[0];
+            ASSERT_EQ(1, zeroItem.get_index_id());
+            ASSERT_EQ("no_field_index", zeroItem.get_index_name());
+            auto zeroFieldResult = zeroItem.get_fields();
+            ASSERT_EQ(0, zeroFieldResult.size());
+        }
         {
             cpp2::ColumnDef column;
             column.set_name("tag_0_col_0");
@@ -2369,8 +2404,8 @@ TEST(ProcessorTest, TagIndexTest) {
             std::vector<cpp2::ColumnDef> columns;
             columns.emplace_back(std::move(column));
 
-            auto singleItem = items[0];
-            ASSERT_EQ(1, singleItem.get_index_id());
+            auto singleItem = items[1];
+            ASSERT_EQ(2, singleItem.get_index_id());
             ASSERT_EQ("single_field_index", singleItem.get_index_name());
             auto singleFieldResult = singleItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, singleFieldResult));
@@ -2387,8 +2422,8 @@ TEST(ProcessorTest, TagIndexTest) {
             stringColumn.type.set_type(PropertyType::STRING);
             columns.emplace_back(std::move(stringColumn));
 
-            auto multiItem = items[1];
-            ASSERT_EQ(2, multiItem.get_index_id());
+            auto multiItem = items[2];
+            ASSERT_EQ(3, multiItem.get_index_id());
             auto multiFieldResult = multiItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, multiFieldResult));
         }
@@ -2403,8 +2438,8 @@ TEST(ProcessorTest, TagIndexTest) {
             intColumn.type.set_type(PropertyType::INT64);
             columns.emplace_back(std::move(intColumn));
 
-            auto disorderItem = items[2];
-            ASSERT_EQ(3, disorderItem.get_index_id());
+            auto disorderItem = items[3];
+            ASSERT_EQ(4, disorderItem.get_index_id());
             auto disorderFieldResult = disorderItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, disorderFieldResult));
         }
@@ -2421,7 +2456,7 @@ TEST(ProcessorTest, TagIndexTest) {
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
         auto item = resp.get_item();
         auto fields = item.get_fields();
-        ASSERT_EQ(1, item.get_index_id());
+        ASSERT_EQ(2, item.get_index_id());
 
         cpp2::ColumnDef column;
         column.set_name("tag_0_col_0");
@@ -2516,6 +2551,34 @@ TEST(ProcessorTest, EdgeIndexTest) {
     TestUtils::createSomeHosts(kv.get());
     ASSERT_TRUE(TestUtils::assembleSpace(kv.get(), 1, 1));
     TestUtils::mockEdge(kv.get(), 2);
+    {
+        // Allow to create edge index on no fields
+        cpp2::CreateEdgeIndexReq req;
+        req.set_space_id(1);
+        req.set_edge_name("edge_0");
+        std::vector<std::string> fields{};
+        req.set_fields(std::move(fields));
+        req.set_index_name("no_field_index");
+        auto* processor = CreateEdgeIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
+    {
+        // Duplicate edge index on no fields
+        cpp2::CreateEdgeIndexReq req;
+        req.set_space_id(1);
+        req.set_edge_name("edge_0");
+        std::vector<std::string> fields{};
+        req.set_fields(std::move(fields));
+        req.set_index_name("no_field_index");
+        auto* processor = CreateEdgeIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
     {
         cpp2::CreateEdgeIndexReq req;
         req.set_space_id(1);
@@ -2655,8 +2718,14 @@ TEST(ProcessorTest, EdgeIndexTest) {
         auto resp = std::move(f).get();
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
         auto items = resp.get_items();
-        ASSERT_EQ(3, items.size());
+        ASSERT_EQ(4, items.size());
 
+        {
+            auto zeroItem = items[0];
+            ASSERT_EQ(1, zeroItem.get_index_id());
+            auto zeroFieldResult = zeroItem.get_fields();
+            ASSERT_EQ(0, zeroFieldResult.size());
+        }
         {
             cpp2::ColumnDef column;
             column.set_name("edge_0_col_0");
@@ -2664,8 +2733,8 @@ TEST(ProcessorTest, EdgeIndexTest) {
             std::vector<cpp2::ColumnDef> columns;
             columns.emplace_back(std::move(column));
 
-            auto singleItem = items[0];
-            ASSERT_EQ(1, singleItem.get_index_id());
+            auto singleItem = items[1];
+            ASSERT_EQ(2, singleItem.get_index_id());
             auto singleFieldResult = singleItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, singleFieldResult));
         }
@@ -2681,8 +2750,8 @@ TEST(ProcessorTest, EdgeIndexTest) {
             stringColumn.type.set_type(PropertyType::STRING);
             columns.emplace_back(std::move(stringColumn));
 
-            auto multiItem = items[1];
-            ASSERT_EQ(2, multiItem.get_index_id());
+            auto multiItem = items[2];
+            ASSERT_EQ(3, multiItem.get_index_id());
             auto multiFieldResult = multiItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, multiFieldResult));
         }
@@ -2697,8 +2766,8 @@ TEST(ProcessorTest, EdgeIndexTest) {
             intColumn.type.set_type(PropertyType::INT64);
             columns.emplace_back(std::move(intColumn));
 
-            auto disorderItem = items[2];
-            ASSERT_EQ(3, disorderItem.get_index_id());
+            auto disorderItem = items[3];
+            ASSERT_EQ(4, disorderItem.get_index_id());
             auto disorderFieldResult = disorderItem.get_fields();
             ASSERT_TRUE(TestUtils::verifyResult(columns, disorderFieldResult));
         }
@@ -2715,7 +2784,7 @@ TEST(ProcessorTest, EdgeIndexTest) {
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
         auto item = resp.get_item();
         auto properties = item.get_fields();
-        ASSERT_EQ(1, item.get_index_id());
+        ASSERT_EQ(2, item.get_index_id());
     }
     {
         cpp2::DropEdgeIndexReq req;

--- a/src/mock/MockCluster.cpp
+++ b/src/mock/MockCluster.cpp
@@ -207,8 +207,12 @@ MockCluster::memIndexMan(GraphSpaceID spaceId) {
     indexMan->addTagIndex(spaceId, 1, 1, MockData::mockPlayerTagIndexColumns());
     indexMan->addTagIndex(spaceId, 2, 2, MockData::mockTeamTagIndexColumns());
     indexMan->addTagIndex(spaceId, 3, 3, MockData::mockGeneralTagIndexColumns());
+    indexMan->addTagIndex(spaceId, 1, 4, {});
+    indexMan->addTagIndex(spaceId, 2, 5, {});
     indexMan->addEdgeIndex(spaceId, 101, 101, MockData::mockServeEdgeIndexColumns());
     indexMan->addEdgeIndex(spaceId, 102, 102, MockData::mockTeammateEdgeIndexColumns());
+    indexMan->addEdgeIndex(spaceId, 101, 103, {});
+    indexMan->addEdgeIndex(spaceId, 102, 104, {});
     return indexMan;
 }
 

--- a/src/mock/MockCluster.cpp
+++ b/src/mock/MockCluster.cpp
@@ -105,7 +105,8 @@ void MockCluster::startMeta(int32_t port,
 
 void MockCluster::initStorageKV(const char* dataPath,
                                 HostAddr addr,
-                                SchemaVer schemaVerCount) {
+                                SchemaVer schemaVerCount,
+                                bool hasProp) {
     const std::vector<PartitionID> parts{1, 2, 3, 4, 5, 6};
     totalParts_ = 6;  // don't not delete this...
     kvstore::KVOptions options;
@@ -132,8 +133,8 @@ void MockCluster::initStorageKV(const char* dataPath,
     } else {
         LOG(INFO) << "Use meta in memory!";
         options.partMan_ = memPartMan(1, parts);;
-        schemaMan_ = memSchemaMan(schemaVerCount);
-        indexMan_ = memIndexMan();
+        schemaMan_ = memSchemaMan(schemaVerCount, 1, hasProp);
+        indexMan_ = memIndexMan(1, hasProp);
     }
     std::vector<std::string> paths;
     paths.emplace_back(folly::stringPrintf("%s/disk1", dataPath));
@@ -177,21 +178,21 @@ void MockCluster::startStorage(HostAddr addr,
 }
 
 std::unique_ptr<meta::SchemaManager>
-MockCluster::memSchemaMan(SchemaVer schemaVerCount, GraphSpaceID spaceId) {
+MockCluster::memSchemaMan(SchemaVer schemaVerCount, GraphSpaceID spaceId, bool hasProp) {
     auto schemaMan = std::make_unique<AdHocSchemaManager>();
     // if have multi version schema, need to add from oldest to newest
     for (SchemaVer ver = 0; ver < schemaVerCount; ver++) {
         // Vertex has two tags: players and teams
         // When tagId is 1, use players data
-        schemaMan->addTagSchema(spaceId, 1, MockData::mockPlayerTagSchema(ver));
+        schemaMan->addTagSchema(spaceId, 1, MockData::mockPlayerTagSchema(ver, hasProp));
         // When tagId is 2, use teams data
-        schemaMan->addTagSchema(spaceId, 2, MockData::mockTeamTagSchema(ver));
+        schemaMan->addTagSchema(spaceId, 2, MockData::mockTeamTagSchema(ver, hasProp));
 
         // Edge has two type: serve and teammate
         // When edgeType is 101, use serve data
-        schemaMan->addEdgeSchema(spaceId, 101, MockData::mockServeEdgeSchema(ver));
+        schemaMan->addEdgeSchema(spaceId, 101, MockData::mockServeEdgeSchema(ver, hasProp));
         // When edgeType is 102, use teammate data
-        schemaMan->addEdgeSchema(spaceId, 102, MockData::mockTeammateEdgeSchema(ver));
+        schemaMan->addEdgeSchema(spaceId, 102, MockData::mockTeammateEdgeSchema(ver, hasProp));
     }
 
     schemaMan->addTagSchema(spaceId, 3, MockData::mockGeneralTagSchemaV1());
@@ -202,15 +203,18 @@ MockCluster::memSchemaMan(SchemaVer schemaVerCount, GraphSpaceID spaceId) {
 }
 
 std::unique_ptr<meta::IndexManager>
-MockCluster::memIndexMan(GraphSpaceID spaceId) {
+MockCluster::memIndexMan(GraphSpaceID spaceId, bool hasProp) {
     auto indexMan = std::make_unique<AdHocIndexManager>();
-    indexMan->addTagIndex(spaceId, 1, 1, MockData::mockPlayerTagIndexColumns());
-    indexMan->addTagIndex(spaceId, 2, 2, MockData::mockTeamTagIndexColumns());
-    indexMan->addTagIndex(spaceId, 3, 3, MockData::mockGeneralTagIndexColumns());
+    if (hasProp) {
+        indexMan->addTagIndex(spaceId, 1, 1, MockData::mockPlayerTagIndexColumns());
+        indexMan->addTagIndex(spaceId, 2, 2, MockData::mockTeamTagIndexColumns());
+        indexMan->addTagIndex(spaceId, 3, 3, MockData::mockGeneralTagIndexColumns());
+        indexMan->addEdgeIndex(spaceId, 101, 101, MockData::mockServeEdgeIndexColumns());
+        indexMan->addEdgeIndex(spaceId, 102, 102, MockData::mockTeammateEdgeIndexColumns());
+    }
+
     indexMan->addTagIndex(spaceId, 1, 4, {});
     indexMan->addTagIndex(spaceId, 2, 5, {});
-    indexMan->addEdgeIndex(spaceId, 101, 101, MockData::mockServeEdgeIndexColumns());
-    indexMan->addEdgeIndex(spaceId, 102, 102, MockData::mockTeammateEdgeIndexColumns());
     indexMan->addEdgeIndex(spaceId, 101, 103, {});
     indexMan->addEdgeIndex(spaceId, 102, 104, {});
     return indexMan;

--- a/src/mock/MockCluster.h
+++ b/src/mock/MockCluster.h
@@ -68,9 +68,11 @@ public:
     storage::GeneralStorageClient* initGeneralStorageClient();
 
     std::unique_ptr<meta::SchemaManager> memSchemaMan(SchemaVer schemaVerCount = 1,
-                                                      GraphSpaceID spaceId = 1);
+                                                      GraphSpaceID spaceId = 1,
+                                                      bool hasProp = true);
 
-    std::unique_ptr<meta::IndexManager> memIndexMan(GraphSpaceID spaceId = 1);
+    std::unique_ptr<meta::IndexManager> memIndexMan(GraphSpaceID spaceId = 1,
+                                                    bool hasProp = true);
 
     static void waitUntilAllElected(kvstore::NebulaStore* kvstore,
                                     GraphSpaceID spaceId,
@@ -87,7 +89,8 @@ public:
 
     void initStorageKV(const char* dataPath,
                        HostAddr localHost = HostAddr("", 0),
-                       SchemaVer schemaVerCount = 1);
+                       SchemaVer schemaVerCount = 1,
+                       bool hasProp = true);
 
     static std::string localIP();
 

--- a/src/mock/MockData.cpp
+++ b/src/mock/MockData.cpp
@@ -295,8 +295,12 @@ std::unordered_map<std::string, std::vector<Serve>> MockData::playerServes_ = pl
 std::unordered_map<std::string, std::vector<Serve>> MockData::teamServes_ = teamServes();
 
 // Mock schema
-std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockPlayerTagSchema(SchemaVer ver) {
+std::shared_ptr<meta::NebulaSchemaProvider>
+MockData::mockPlayerTagSchema(SchemaVer ver, bool hasProp) {
     std::shared_ptr<meta::NebulaSchemaProvider> schema(new meta::NebulaSchemaProvider(ver));
+    if (!hasProp) {
+        return schema;
+    }
     schema->addField("name",
                      meta::cpp2::PropertyType::STRING,
                      0,
@@ -371,14 +375,22 @@ std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockPlayerTagSchema(Schema
     return schema;
 }
 
-std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockTeamTagSchema(SchemaVer ver) {
+std::shared_ptr<meta::NebulaSchemaProvider>
+MockData::mockTeamTagSchema(SchemaVer ver, bool hasProp) {
     std::shared_ptr<meta::NebulaSchemaProvider> schema(new meta::NebulaSchemaProvider(ver));
+    if (!hasProp) {
+        return schema;
+    }
     schema->addField("name", meta::cpp2::PropertyType::STRING);
     return schema;
 }
 
-std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockServeEdgeSchema(SchemaVer ver) {
+std::shared_ptr<meta::NebulaSchemaProvider>
+MockData::mockServeEdgeSchema(SchemaVer ver, bool hasProp) {
     std::shared_ptr<meta::NebulaSchemaProvider> schema(new meta::NebulaSchemaProvider(ver));
+    if (!hasProp) {
+        return schema;
+    }
     schema->addField("playerName",
                      meta::cpp2::PropertyType::STRING,
                      0,
@@ -443,8 +455,12 @@ std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockServeEdgeSchema(Schema
     return schema;
 }
 
-std::shared_ptr<meta::NebulaSchemaProvider> MockData::mockTeammateEdgeSchema(SchemaVer ver) {
+std::shared_ptr<meta::NebulaSchemaProvider>
+MockData::mockTeammateEdgeSchema(SchemaVer ver, bool hasProp) {
     std::shared_ptr<meta::NebulaSchemaProvider> schema(new meta::NebulaSchemaProvider(ver));
+    if (!hasProp) {
+        return schema;
+    }
     schema->addField("player1",   meta::cpp2::PropertyType::STRING);
     schema->addField("player2",   meta::cpp2::PropertyType::STRING);
     schema->addField("teamName",  meta::cpp2::PropertyType::STRING);

--- a/src/mock/MockData.cpp
+++ b/src/mock/MockData.cpp
@@ -814,6 +814,16 @@ std::vector<VertexID> MockData::mockVerticeIds() {
     return ret;
 }
 
+std::vector<VertexID> MockData::mockPlayerVerticeIds() {
+    std::vector<VertexID> ret;
+    for (auto& player : players_) {
+        VertexID data;
+        data = player.name_;
+        ret.push_back(data);
+    }
+    return ret;
+}
+
 std::vector<EdgeData> MockData::mockEdges(bool upper) {
     std::vector<EdgeData> ret;
     // Use serve data, positive edgeType is 101, reverse edgeType is -101

--- a/src/mock/MockData.h
+++ b/src/mock/MockData.h
@@ -119,6 +119,8 @@ public:
 
     static std::vector<VertexID> mockVerticeIds();
 
+    static std::vector<VertexID> mockPlayerVerticeIds();
+
     // generate serve edge with different rank
     static std::unordered_map<VertexID, std::vector<EdgeData>> mockmMultiRankServes(
             EdgeRanking rankCount = 1);

--- a/src/mock/MockData.h
+++ b/src/mock/MockData.h
@@ -71,13 +71,17 @@ public:
     /*
      * Mock schema
      */
-    static std::shared_ptr<meta::NebulaSchemaProvider> mockPlayerTagSchema(SchemaVer ver = 0);
+    static std::shared_ptr<meta::NebulaSchemaProvider>
+    mockPlayerTagSchema(SchemaVer ver = 0, bool hasProp = true);
 
-    static std::shared_ptr<meta::NebulaSchemaProvider> mockTeamTagSchema(SchemaVer ver = 0);
+    static std::shared_ptr<meta::NebulaSchemaProvider>
+    mockTeamTagSchema(SchemaVer ver = 0, bool hasProp = true);
 
-    static std::shared_ptr<meta::NebulaSchemaProvider> mockServeEdgeSchema(SchemaVer ver = 0);
+    static std::shared_ptr<meta::NebulaSchemaProvider>
+    mockServeEdgeSchema(SchemaVer ver = 0, bool hasProp = true);
 
-    static std::shared_ptr<meta::NebulaSchemaProvider> mockTeammateEdgeSchema(SchemaVer ver = 0);
+    static std::shared_ptr<meta::NebulaSchemaProvider>
+    mockTeammateEdgeSchema(SchemaVer ver = 0, bool hasProp = true);
 
     static std::vector<nebula::meta::cpp2::ColumnDef> mockGeneralTagIndexColumns();
 

--- a/src/storage/exec/IndexOutputNode.h
+++ b/src/storage/exec/IndexOutputNode.h
@@ -245,7 +245,7 @@ private:
                 VLOG(1) << "Can't get tag reader";
                 return kvstore::ResultCode::ERR_EDGE_NOT_FOUND;
             }
-            // skip column src_ , edgeType, ranking, dst_
+            // skip column src_, ranking, dst_
             for (size_t i = 3; i < returnCols.size(); i++) {
                 auto v = reader->getValueByName(returnCols[i]);
                 row.emplace_back(std::move(v));

--- a/src/storage/index/LookupBaseProcessor.h
+++ b/src/storage/index/LookupBaseProcessor.h
@@ -75,6 +75,7 @@ protected:
     std::vector<cpp2::IndexQueryContext>        contexts_{};
     std::vector<std::string>                    yieldCols_{};
     IndexFilterItem                             filterItems_;
+    // Used to identify no fields in the index
     bool                                        noProp_{false};
 };
 }  // namespace storage

--- a/src/storage/index/LookupBaseProcessor.h
+++ b/src/storage/index/LookupBaseProcessor.h
@@ -75,6 +75,7 @@ protected:
     std::vector<cpp2::IndexQueryContext>        contexts_{};
     std::vector<std::string>                    yieldCols_{};
     IndexFilterItem                             filterItems_;
+    bool                                        noProp_{false};
 };
 }  // namespace storage
 }  // namespace nebula

--- a/src/storage/index/LookupBaseProcessor.inl
+++ b/src/storage/index/LookupBaseProcessor.inl
@@ -33,8 +33,32 @@ cpp2::ErrorCode LookupBaseProcessor<REQ, RESP>::requestCheck(const cpp2::LookupI
 
     // setup yield columns.
     if (req.__isset.return_columns) {
-        const auto& retcols = *req.get_return_columns();
-        yieldCols_ = retcols;
+        yieldCols_ = *req.get_return_columns();
+    }
+
+    for (const auto& ctx : contexts_) {
+        const auto& indexId = ctx.get_index_id();
+        auto needFilter = ctx.__isset.filter && !ctx.get_filter().empty();
+
+        auto index = planContext_->isEdge_
+            ? this->env_->indexMan_->getEdgeIndex(spaceId_, indexId)
+            : this->env_->indexMan_->getTagIndex(spaceId_, indexId);
+        if (!index.ok()) {
+            return cpp2::ErrorCode::E_INDEX_NOT_FOUND;
+        }
+
+        auto fields = index.value()->get_fields();
+
+        // If no filed in fields, only _vid can be returned for tag.
+        // For edge, only _src, _ranking, _dst can be returned
+        if (fields.size() == 0) {
+            //
+            if (contexts_.size() != 1 || yieldCols_.size() != 0 ||
+                needFilter || ctx.get_column_hints().size() != 0) {
+                return cpp2::ErrorCode::E_INVALID_OPERATION;
+            }
+            noProp_ = true;
+        }
     }
 
     // setup result set columns.
@@ -126,92 +150,108 @@ StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan() {
     StoragePlan<IndexID> plan;
     auto IndexAggr = std::make_unique<AggregateNode<IndexID>>(&resultDataSet_);
     int32_t filterId = 0;
-    for (const auto& ctx : contexts_) {
-        const auto& indexId = ctx.get_index_id();
-        auto needFilter = ctx.__isset.filter && !ctx.get_filter().empty();
+    std::unique_ptr<IndexOutputNode<IndexID>> out;
+    std::vector<std::pair<std::string, Value::Type>> indexCols;
 
-        // Check whether a data node is required.
-        // If a non-indexed column appears in the WHERE clause or YIELD clause,
-        // That means need to query the corresponding data.
-        bool needData = false;
-        auto index = planContext_->isEdge_
-            ? this->env_->indexMan_->getEdgeIndex(spaceId_, indexId)
-            : this->env_->indexMan_->getTagIndex(spaceId_, indexId);
-        if (!index.ok()) {
-            return Status::IndexNotFound();
-        }
-
-        // check nullable column
-        bool hasNullableCol = false;
-        int32_t vColNum = 0;
-        std::vector<std::pair<std::string, Value::Type>> indexCols;
-        for (const auto& col : index.value()->get_fields()) {
-            auto& colType = col.get_type();
-            indexCols.emplace_back(col.get_name(), IndexKeyUtils::toValueType(colType.get_type()));
-            if (IndexKeyUtils::toValueType(colType.get_type()) == Value::Type::STRING) {
-                vColNum++;
-            }
-            if (!hasNullableCol && col.get_nullable()) {
-                hasNullableCol = true;
-            }
-        }
-
-        for (const auto& yieldCol : yieldCols_) {
-            auto it = std::find_if(index.value()->get_fields().begin(),
-                                   index.value()->get_fields().end(),
-                                   [&yieldCol] (const auto& columnDef) {
-                                       return yieldCol == columnDef.get_name();
-                                   });
-            if (it == index.value()->get_fields().end()) {
-                needData = true;
-                break;
-            }
-        }
-        auto colHints = ctx.get_column_hints();
-
-        // Check WHERE clause contains columns that ware not indexed
-        if (ctx.__isset.filter && !ctx.get_filter().empty()) {
-            auto filter = Expression::decode(ctx.get_filter());
-            auto isFieldsOutsideIndex = isOutsideIndex(filter.get(), index.value().get());
-            if (isFieldsOutsideIndex) {
-                needData = needFilter = true;
-            }
-        }
-
-        std::unique_ptr<IndexOutputNode<IndexID>> out;
-        if (!needData && !needFilter) {
-            out = buildPlanBasic(ctx, plan, indexCols, vColNum, hasNullableCol);
-        } else if (needData && !needFilter) {
-            out = buildPlanWithData(ctx, plan);
-        } else if (!needData && needFilter) {
-            auto expr = Expression::decode(ctx.get_filter());
-            auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
-                                                                      planContext_->isIntId_,
-                                                                      vColNum,
-                                                                      hasNullableCol,
-                                                                      indexCols);
-            filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
-            out = buildPlanWithFilter(ctx,
-                                      plan,
-                                      filterItems_[filterId].first.get(),
-                                      filterItems_[filterId].second.get());
-            filterId++;
-        } else {
-            auto expr = Expression::decode(ctx.get_filter());
-            auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
-                                                                      planContext_->isIntId_);
-            filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
-            out = buildPlanWithDataAndFilter(ctx,
-                                             plan,
-                                             filterItems_[filterId].first.get(),
-                                             filterItems_[filterId].second.get());
-            filterId++;
-        }
-        if (out == nullptr) {
+    if (noProp_) {
+        out = buildPlanBasic(contexts_[0], plan, indexCols, indexCols.size(), false);
+         if (out == nullptr) {
             return Status::Error("Index scan plan error");
         }
         IndexAggr->addDependency(out.get());
         plan.addNode(std::move(out));
+    } else {
+        for (const auto& ctx : contexts_) {
+            indexCols.clear();
+            const auto& indexId = ctx.get_index_id();
+            auto needFilter = ctx.__isset.filter && !ctx.get_filter().empty();
+
+            // Check whether a data node is required.
+            // If a non-indexed column appears in the WHERE clause or YIELD clause,
+            // That means need to query the corresponding data.
+            bool needData = false;
+            auto index = planContext_->isEdge_
+                ? this->env_->indexMan_->getEdgeIndex(spaceId_, indexId)
+                : this->env_->indexMan_->getTagIndex(spaceId_, indexId);
+            if (!index.ok()) {
+                return Status::IndexNotFound();
+            }
+
+            // check nullable column
+            bool hasNullableCol = false;
+            int32_t vColNum = 0;
+
+            auto* indexItem = index.value().get();
+            auto fields = indexItem->get_fields();
+
+            for (const auto& col : fields) {
+                const auto& colType = col.get_type().get_type();
+                const auto& vType = IndexKeyUtils::toValueType(colType);
+                indexCols.emplace_back(col.get_name(), vType);
+                if (vType == Value::Type::STRING) {
+                    vColNum++;
+                }
+                if (!hasNullableCol && col.get_nullable()) {
+                    hasNullableCol = true;
+                }
+            }
+
+            for (const auto& yieldCol : yieldCols_) {
+                auto it = std::find_if(fields.begin(),
+                                       fields.end(),
+                                       [&yieldCol] (const auto& columnDef) {
+                                           return yieldCol == columnDef.get_name();
+                                       });
+                if (it == fields.end()) {
+                    needData = true;
+                    break;
+                }
+            }
+            auto colHints = ctx.get_column_hints();
+
+            // Check WHERE clause contains columns that ware not indexed
+            if (ctx.__isset.filter && !ctx.get_filter().empty()) {
+                auto filter = Expression::decode(ctx.get_filter());
+                auto isFieldsOutsideIndex = isOutsideIndex(filter.get(), indexItem);
+                if (isFieldsOutsideIndex) {
+                    needData = needFilter = true;
+                }
+            }
+
+            if (!needData && !needFilter) {
+                out = buildPlanBasic(ctx, plan, indexCols, vColNum, hasNullableCol);
+            } else if (needData && !needFilter) {
+                out = buildPlanWithData(ctx, plan);
+            } else if (!needData && needFilter) {
+                auto expr = Expression::decode(ctx.get_filter());
+                auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
+                                                                          planContext_->isIntId_,
+                                                                          vColNum,
+                                                                          hasNullableCol,
+                                                                          indexCols);
+                filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
+                out = buildPlanWithFilter(ctx,
+                                          plan,
+                                          filterItems_[filterId].first.get(),
+                                          filterItems_[filterId].second.get());
+                filterId++;
+            } else {
+                auto expr = Expression::decode(ctx.get_filter());
+                auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
+                                                                          planContext_->isIntId_);
+                filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
+                out = buildPlanWithDataAndFilter(ctx,
+                                                 plan,
+                                                 filterItems_[filterId].first.get(),
+                                                 filterItems_[filterId].second.get());
+                filterId++;
+            }
+            if (out == nullptr) {
+                return Status::Error("Index scan plan error");
+            }
+            IndexAggr->addDependency(out.get());
+            plan.addNode(std::move(out));
+        }
     }
     plan.addNode(std::move(IndexAggr));
     return plan;

--- a/src/storage/index/LookupBaseProcessor.inl
+++ b/src/storage/index/LookupBaseProcessor.inl
@@ -63,11 +63,11 @@ cpp2::ErrorCode LookupBaseProcessor<REQ, RESP>::requestCheck(const cpp2::LookupI
 
     // setup result set columns.
     if (planContext_->isEdge_) {
-        resultDataSet_.colNames.emplace_back("_src");
+        resultDataSet_.colNames.emplace_back(kSrc);
         resultDataSet_.colNames.emplace_back("_ranking");
-        resultDataSet_.colNames.emplace_back("_dst");
+        resultDataSet_.colNames.emplace_back(kDst);
     } else {
-        resultDataSet_.colNames.emplace_back("_vid");
+        resultDataSet_.colNames.emplace_back(kVid);
     }
 
     for (const auto& col : yieldCols_) {
@@ -117,11 +117,11 @@ bool LookupBaseProcessor<REQ, RESP>::isOutsideIndex(Expression* filter,
         case Expression::Kind::kTagProperty:
         case Expression::Kind::kEdgeProperty: {
             auto* sExpr = static_cast<PropertyExpression*>(filter);
-            const auto* prop = sExpr->prop();
-            auto it = std::find_if(fields.begin(), fields.end(), [&prop] (const auto& f) {
-                return f.get_name() == prop;
+            auto propName = *(sExpr->prop());
+            auto it = std::find_if(fields.begin(), fields.end(), [&propName] (const auto& f) {
+                return f.get_name() == propName;
             });
-            return it != fields.end();
+            return it == fields.end();
         }
         default: {
             return false;

--- a/src/storage/test/LookupIndexTest.cpp
+++ b/src/storage/test/LookupIndexTest.cpp
@@ -522,7 +522,7 @@ TEST(LookupIndexTest, TagIndexFilterTest) {
     ASSERT_TRUE(QueryTestUtils::mockVertexData(env, totalParts, true));
 
     /**
-     * one IndexQueryContext, where player.name == "Rudy Gay" AND player.name == 34
+     * one IndexQueryContext, where player.name == "Rudy Gay" AND player.age == 34
      * lookup plan should be :
      *              +--------+---------+
      *              |       Plan       |

--- a/src/storage/test/LookupIndexTest.cpp
+++ b/src/storage/test/LookupIndexTest.cpp
@@ -998,8 +998,9 @@ TEST(LookupIndexTest, EdgeIndexWithDataTest) {
     }
 }
 
-TEST(LookupIndexTest, TagStatisVerticesIndexTest) {
-    fs::TempDir rootPath("/tmp/TagStatisVerticesIndexTest.XXXXXX");
+// Tag has prop, statistics vertices
+TEST(LookupIndexTest, TagWithPropStatisVerticesIndexTest) {
+    fs::TempDir rootPath("/tmp/TagWithPropStatisVerticesIndexTest.XXXXXX");
     mock::MockCluster cluster;
     cluster.initStorageKV(rootPath.path());
     auto* env = cluster.storageEnv_.get();
@@ -1065,8 +1066,78 @@ TEST(LookupIndexTest, TagStatisVerticesIndexTest) {
     }
 }
 
-TEST(LookupIndexTest, EdgeStatisVerticesIndexTest) {
-    fs::TempDir rootPath("/tmp/EdgeStatisVerticesIndexTest.XXXXXX");
+// Tag no prop, statistics vertices
+TEST(LookupIndexTest, TagWithoutPropStatisVerticesIndexTest) {
+    fs::TempDir rootPath("/tmp/TagWithoutPropStatisVerticesIndexTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path(), HostAddr("", 0), 1, false);
+    auto* env = cluster.storageEnv_.get();
+    GraphSpaceID spaceId = 1;
+    auto vIdLen = env->schemaMan_->getSpaceVidLen(spaceId);
+    ASSERT_TRUE(vIdLen.ok());
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_TRUE(QueryTestUtils::mockVertexData(env, totalParts, true, false, false));
+
+    /**
+     * one IndexQueryContext, only has index_id, filter and column_hints are empty
+     * lookup plan should be :
+     *              +--------+---------+
+     *              |       Plan       |
+     *              +--------+---------+
+     *                       |
+     *              +--------+---------+
+     *              |  AggregateNode   |
+     *              +--------+---------+
+     *                       |
+     *            +----------+-----------+
+     *            +   IndexOutputNode    +
+     *            +----------+-----------+
+     *                       |
+     *            +----------+-----------+
+     *            +    IndexScanNode     +
+     *            +----------+-----------+
+    **/
+    {
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        cpp2::LookupIndexRequest req;
+        decltype(req.indices) indices;
+        req.set_space_id(spaceId);
+        indices.set_tag_or_edge_id(1);
+        indices.set_is_edge(false);
+        decltype(req.parts) parts;
+        for (int32_t p = 1; p <= totalParts; p++) {
+            parts.emplace_back(p);
+        }
+        req.set_parts(std::move(parts));
+        cpp2::IndexQueryContext context1;
+        context1.set_filter("");
+        context1.set_index_id(4);
+        decltype(indices.contexts) contexts;
+        contexts.emplace_back(std::move(context1));
+        indices.set_contexts(std::move(contexts));
+        req.set_indices(std::move(indices));
+
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        std::vector<std::string> expectCols = {"_vid"};
+        decltype(resp.get_data()->rows) expectRows;
+
+        auto playerVerticeId = mock::MockData::mockPlayerVerticeIds();
+        for (auto& vId : playerVerticeId) {
+            Row row1;
+            row1.emplace_back(Value(vId));
+            expectRows.emplace_back(Row(row1));
+        }
+
+        QueryTestUtils::checkResponse(resp, expectCols, expectRows);
+    }
+}
+
+
+// Edge has prop, statistics edges
+TEST(LookupIndexTest, EdgeWithPropStatisVerticesIndexTest) {
+    fs::TempDir rootPath("/tmp/EdgeWithPropStatisVerticesIndexTest.XXXXXX");
     mock::MockCluster cluster;
     cluster.initStorageKV(rootPath.path());
     auto* env = cluster.storageEnv_.get();
@@ -1076,6 +1147,82 @@ TEST(LookupIndexTest, EdgeStatisVerticesIndexTest) {
     auto totalParts = cluster.getTotalParts();
     ASSERT_TRUE(QueryTestUtils::mockVertexData(env, totalParts));
     ASSERT_TRUE(QueryTestUtils::mockEdgeData(env, totalParts, 1, true, false));
+
+    /**
+     * one IndexQueryContext, only has index_id, filter and column_hints are empty
+     * lookup plan should be :
+     *              +--------+---------+
+     *              |       Plan       |
+     *              +--------+---------+
+     *                       |
+     *              +--------+---------+
+     *              |  AggregateNode   |
+     *              +--------+---------+
+     *                       |
+     *            +----------+-----------+
+     *            +   IndexOutputNode    +
+     *            +----------+-----------+
+     *                       |
+     *            +----------+-----------+
+     *            +    IndexScanNode     +
+     *            +----------+-----------+
+    **/
+    {
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        cpp2::LookupIndexRequest req;
+        decltype(req.indices) indices;
+        req.set_space_id(spaceId);
+        indices.set_tag_or_edge_id(102);
+        indices.set_is_edge(true);
+        decltype(req.parts) parts;
+        for (int32_t p = 1; p <= totalParts; p++) {
+            parts.emplace_back(p);
+        }
+        req.set_parts(std::move(parts));
+        cpp2::IndexQueryContext context1;
+        context1.set_filter("");
+        context1.set_index_id(103);
+        decltype(indices.contexts) contexts;
+        contexts.emplace_back(std::move(context1));
+        indices.set_contexts(std::move(contexts));
+        req.set_indices(std::move(indices));
+
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        std::vector<std::string> expectCols = {"_src", "_ranking", "_dst"};
+        decltype(resp.get_data()->rows) expectRows;
+
+        auto serveEdgeKey = mock::MockData::mockEdgeKeys();
+
+        // Only positive edgeTypes are counted
+        for (auto & edgekey : serveEdgeKey) {
+            if (edgekey.type_ < 0) {
+                continue;
+            }
+            Row row1;
+            row1.emplace_back(Value(edgekey.srcId_));
+            row1.emplace_back(Value(edgekey.rank_));
+            row1.emplace_back(Value(edgekey.dstId_));
+            expectRows.emplace_back(Row(row1));
+        }
+
+        QueryTestUtils::checkResponse(resp, expectCols, expectRows);
+    }
+}
+
+// Edge no prop, statistics edges
+TEST(LookupIndexTest, EdgeWithoutPropStatisVerticesIndexTest) {
+    fs::TempDir rootPath("/tmp/EdgeWithoutPropStatisVerticesIndexTest.XXXXXX");
+    mock::MockCluster cluster;
+    cluster.initStorageKV(rootPath.path(), HostAddr("", 0), 1, false);
+    auto* env = cluster.storageEnv_.get();
+    GraphSpaceID spaceId = 1;
+    auto vIdLen = env->schemaMan_->getSpaceVidLen(spaceId);
+    ASSERT_TRUE(vIdLen.ok());
+    auto totalParts = cluster.getTotalParts();
+    ASSERT_TRUE(QueryTestUtils::mockVertexData(env, totalParts, false, false, false));
+    ASSERT_TRUE(QueryTestUtils::mockEdgeData(env, totalParts, 1, true, false, false));
 
     /**
      * one IndexQueryContext, only has index_id, filter and column_hints are empty

--- a/src/storage/test/QueryTestUtils.h
+++ b/src/storage/test/QueryTestUtils.h
@@ -27,7 +27,8 @@ class QueryTestUtils {
 public:
     static bool mockVertexData(storage::StorageEnv* env,
                                int32_t totalParts,
-                               bool enableIndex = false) {
+                               bool enableIndex = false,
+                               bool indexWithProp = true) {
         GraphSpaceID spaceId = 1;
         auto status = env->schemaMan_->getSpaceVidLen(spaceId);
         if (!status.ok()) {
@@ -54,13 +55,26 @@ public:
             if (enableIndex) {
                 if (tagId == 1 || tagId == 2) {
                     std::vector<Value::Type> colsType({});
+                    std::vector<Value> values;
+                    int32_t colNum = 0;
+                    IndexID indexID = 0;
+
+                    if (indexWithProp) {
+                        values = vertex.props_;
+                        colNum = tagId == 1 ? 3 : 1;
+                        indexID = tagId;
+                    } else {
+                        indexID = tagId == 1 ? 4 : 5;
+                    }
+
                     encodeTagIndex(spaceVidLen,
                                    partId,
                                    vertex.vId_,
-                                   tagId,
-                                   vertex.props_,
-                                   tagId == 1 ? 3 : 1,
-                                   colsType, data);
+                                   indexID,
+                                   values,
+                                   colNum,
+                                   colsType,
+                                   data);
                 }
             }
             env->kvstore_->asyncMultiPut(spaceId, partId, std::move(data),
@@ -83,7 +97,8 @@ public:
     static bool mockEdgeData(storage::StorageEnv* env,
                              int32_t totalParts,
                              EdgeVersion maxVersions = 1,
-                             bool enableIndex = false) {
+                             bool enableIndex = false,
+                             bool indexWithProp = true) {
         GraphSpaceID spaceId = 1;
         auto status = env->schemaMan_->getSpaceVidLen(spaceId);
         if (!status.ok()) {
@@ -110,14 +125,26 @@ public:
                 if (enableIndex) {
                     if (edge.type_ == 102 || edge.type_ == 101) {
                         std::vector<Value::Type> colsType({});
+                        std::vector<Value> values;
+                        int32_t colNum = 0;
+                        IndexID indexID = 0;
+
+                        if (indexWithProp) {
+                            values = edge.props_;
+                            colNum = 3;
+                            indexID = edge.type_;
+                        } else {
+                            indexID = edge.type_ == 101 ? 103 : 104;
+                        }
+                        
                         encodeEdgeIndex(spaceVidLen,
                                         partId,
                                         edge.srcId_,
                                         edge.dstId_,
                                         edge.rank_,
-                                        edge.type_,
-                                        edge.props_,
-                                        3,
+                                        indexID,
+                                        values,
+                                        colNum,
                                         colsType,
                                         data);
                     }

--- a/src/storage/test/RebuildIndexTest.cpp
+++ b/src/storage/test/RebuildIndexTest.cpp
@@ -126,8 +126,8 @@ TEST_F(RebuildIndexTest, RebuildTagIndexCheckALLData) {
             iter->next();
         }
     }
-    // The number of vertices index is 81, the count of players_ and teams_
-    EXPECT_EQ(81, indexDataNum);
+    // The number of vertices index is 162, the count of players_ and teams_
+    EXPECT_EQ(162, indexDataNum);
 
     RebuildIndexTest::env_->rebuildIndexGuard_->clear();
     sleep(1);
@@ -213,8 +213,8 @@ TEST_F(RebuildIndexTest, RebuildEdgeIndexCheckALLData) {
             iter->next();
         }
     }
-    // The number of edges index is 167, only positive side count of serves_
-    EXPECT_EQ(167, indexDataNum);
+    // The number of edges index is 334, only positive side count of serves_
+    EXPECT_EQ(334, indexDataNum);
 
     RebuildIndexTest::env_->rebuildIndexGuard_->clear();
     sleep(1);


### PR DESCRIPTION
Support get all vertices on tag, get all edges on edgetype through the following statement：
```
lookup on all tags where tag == xxx
lookup on all edges where edge == xxx
```

note：
also support indexes without fields， for example:
```
create tag  player();
insert vertex player() value 11:();  
create tag index player_index on player();

create edge e1();
insert edge e1() value 11->13:(); 
create edge index e1_index on e1();
```

