### PR TITLE
Listener interface

### DIFF
--- a/conf/nebula-storaged.conf.default
+++ b/conf/nebula-storaged.conf.default
@@ -40,6 +40,9 @@
 # Root data path. Split by comma. e.g. --data_path=/disk1/path1/,/disk2/path2/
 # One path per Rocksdb instance.
 --data_path=data/storage
+# Wal path for listener. Conflicts with data_path, if listener_path is specified, the storaged will
+# start as listener (only wal is saved, no storage engine).
+# --listener_path=data/listener
 
 # The default reserved bytes for one batch operation
 --rocksdb_batch_size=4096

--- a/conf/nebula-storaged.conf.production
+++ b/conf/nebula-storaged.conf.production
@@ -42,6 +42,9 @@
 # Root data path. split by comma. e.g. --data_path=/disk1/path1/,/disk2/path2/
 # One path per Rocksdb instance.
 --data_path=data/storage
+# Wal path for listener. Conflicts with data_path, if listener_path is specified, the storaged will
+# start as listener (only wal is saved, no storage engine).
+# --listener_path=data/listener
 
 # The default reserved bytes for one batch operation
 --rocksdb_batch_size=4096
@@ -98,7 +101,3 @@
 ############### misc ####################
 --max_handlers_per_req=1
 --heartbeat_interval_secs=10
-
-############# edge samplings ##############
-# --enable_reservoir_sampling=false
-# --max_edge_returned_per_vertex=2147483647

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -16,6 +16,8 @@
 DEFINE_string(local_ip, "", "IP address which is used to identify this server");
 DEFINE_string(data_path, "", "Root data path, multi paths should be split by comma."
                              "For rocksdb engine, one path one instance.");
+DEFINE_string(listener_path, "", "Path for listener, only wal will be saved."
+                                 "if it is not empty, data_path will not take effect.");
 DEFINE_bool(daemonize, true, "Whether to run the process as a daemon");
 DEFINE_string(pid_file, "pids/nebula-storaged.pid", "File to hold the process id");
 DEFINE_string(meta_server_addrs, "", "list of meta server addresses,"
@@ -111,7 +113,8 @@ int main(int argc, char *argv[]) {
 
     gStorageServer = std::make_unique<nebula::storage::StorageServer>(host,
                                                                       metaAddrsRet.value(),
-                                                                      paths);
+                                                                      paths,
+                                                                      FLAGS_listener_path);
     if (!gStorageServer->start()) {
         LOG(ERROR) << "Storage server start failed";
         gStorageServer->stop();

--- a/src/kvstore/CMakeLists.txt
+++ b/src/kvstore/CMakeLists.txt
@@ -1,6 +1,7 @@
 nebula_add_library(
     kvstore_obj OBJECT
     Part.cpp
+    Listener.cpp
     RocksEngine.cpp
     PartManager.cpp
     NebulaStore.cpp

--- a/src/kvstore/EventListner.h
+++ b/src/kvstore/EventListner.h
@@ -39,23 +39,23 @@ public:
     // A callback function to RocksDB which will be called
     // before a RocksDB starts to flush memtables.
     void OnFlushBegin(rocksdb::DB*, const rocksdb::FlushJobInfo& info) override {
-        LOG(INFO) << "Rocksdb start flush column family: " << info.cf_name
-                  << " because of " << flushReasonString(info.flush_reason)
-                  << " the newly created file: " << info.file_path
-                  << " the smallest sequence number is " << info.smallest_seqno
-                  << " the largest sequence number is " << info.largest_seqno
-                  << " the properties of the table: " << info.table_properties.ToString();
+        VLOG(1) << "Rocksdb start flush column family: " << info.cf_name
+                << " because of " << flushReasonString(info.flush_reason)
+                << ", the newly created file: " << info.file_path
+                << ", the smallest sequence number is " << info.smallest_seqno
+                << ", the largest sequence number is " << info.largest_seqno
+                << ", the properties of the table: " << info.table_properties.ToString();
     }
 
     // A callback function to RocksDB which will be called
     // whenever a registered RocksDB flushes a file.
     void OnFlushCompleted(rocksdb::DB*, const rocksdb::FlushJobInfo& info) override {
-        LOG(INFO) << "Rocksdb flush completed column family: " << info.cf_name
-                  << " because of " << flushReasonString(info.flush_reason)
-                  << " the newly created file: " << info.file_path
-                  << " the smallest sequence number is " << info.smallest_seqno
-                  << " the largest sequence number is " << info.largest_seqno
-                  << " the properties of the table: " << info.table_properties.ToString();
+        VLOG(1) << "Rocksdb flush completed column family: " << info.cf_name
+                << " because of " << flushReasonString(info.flush_reason)
+                << " the newly created file: " << info.file_path
+                << " the smallest sequence number is " << info.smallest_seqno
+                << " the largest sequence number is " << info.largest_seqno
+                << " the properties of the table: " << info.table_properties.ToString();
     }
 
     // A callback function for RocksDB which will be called whenever a SST file is created.
@@ -71,18 +71,18 @@ public:
 
     // A callback function for RocksDB which will be called before a SST file is being created.
     void OnTableFileCreationStarted(const rocksdb::TableFileCreationBriefInfo& info) override {
-        LOG(INFO) << " database's name is " << info.db_name
-                  << " column family's name is " << info.cf_name
-                  << " the created file is " << info.file_path
-                  << " because of " << tableFileCreationReasonString(info.reason);
+        VLOG(3) << " database's name is " << info.db_name
+                << ", column family's name is " << info.cf_name
+                << ", the created file is " << info.file_path
+                << ", because of " << tableFileCreationReasonString(info.reason);
     }
 
     // A callback function for RocksDB which will be called before
     // a memtable is made immutable.
     void OnMemTableSealed(const rocksdb::MemTableInfo& info) override {
         VLOG(3) << "MemTable Sealed column family: " << info.cf_name
-                << " the total number of entries: " << info.num_entries
-                << " the total number of deletes: " << info.num_deletes;
+                << ", the total number of entries: " << info.num_entries
+                << ", the total number of deletes: " << info.num_deletes;
     }
 
     // A callback function for RocksDB which will be called before
@@ -94,9 +94,9 @@ public:
     void OnExternalFileIngested(rocksdb::DB*,
                                 const rocksdb::ExternalFileIngestionInfo& info) override {
         LOG(INFO) << "Ingest external SST file: column family " << info.cf_name
-                  << " the external file path " << info. external_file_path
-                  << " the internal file path " << info.internal_file_path
-                  << " the properties of the table: " << info.table_properties.ToString();
+                  << ", the external file path " << info. external_file_path
+                  << ", the internal file path " << info.internal_file_path
+                  << ", the properties of the table: " << info.table_properties.ToString();
     }
 
     // A callback function for RocksDB which will be called before setting the
@@ -110,8 +110,8 @@ public:
     // of superversion triggers a change of the stall conditions.
     void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) override {
         LOG(INFO) << "Stall conditions changed column family: " << info.cf_name
-                  << " current condition: " << writeStallConditionString(info.condition.cur)
-                  << " previous condition: " << writeStallConditionString(info.condition.prev);
+                  << ", current condition: " << writeStallConditionString(info.condition.cur)
+                  << ", previous condition: " << writeStallConditionString(info.condition.prev);
     }
 
     // A callback function for RocksDB which will be called whenever a file read

--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -27,16 +27,17 @@ struct KVOptions {
     HostAddr hbaseServer_;
 
     // SchemaManager instance, help the hbasestore to encode/decode data.
-    std::unique_ptr<meta::SchemaManager> schemaMan_{nullptr};
+    meta::SchemaManager* schemaMan_{nullptr};
 
     // Paths for data. It would be used by rocksdb engine.
     // Be careful! We should ensure each "paths" has only one instance,
     // otherwise it would mix up the data on disk.
     std::vector<std::string> dataPaths_;
 
+    // Path for listener, only wal is stored, the structure would be spaceId/partId/wal
     std::string listenerPath_;
 
-    //  PartManager instance for kvstore.
+    // PartManager instance for kvstore.
     std::unique_ptr<PartManager> partMan_{nullptr};
 
     // Custom MergeOperator used in rocksdb.merge method.

--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -34,6 +34,8 @@ struct KVOptions {
     // otherwise it would mix up the data on disk.
     std::vector<std::string> dataPaths_;
 
+    std::string listenerPath_;
+
     //  PartManager instance for kvstore.
     std::unique_ptr<PartManager> partMan_{nullptr};
 

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -204,5 +204,21 @@ void Listener::doApply() {
     });
 }
 
+std::pair<int64_t, int64_t> Listener::commitSnapshot(const std::vector<std::string>& rows,
+                                                     LogID committedLogId,
+                                                     TermID committedLogTerm,
+                                                     bool finished) {
+    LOG(WARNING) << "Not implemented";
+    UNUSED(committedLogId); UNUSED(committedLogTerm); UNUSED(finished);
+    int64_t count = 0;
+    int64_t size = 0;
+    for (const auto& row : rows) {
+        count++;
+        size += row.size();
+        // todo(doodle): could decode and apply
+    }
+    return {count, size};
+}
+
 }  // namespace kvstore
 }  // namespace nebula

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -49,28 +49,26 @@ void Listener::start(std::vector<HostAddr>&& peers, bool) {
         wal_->reset();
     }
 
-    LOG(INFO) << idStr_ << "There are "
-                        << peers.size()
-                        << " peer hosts, and total "
-                        << peers.size() + 1
-                        << " copies. The quorum is " << quorum_ + 1
+    LOG(INFO) << idStr_ << "Listener start"
+                        << ", there are " << peers.size() << " peer hosts"
                         << ", lastLogId " << lastLogId_
                         << ", lastLogTerm " << lastLogTerm_
                         << ", committedLogId " << committedLogId_
                         << ", term " << term_;
 
-    // Start all peer hosts
-    // todo(doodle): as for listener, we don't need Host in most case. However, listener need to be
-    // aware of membership change. We just save peers for now.
-    peers_ = std::move(peers);
+    // As for listener, we don't need Host actually. However, listener need to be aware of
+    // membership change, it can be handled in preProcessLog.
+    for (auto& addr : peers) {
+        auto hostPtr = std::make_shared<raftex::Host>(addr, shared_from_this());
+        hosts_.emplace_back(hostPtr);
+    }
 
     status_ = Status::RUNNING;
     role_ = Role::LEARNER;
-    LOG(INFO) << "Start listener [" << spaceId_ << ", " << partId_;
 }
 
 void Listener::stop() {
-    LOG(INFO) << "Stop listener [" << spaceId_ << ", " << partId_;
+    LOG(INFO) << "Stop listener [" << spaceId_ << ", " << partId_ << "] on " << addr_;
     {
         std::unique_lock<std::mutex> lck(raftLock_);
         status_ = Status::STOPPED;

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "kvstore/Listener.h"
+#include "codec/RowReaderWrapper.h"
 
 namespace nebula {
 namespace kvstore {
@@ -17,9 +18,11 @@ Listener::Listener(GraphSpaceID spaceId,
                    std::shared_ptr<thread::GenericThreadPool> workers,
                    std::shared_ptr<folly::Executor> handlers,
                    std::shared_ptr<raftex::SnapshotManager> snapshotMan,
-                   std::shared_ptr<RaftClient> clientMan)
+                   std::shared_ptr<RaftClient> clientMan,
+                   meta::SchemaManager* schemaMan)
     : RaftPart(FLAGS_cluster_id, spaceId, partId, localAddr, walPath,
-               ioPool, workers, handlers, snapshotMan, clientMan) {
+               ioPool, workers, handlers, snapshotMan, clientMan)
+    , schemaMan_(schemaMan) {
 }
 
 void Listener::setCallback(std::function<bool(LogID, folly::StringPiece)> commitLogFunc,

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -1,0 +1,144 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "kvstore/Listener.h"
+
+
+namespace nebula {
+namespace kvstore {
+
+Listener::Listener(GraphSpaceID spaceId,
+                   PartitionID partId,
+                   HostAddr localAddr,
+                   const std::string& walPath,
+                   std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+                   std::shared_ptr<thread::GenericThreadPool> workers,
+                   std::shared_ptr<folly::Executor> handlers,
+                   std::shared_ptr<raftex::SnapshotManager> snapshotMan,
+                   std::shared_ptr<RaftClient> clientMan)
+    : RaftPart(FLAGS_cluster_id,
+               spaceId,
+               partId,
+               localAddr,
+               walPath,
+               ioPool,
+               workers,
+               handlers,
+               snapshotMan,
+               clientMan) {
+}
+
+void Listener::setCallback(std::function<bool(LogID, folly::StringPiece)> commitLogFunc,
+                           std::function<bool(LogID, TermID)> updateCommitFunc) {
+    commitLog_ = std::move(commitLogFunc);
+    updateCommit_ = std::move(updateCommitFunc);
+}
+
+void Listener::start(std::vector<HostAddr>&& peers, bool) {
+    std::lock_guard<std::mutex> g(raftLock_);
+
+    lastLogId_ = wal_->lastLogId();
+    lastLogTerm_ = wal_->lastLogTerm();
+    term_ = proposedTerm_ = lastLogTerm_;
+
+    // Set the quorum number
+    quorum_ = (peers.size() + 1) / 2;
+
+    auto logIdAndTerm = lastCommittedLogId();
+    committedLogId_ = logIdAndTerm.first;
+
+    if (lastLogId_ < committedLogId_) {
+        LOG(INFO) << idStr_ << "Reset lastLogId " << lastLogId_
+                << " to be the committedLogId " << committedLogId_;
+        lastLogId_ = committedLogId_;
+        lastLogTerm_ = term_;
+        wal_->reset();
+    }
+
+    LOG(INFO) << idStr_ << "There are "
+                        << peers.size()
+                        << " peer hosts, and total "
+                        << peers.size() + 1
+                        << " copies. The quorum is " << quorum_ + 1
+                        << ", lastLogId " << lastLogId_
+                        << ", lastLogTerm " << lastLogTerm_
+                        << ", committedLogId " << committedLogId_
+                        << ", term " << term_;
+
+    // Start all peer hosts
+    for (auto& addr : peers) {
+        LOG(INFO) << idStr_ << "Add peer " << addr;
+        auto hostPtr = std::make_shared<raftex::Host>(addr, shared_from_this());
+        hosts_.emplace_back(hostPtr);
+    }
+
+    status_ = Status::RUNNING;
+    role_ = Role::LEARNER;
+    LOG(INFO) << "Start listener [" << spaceId_ << ", " << partId_;
+}
+
+void Listener::stop() {
+    LOG(INFO) << "Stop listener [" << spaceId_ << ", " << partId_;
+
+    decltype(hosts_) hosts;
+    {
+        std::unique_lock<std::mutex> lck(raftLock_);
+        status_ = Status::STOPPED;
+        leader_ = {"", 0};
+        hosts = std::move(hosts_);
+    }
+
+    for (auto& h : hosts) {
+        h->stop();
+        h->waitForStop();
+    }
+    hosts.clear();
+}
+
+void Listener::cleanup() {
+    LOG(INFO) << idStr_ << "Clean up all wals, "
+                << "the commit id and term need to be cleaned up by manual";
+    wal()->reset();
+}
+
+bool Listener::commitLogs(std::unique_ptr<LogIterator> iter) {
+    LogID lastId = -1, prevId = -1;
+    TermID lastTerm = -1, prevTerm = -1;
+    while (iter->valid()) {
+        if (lastId != -1) {
+            prevId = lastId;
+            prevTerm = lastTerm;
+        }
+        lastId = iter->logId();
+        lastTerm = iter->logTerm();
+
+        auto log = iter->logMsg();
+        if (log.empty()) {
+            // skip the heartbeat
+            ++(*iter);
+            continue;
+        }
+
+        // try to decode the log and replicate to external source
+        if (!commitLog_(iter->logId(), iter->logMsg())) {
+            // If commit failed, will try it to commit later, update the commited
+            // log id and term to (prevId, prevTerm)
+            if (prevId != -1) {
+                updateCommit_(prevId, prevTerm);
+            }
+            return true;
+        }
+        ++(*iter);
+    }
+
+    if (lastId >= 0) {
+        updateCommit_(lastId, lastTerm);
+    }
+    return true;
+}
+
+}  // namespace kvstore
+}  // namespace nebula

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -8,6 +8,7 @@
 #define KVSTORE_LISTENER_H_
 
 #include "common/base/Base.h"
+#include "common/meta/SchemaManager.h"
 #include "kvstore/raftex/RaftPart.h"
 #include "kvstore/raftex/Host.h"
 #include "kvstore/wal/FileBasedWal.h"
@@ -29,7 +30,8 @@ public:
              std::shared_ptr<thread::GenericThreadPool> workers,
              std::shared_ptr<folly::Executor> handlers,
              std::shared_ptr<raftex::SnapshotManager> snapshotMan,
-             std::shared_ptr<RaftClient> clientMan);
+             std::shared_ptr<RaftClient> clientMan,
+             meta::SchemaManager* schemaMan);
 
     void setCallback(std::function<bool(LogID, folly::StringPiece)> commitLogFunc,
                      std::function<bool(LogID, TermID)> updateCommitFunc);
@@ -82,9 +84,10 @@ protected:
                                                        TermID committedLogTerm,
                                                        bool finished) override = 0;
 
-private:
+protected:
     std::function<bool(LogID, folly::StringPiece)> commitLog_;
     std::function<bool(LogID, TermID)> updateCommit_;
+    meta::SchemaManager* schemaMan_{nullptr};
 };
 
 }  // namespace kvstore

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -85,7 +85,6 @@ protected:
 private:
     std::function<bool(LogID, folly::StringPiece)> commitLog_;
     std::function<bool(LogID, TermID)> updateCommit_;
-    std::vector<HostAddr> peers_;
 };
 
 }  // namespace kvstore

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -40,15 +40,17 @@ public:
     // Stop listener
     void stop() override;
 
-    // Clean the wal and other data of listener
-    virtual void cleanup() override = 0;
-
     int64_t logGap() {
         return wal_->lastLogId() - lastApplyLogId_;
     }
 
     LogID getApplyId() {
         return lastApplyLogId_;
+    }
+
+    void reset() {
+        LOG(INFO) << idStr_ << "Clean up all wals";
+        wal_->reset();
     }
 
 protected:
@@ -93,7 +95,7 @@ protected:
     virtual std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>& data,
                                                        LogID committedLogId,
                                                        TermID committedLogTerm,
-                                                       bool finished) override = 0;
+                                                       bool finished) override;
 
     void doApply();
 

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -76,11 +76,8 @@ derived class.
     // apply the kv to state machine
     bool apply(const std::vector<KV>& data)
 
-    // persist last commit log id and term
-    bool persistCommitLogId(LogID, TermID)
-
-    // persist last apply id
-    bool persistApplyId(LogID)
+    // persist last commit log id/term and lastApplyId
+    bool persist(LogID, TermID, LogID)
 
     // extra cleanup work, will be invoked when listener is about to be removed
     virtual void cleanup() = 0
@@ -124,9 +121,7 @@ protected:
 
     virtual bool apply(const std::vector<KV>& data) = 0;
 
-    virtual bool persistCommitLogId(LogID, TermID) = 0;
-
-    virtual bool persistApplyId(LogID) = 0;
+    virtual bool persist(LogID, TermID, LogID) = 0;
 
     void onLostLeadership(TermID) override {
         LOG(FATAL) << "Should not reach here";
@@ -162,6 +157,9 @@ protected:
     void doApply();
 
 protected:
+    // lastId_ and lastTerm_ is same as committedLogId_ and term_ in usual case
+    LogID lastId_ = -1;
+    TermID lastTerm_ = -1;
     LogID lastApplyLogId_ = 0;
     meta::SchemaManager* schemaMan_{nullptr};
 };

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -47,11 +47,15 @@ public:
         return wal_->lastLogId() - lastApplyLogId_;
     }
 
+    LogID getApplyId() {
+        return lastApplyLogId_;
+    }
+
 protected:
-    // Last commit id and term, need to be persisted
+    // Last commit id and term, need to be persisted, used in initialization
     virtual std::pair<LogID, TermID> lastCommittedLogId() override = 0;
 
-    // Last apply id, need to be persisted
+    // Last apply id, need to be persisted, used in initialization
     virtual LogID lastApplyLogId() = 0;
 
     virtual bool apply(const std::vector<KV>& data) = 0;

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -1,0 +1,94 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef KVSTORE_LISTENER_H_
+#define KVSTORE_LISTENER_H_
+
+#include "common/base/Base.h"
+#include "kvstore/raftex/RaftPart.h"
+#include "kvstore/raftex/Host.h"
+#include "kvstore/wal/FileBasedWal.h"
+
+DECLARE_int32(cluster_id);
+
+namespace nebula {
+namespace kvstore {
+
+using RaftClient = thrift::ThriftClientManager<raftex::cpp2::RaftexServiceAsyncClient>;
+
+class Listener : public raftex::RaftPart {
+public:
+    Listener(GraphSpaceID spaceId,
+             PartitionID partId,
+             HostAddr localAddr,
+             const std::string& walPath,
+             std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+             std::shared_ptr<thread::GenericThreadPool> workers,
+             std::shared_ptr<folly::Executor> handlers,
+             std::shared_ptr<raftex::SnapshotManager> snapshotMan,
+             std::shared_ptr<RaftClient> clientMan);
+
+    void setCallback(std::function<bool(LogID, folly::StringPiece)> commitLogFunc,
+                     std::function<bool(LogID, TermID)> updateCommitFunc);
+
+    // Initialize listener, all Listener must call this method
+    void start(std::vector<HostAddr>&& peers, bool) override;
+
+    // Stop listener
+    void stop() override;
+
+    // Clean the wal and other data of listener
+    void cleanup() override;
+
+    int64_t logGap() {
+        return wal_->lastLogId() - lastCommittedLogId().first;
+    }
+
+protected:
+    // Last commit id and term, need to be persisted
+    // virtual std::pair<LogID, TermID> lastCommittedLogId() override = 0;
+
+    void onLostLeadership(TermID) override {
+        LOG(FATAL) << "Should not reach here";
+    }
+
+    void onElected(TermID) override {
+        LOG(FATAL) << "Should not reach here";
+    }
+
+    void onDiscoverNewLeader(HostAddr nLeader) override {
+        LOG(INFO) << idStr_ << "Find the new leader " << nLeader;
+    }
+
+    // Commit the logs which are accepted by quorum, for example, sync to remote cluster
+    // The empty log in iterator could be skipped, which is the raft heartbeat.
+    // TODO(doodle): need to handle the case when updateCommit_
+    bool commitLogs(std::unique_ptr<LogIterator> iter) override;
+
+    // If some wal need to be pre-process, could do it here. For most of the listeners,
+    // just return true is enough.
+    bool preProcessLog(LogID, TermID, ClusterID, const std::string&) override {
+        return true;
+    }
+
+    // If the listener falls behind way to much than leader, the leader will send all its data
+    // in snapshot by batch, listener need to implement it if it need handle this case. The return
+    // value is a pair of <logs count, logs size> of this batch.
+    /*
+    virtual std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>& data,
+                                                       LogID committedLogId,
+                                                       TermID committedLogTerm,
+                                                       bool finished) override = 0;
+    */
+
+private:
+    std::function<bool(LogID, folly::StringPiece)> commitLog_;
+    std::function<bool(LogID, TermID)> updateCommit_;
+};
+
+}  // namespace kvstore
+}  // namespace nebula
+#endif  // KVSTORE_LISTENER_H_

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -67,6 +67,9 @@ derived class.
                                                bool finished) override;
 
 * Must implement in derived class
+    // extra initialize work could do here
+    void init()
+
     // read last commit log id and term from external storage, used in initialization
     std::pair<LogID, TermID> lastCommittedLogId()
 
@@ -102,8 +105,8 @@ public:
     // Stop listener
     void stop() override;
 
-    int64_t logGap() {
-        return wal_->lastLogId() - lastApplyLogId_;
+    int64_t logGapInMs() {
+        return lastCommitTime_ - lastApplyTime_;
     }
 
     LogID getApplyId() {
@@ -116,6 +119,8 @@ public:
     }
 
 protected:
+    virtual void init() = 0;
+
     // Last apply id, need to be persisted, used in initialization
     virtual LogID lastApplyLogId() = 0;
 
@@ -157,10 +162,12 @@ protected:
     void doApply();
 
 protected:
-    // lastId_ and lastTerm_ is same as committedLogId_ and term_ in usual case
+    // lastId_ and lastTerm_ is same as committedLogId_ and term_
     LogID lastId_ = -1;
     TermID lastTerm_ = -1;
     LogID lastApplyLogId_ = 0;
+    int64_t lastCommitTime_ = 0;
+    int64_t lastApplyTime_ = 0;
     meta::SchemaManager* schemaMan_{nullptr};
 };
 

--- a/src/kvstore/ListenerFactory.h
+++ b/src/kvstore/ListenerFactory.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef KVSTORE_LISTENER_FACTORY_H_
+#define KVSTORE_LISTENER_FACTORY_H_
+
+#include "kvstore/Listener.h"
+#include "kvstore/plugins/elasticsearch/ESListener.h"
+
+namespace nebula {
+namespace kvstore {
+
+class ListenerFactory {
+public:
+    template <typename... Args>
+    static std::shared_ptr<Listener> createListener(int, Args&&... args) {
+        return std::make_shared<ESListner>(std::forward<Args>(args)...);
+    }
+};
+
+}  // namespace kvstore
+}  // namespace nebula
+#endif  // KVSTORE_LISTENER_FACTORY_H_

--- a/src/kvstore/ListenerFactory.h
+++ b/src/kvstore/ListenerFactory.h
@@ -16,8 +16,11 @@ namespace kvstore {
 class ListenerFactory {
 public:
     template <typename... Args>
-    static std::shared_ptr<Listener> createListener(int, Args&&... args) {
-        return std::make_shared<ESListner>(std::forward<Args>(args)...);
+    static std::shared_ptr<Listener> createListener(meta::cpp2::ListenerType type, Args&&... args) {
+        if (type == meta::cpp2::ListenerType::ELASTICSEARCH) {
+            return std::make_shared<ESListner>(std::forward<Args>(args)...);
+        }
+        LOG(FATAL) << "Should not reach here";
     }
 };
 

--- a/src/kvstore/ListenerFactory.h
+++ b/src/kvstore/ListenerFactory.h
@@ -18,7 +18,7 @@ public:
     template <typename... Args>
     static std::shared_ptr<Listener> createListener(meta::cpp2::ListenerType type, Args&&... args) {
         if (type == meta::cpp2::ListenerType::ELASTICSEARCH) {
-            return std::make_shared<ESListner>(std::forward<Args>(args)...);
+            return std::make_shared<ESListener>(std::forward<Args>(args)...);
         }
         LOG(FATAL) << "Should not reach here";
     }

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -21,6 +21,7 @@ DEFINE_int32(custom_filter_interval_secs, 24 * 3600,
 DEFINE_int32(num_workers, 4, "Number of worker threads");
 DEFINE_bool(check_leader, true, "Check leader or not");
 DEFINE_int32(clean_wal_interval_secs, 600, "inerval to trigger clean expired wal");
+DEFINE_bool(auto_remove_invalid_space, false, "whether remove data of invalid space when restart");
 
 DECLARE_bool(rocksdb_disable_wal);
 DECLARE_int32(wal_ttl);
@@ -88,14 +89,16 @@ void NebulaStore::loadPartFromDataPath() {
                 }
 
                 if (!options_.partMan_->spaceExist(storeSvcAddr_, spaceId).ok()) {
-                    // TODO We might want to have a second thought here.
-                    // Removing the data directly feels a little strong
-                    LOG(INFO) << "Space " << spaceId
-                                << " does not exist any more, remove the data!";
-                    auto dataPath = folly::stringPrintf("%s/%s",
-                                                        rootPath.c_str(),
-                                                        dir.c_str());
-                    CHECK(fs::FileUtils::remove(dataPath.c_str(), true));
+                    if (FLAGS_auto_remove_invalid_space) {
+                        // TODO We might want to have a second thought here.
+                        // Removing the data directly feels a little strong
+                        LOG(INFO) << "Space " << spaceId
+                                    << " does not exist any more, remove the data!";
+                        auto dataPath = folly::stringPrintf("%s/%s",
+                                                            rootPath.c_str(),
+                                                            dir.c_str());
+                        CHECK(fs::FileUtils::remove(dataPath.c_str(), true));
+                    }
                     continue;
                 }
 

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -54,10 +54,14 @@ bool NebulaStore::init() {
         LOG(ERROR) << "Start the raft service failed";
         return false;
     }
-    loadPartFromDataPath();
-    loadPartFromPartManager();
-    loadLocalListenerFromPartManager();
-    loadRemoteListenerFromPartManager();
+    // todo(doodle): we could support listener and normal storage start at same instance
+    if (!isListener()) {
+        loadPartFromDataPath();
+        loadPartFromPartManager();
+        loadRemoteListenerFromPartManager();
+    } else {
+        loadLocalListenerFromPartManager();
+    }
 
     bgWorkers_->addDelayTask(FLAGS_clean_wal_interval_secs * 1000, &NebulaStore::cleanWAL, this);
     LOG(INFO) << "Register handler...";

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -35,6 +35,7 @@ NebulaStore::~NebulaStore() {
     LOG(INFO) << "Waiting for the raft service stop...";
     raftService_->waitUntilStop();
     spaces_.clear();
+    spaceListeners_.clear();
     bgWorkers_->stop();
     bgWorkers_->wait();
     LOG(INFO) << "~NebulaStore()";
@@ -1008,6 +1009,7 @@ void NebulaStore::cleanWAL() {
             }
         }
     }
+    // todo(doodle): handle listener
 }
 
 }  // namespace kvstore

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -1036,7 +1036,7 @@ void NebulaStore::cleanWAL() {
             auto& part = partEntry.second;
             if (part->needToCleanWal()) {
                 // clean wal by expired time
-                part->wal()->cleanWAL(FLAGS_wal_ttl);
+                part->wal()->cleanWAL();
             }
         }
     }

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -23,6 +23,8 @@
 namespace nebula {
 namespace kvstore {
 
+using ListenerMap = std::unordered_map<meta::cpp2::ListenerType, std::shared_ptr<Listener>>;
+
 struct SpacePartInfo {
     ~SpacePartInfo() {
         parts_.clear();
@@ -33,7 +35,7 @@ struct SpacePartInfo {
     std::unordered_map<PartitionID, std::shared_ptr<Part>> parts_;
     std::vector<std::unique_ptr<KVEngine>> engines_;
 
-    std::unordered_map<PartitionID, std::shared_ptr<Listener>> listeners_;
+    std::unordered_map<PartitionID, ListenerMap> listeners_;
 };
 
 class NebulaStore : public KVStore, public Handler {
@@ -243,9 +245,9 @@ public:
     void addListener(GraphSpaceID spaceId,
                      PartitionID partId,
                      meta::cpp2::ListenerType type,
-                     std::vector<HostAddr> peers);
+                     const std::vector<HostAddr>& peers);
 
-    void removeListener(GraphSpaceID spaceId, PartitionID partId);
+    void removeListener(GraphSpaceID spaceId, PartitionID partId, meta::cpp2::ListenerType type);
 
     int32_t allLeader(std::unordered_map<GraphSpaceID,
                                          std::vector<PartitionID>>& leaderIds) override;
@@ -274,7 +276,7 @@ private:
     std::shared_ptr<Listener> newListener(GraphSpaceID spaceId,
                                           PartitionID partId,
                                           meta::cpp2::ListenerType type,
-                                          std::vector<HostAddr> peers);
+                                          const std::vector<HostAddr>& peers);
 
     ErrorOr<ResultCode, KVEngine*> engine(GraphSpaceID spaceId, PartitionID partId);
 

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -47,7 +47,7 @@ class NebulaStore : public KVStore, public Handler {
     FRIEND_TEST(NebulaStoreTest, TransLeaderTest);
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
-    FRIEND_TEST(ListenerBasicTest, SimpleTest);
+    friend class ListenerBasicTest;
 
 public:
     NebulaStore(KVOptions options,

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -34,7 +34,9 @@ struct SpacePartInfo {
 
     std::unordered_map<PartitionID, std::shared_ptr<Part>> parts_;
     std::vector<std::unique_ptr<KVEngine>> engines_;
+};
 
+struct SpaceListenerInfo {
     std::unordered_map<PartitionID, ListenerMap> listeners_;
 };
 
@@ -231,23 +233,25 @@ public:
     /**
      * Implement four interfaces in Handler.
      * */
-    void addSpace(GraphSpaceID spaceId) override;
+    void addSpace(GraphSpaceID spaceId, bool isListener = false) override;
 
     void addPart(GraphSpaceID spaceId,
                  PartitionID partId,
                  bool asLearner,
                  const std::vector<HostAddr>& peers = {}) override;
 
-    void removeSpace(GraphSpaceID spaceId) override;
+    void removeSpace(GraphSpaceID spaceId, bool isListener) override;
 
     void removePart(GraphSpaceID spaceId, PartitionID partId) override;
 
     void addListener(GraphSpaceID spaceId,
                      PartitionID partId,
                      meta::cpp2::ListenerType type,
-                     const std::vector<HostAddr>& peers);
+                     const std::vector<HostAddr>& peers) override;
 
-    void removeListener(GraphSpaceID spaceId, PartitionID partId, meta::cpp2::ListenerType type);
+    void removeListener(GraphSpaceID spaceId,
+                        PartitionID partId,
+                        meta::cpp2::ListenerType type) override;
 
     int32_t allLeader(std::unordered_map<GraphSpaceID,
                                          std::vector<PartitionID>>& leaderIds) override;
@@ -288,6 +292,7 @@ private:
     // The lock used to protect spaces_
     folly::RWSpinLock lock_;
     std::unordered_map<GraphSpaceID, std::shared_ptr<SpacePartInfo>> spaces_;
+    std::unordered_map<GraphSpaceID, std::shared_ptr<SpaceListenerInfo>> spaceListeners_;
 
     std::shared_ptr<folly::IOThreadPoolExecutor> ioPool_;
     std::shared_ptr<thread::GenericThreadPool> bgWorkers_;

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -244,6 +244,9 @@ public:
 
     void removePart(GraphSpaceID spaceId, PartitionID partId) override;
 
+    int32_t allLeader(std::unordered_map<GraphSpaceID,
+                                         std::vector<PartitionID>>& leaderIds) override;
+
     void addListener(GraphSpaceID spaceId,
                      PartitionID partId,
                      meta::cpp2::ListenerType type,
@@ -253,8 +256,9 @@ public:
                         PartitionID partId,
                         meta::cpp2::ListenerType type) override;
 
-    int32_t allLeader(std::unordered_map<GraphSpaceID,
-                                         std::vector<PartitionID>>& leaderIds) override;
+    void checkRemoteListeners(GraphSpaceID spaceId,
+                              PartitionID partId,
+                              const std::vector<HostAddr>& remoteListeners) override;
 
 private:
     void loadPartFromDataPath();

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -114,6 +114,10 @@ public:
         return options_.partMan_.get();
     }
 
+    bool isListener() const {
+        return !options_.listenerPath_.empty();
+    }
+
     ResultCode get(GraphSpaceID spaceId,
                    PartitionID  partId,
                    const std::string& key,

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -242,6 +242,7 @@ public:
 
     void addListener(GraphSpaceID spaceId,
                      PartitionID partId,
+                     meta::cpp2::ListenerType type,
                      std::vector<HostAddr> peers);
 
     void removeListener(GraphSpaceID spaceId, PartitionID partId);
@@ -254,7 +255,9 @@ private:
 
     void loadPartFromPartManager();
 
-    void loadListenerFromPartManager();
+    void loadLocalListenerFromPartManager();
+
+    void loadRemoteListenerFromPartManager();
 
     void updateSpaceOption(GraphSpaceID spaceId,
                            const std::unordered_map<std::string, std::string>& options,
@@ -270,6 +273,7 @@ private:
 
     std::shared_ptr<Listener> newListener(GraphSpaceID spaceId,
                                           PartitionID partId,
+                                          meta::cpp2::ListenerType type,
                                           std::vector<HostAddr> peers);
 
     ErrorOr<ResultCode, KVEngine*> engine(GraphSpaceID spaceId, PartitionID partId);

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -16,6 +16,7 @@
 #include "kvstore/PartManager.h"
 #include "kvstore/Part.h"
 #include "kvstore/Listener.h"
+#include "kvstore/ListenerFactory.h"
 #include "kvstore/KVEngine.h"
 #include "kvstore/raftex/SnapshotManager.h"
 
@@ -42,6 +43,7 @@ class NebulaStore : public KVStore, public Handler {
     FRIEND_TEST(NebulaStoreTest, TransLeaderTest);
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
+    FRIEND_TEST(NebulaStoreTest, SimpleTest);
 
 public:
     NebulaStore(KVOptions options,
@@ -240,7 +242,7 @@ public:
 
     void addListener(GraphSpaceID spaceId,
                      PartitionID partId,
-                     std::shared_ptr<Listener> listener);
+                     std::vector<HostAddr> peers);
 
     void removeListener(GraphSpaceID spaceId, PartitionID partId);
 
@@ -266,11 +268,9 @@ private:
                                   bool asLearner,
                                   const std::vector<HostAddr>& defaultPeers);
 
-    /*
     std::shared_ptr<Listener> newListener(GraphSpaceID spaceId,
                                           PartitionID partId,
-                                          const std::vector<HostAddr>& peers);
-    */
+                                          std::vector<HostAddr> peers);
 
     ErrorOr<ResultCode, KVEngine*> engine(GraphSpaceID spaceId, PartitionID partId);
 

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -43,7 +43,7 @@ class NebulaStore : public KVStore, public Handler {
     FRIEND_TEST(NebulaStoreTest, TransLeaderTest);
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
-    FRIEND_TEST(NebulaStoreTest, SimpleTest);
+    FRIEND_TEST(ListenerBasicTest, SimpleTest);
 
 public:
     NebulaStore(KVOptions options,

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -132,8 +132,10 @@ protected:
     GraphSpaceID spaceId_;
     PartitionID partId_;
     std::string walPath_;
-    KVEngine* engine_ = nullptr;
     NewLeaderCallback newLeaderCb_ = nullptr;
+
+private:
+    KVEngine* engine_ = nullptr;
 };
 
 }  // namespace kvstore

--- a/src/kvstore/PartManager.cpp
+++ b/src/kvstore/PartManager.cpp
@@ -233,5 +233,16 @@ void MetaServerBasedPartManager::onListenerRemoved(GraphSpaceID spaceId,
     }
 }
 
+void MetaServerBasedPartManager::onCheckRemoteListeners(
+        GraphSpaceID spaceId,
+        PartitionID partId,
+        const std::vector<HostAddr>& remoteListeners) {
+    if (handler_ != nullptr) {
+        handler_->checkRemoteListeners(spaceId, partId, remoteListeners);
+    } else {
+        VLOG(1) << "handler_ is nullptr!";
+    }
+}
+
 }  // namespace kvstore
 }  // namespace nebula

--- a/src/kvstore/PartManager.cpp
+++ b/src/kvstore/PartManager.cpp
@@ -16,7 +16,7 @@ meta::ListenersMap MemPartManager::listeners(const HostAddr&) {
     return listenersMap_;
 }
 
-StatusOr<std::vector<meta::RemoteListnerInfo>>
+StatusOr<std::vector<meta::RemoteListenerInfo>>
 MemPartManager::listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) {
     auto listeners = remoteListeners_[spaceId][partId];
     if (listeners.empty()) {
@@ -208,7 +208,7 @@ meta::ListenersMap MetaServerBasedPartManager::listeners(const HostAddr& host) {
     return meta::ListenersMap();
 }
 
-StatusOr<std::vector<meta::RemoteListnerInfo>>
+StatusOr<std::vector<meta::RemoteListenerInfo>>
 MetaServerBasedPartManager::listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) {
     return client_->getListenerHostTypeBySpacePartType(spaceId, partId);
 }

--- a/src/kvstore/PartManager.cpp
+++ b/src/kvstore/PartManager.cpp
@@ -8,9 +8,12 @@
 namespace nebula {
 namespace kvstore {
 
-meta::PartsMap MemPartManager::parts(const HostAddr& hostAddr) {
-    UNUSED(hostAddr);
+meta::PartsMap MemPartManager::parts(const HostAddr&) {
     return partsMap_;
+}
+
+meta::ListenersMap MemPartManager::listeners(const HostAddr&) {
+    return listenersMap_;
 }
 
 StatusOr<meta::PartHosts> MemPartManager::partMeta(GraphSpaceID spaceId, PartitionID partId) {

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -96,6 +96,7 @@ class MemPartManager final : public PartManager {
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
     FRIEND_TEST(NebulaStoreTest, AtomicOpBatchTest);
+    FRIEND_TEST(ListenerBasicTest, SimpleTest);
 
 public:
     MemPartManager() = default;

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -69,7 +69,7 @@ public:
     virtual Status spaceExist(const HostAddr& host, GraphSpaceID spaceId) = 0;
 
     // doodle
-    // virtual meta::ListenersMap listeners(const HostAddr& host) = 0;
+    virtual meta::ListenersMap listeners(const HostAddr& host) = 0;
 
     /**
      * Register Handler
@@ -101,6 +101,8 @@ public:
     ~MemPartManager() = default;
 
     meta::PartsMap parts(const HostAddr& host) override;
+
+    meta::ListenersMap listeners(const HostAddr& host) override;
 
     StatusOr<meta::PartHosts> partMeta(GraphSpaceID spaceId, PartitionID partId) override;
 
@@ -151,58 +153,64 @@ public:
 
 private:
     meta::PartsMap partsMap_;
+    meta::ListenersMap listenersMap_;
 };
 
 
 class MetaServerBasedPartManager : public PartManager, public meta::MetaChangedListener {
 public:
-     explicit MetaServerBasedPartManager(HostAddr host, meta::MetaClient *client = nullptr);
+    explicit MetaServerBasedPartManager(HostAddr host, meta::MetaClient *client = nullptr);
 
-     ~MetaServerBasedPartManager();
+    ~MetaServerBasedPartManager();
 
-     meta::PartsMap parts(const HostAddr& host) override;
+    meta::PartsMap parts(const HostAddr& host) override;
 
-     StatusOr<meta::PartHosts> partMeta(GraphSpaceID spaceId, PartitionID partId) override;
+    StatusOr<meta::PartHosts> partMeta(GraphSpaceID spaceId, PartitionID partId) override;
 
-     Status partExist(const HostAddr& host, GraphSpaceID spaceId, PartitionID partId) override;
+    Status partExist(const HostAddr& host, GraphSpaceID spaceId, PartitionID partId) override;
 
-     Status spaceExist(const HostAddr& host, GraphSpaceID spaceId) override;
+    Status spaceExist(const HostAddr& host, GraphSpaceID spaceId) override;
 
-     /**
-      * Implement the interfaces in MetaChangedListener
-      * */
-     void onSpaceAdded(GraphSpaceID spaceId) override;
+    /**
+     * Implement the interfaces in MetaChangedListener
+     * */
+    void onSpaceAdded(GraphSpaceID spaceId) override;
 
-     void onSpaceRemoved(GraphSpaceID spaceId) override;
+    void onSpaceRemoved(GraphSpaceID spaceId) override;
 
-     void onSpaceOptionUpdated(GraphSpaceID spaceId,
-                               const std::unordered_map<std::string, std::string>& options)
-                               override;
+    void onSpaceOptionUpdated(GraphSpaceID spaceId,
+                              const std::unordered_map<std::string, std::string>& options)
+                              override;
 
-     void onPartAdded(const meta::PartHosts& partMeta) override;
+    void onPartAdded(const meta::PartHosts& partMeta) override;
 
-     void onPartRemoved(GraphSpaceID spaceId, PartitionID partId) override;
+    void onPartRemoved(GraphSpaceID spaceId, PartitionID partId) override;
 
-     void onPartUpdated(const meta::PartHosts& partMeta) override;
+    void onPartUpdated(const meta::PartHosts& partMeta) override;
 
-     void fetchLeaderInfo(std::unordered_map<GraphSpaceID,
-                                             std::vector<PartitionID>>& leaderParts) override;
+    void fetchLeaderInfo(std::unordered_map<GraphSpaceID,
+                                            std::vector<PartitionID>>& leaderParts) override;
 
-     HostAddr getLocalHost() {
-        return localHost_;
-     }
+    // doodle
+    meta::ListenersMap listeners(const HostAddr&) override {
+        return meta::ListenersMap();
+    }
 
-     /**
-      * for UTs, because the port is chosen by system,
-      * we should update port after thrift setup
-      * */
-     void setLocalHost(HostAddr localHost) {
-        localHost_ = std::move(localHost);
-     }
+    HostAddr getLocalHost() {
+       return localHost_;
+    }
+
+    /**
+     * for UTs, because the port is chosen by system,
+     * we should update port after thrift setup
+     * */
+    void setLocalHost(HostAddr localHost) {
+       localHost_ = std::move(localHost);
+    }
 
 private:
-     meta::MetaClient *client_{nullptr};
-     HostAddr localHost_;
+    meta::MetaClient *client_{nullptr};
+    HostAddr localHost_;
 };
 
 }  // namespace kvstore

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -68,8 +68,10 @@ public:
      * */
     virtual Status spaceExist(const HostAddr& host, GraphSpaceID spaceId) = 0;
 
-    // doodle
     virtual meta::ListenersMap listeners(const HostAddr& host) = 0;
+
+    virtual StatusOr<std::vector<meta::RemoteListnerInfo>>
+    listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) = 0;
 
     /**
      * Register Handler
@@ -101,8 +103,6 @@ public:
     ~MemPartManager() = default;
 
     meta::PartsMap parts(const HostAddr& host) override;
-
-    meta::ListenersMap listeners(const HostAddr& host) override;
 
     StatusOr<meta::PartHosts> partMeta(GraphSpaceID spaceId, PartitionID partId) override;
 
@@ -151,9 +151,15 @@ public:
         return partsMap_;
     }
 
+    meta::ListenersMap listeners(const HostAddr& host) override;
+
+    StatusOr<std::vector<meta::RemoteListnerInfo>>
+    listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) override;
+
 private:
     meta::PartsMap partsMap_;
     meta::ListenersMap listenersMap_;
+    meta::RemoteListeners remoteListeners_;
 };
 
 
@@ -170,6 +176,11 @@ public:
     Status partExist(const HostAddr& host, GraphSpaceID spaceId, PartitionID partId) override;
 
     Status spaceExist(const HostAddr& host, GraphSpaceID spaceId) override;
+
+    meta::ListenersMap listeners(const HostAddr& host) override;
+
+    StatusOr<std::vector<meta::RemoteListnerInfo>>
+    listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) override;
 
     /**
      * Implement the interfaces in MetaChangedListener
@@ -190,11 +201,6 @@ public:
 
     void fetchLeaderInfo(std::unordered_map<GraphSpaceID,
                                             std::vector<PartitionID>>& leaderParts) override;
-
-    // doodle
-    meta::ListenersMap listeners(const HostAddr&) override {
-        return meta::ListenersMap();
-    }
 
     HostAddr getLocalHost() {
        return localHost_;

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -36,6 +36,15 @@ public:
 
     virtual int32_t allLeader(std::unordered_map<GraphSpaceID,
                                                  std::vector<PartitionID>>& leaderIds) = 0;
+
+    /*
+    virtual void addListener(GraphSpaceID spaceId,
+                             PartitionID partId,
+                             meta::cpp2::ListenerType type,
+                             const std::vector<HostAddr>& peers);
+
+    void removeListener(GraphSpaceID spaceId, PartitionID partId);
+    */
 };
 
 
@@ -70,7 +79,7 @@ public:
 
     virtual meta::ListenersMap listeners(const HostAddr& host) = 0;
 
-    virtual StatusOr<std::vector<meta::RemoteListnerInfo>>
+    virtual StatusOr<std::vector<meta::RemoteListenerInfo>>
     listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) = 0;
 
     /**
@@ -154,7 +163,7 @@ public:
 
     meta::ListenersMap listeners(const HostAddr& host) override;
 
-    StatusOr<std::vector<meta::RemoteListnerInfo>>
+    StatusOr<std::vector<meta::RemoteListenerInfo>>
     listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) override;
 
 private:
@@ -180,7 +189,7 @@ public:
 
     meta::ListenersMap listeners(const HostAddr& host) override;
 
-    StatusOr<std::vector<meta::RemoteListnerInfo>>
+    StatusOr<std::vector<meta::RemoteListenerInfo>>
     listenerPeerExist(GraphSpaceID spaceId, PartitionID partId) override;
 
     /**

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -68,6 +68,9 @@ public:
      * */
     virtual Status spaceExist(const HostAddr& host, GraphSpaceID spaceId) = 0;
 
+    // doodle
+    // virtual meta::ListenersMap listeners(const HostAddr& host) = 0;
+
     /**
      * Register Handler
      * */
@@ -116,7 +119,7 @@ public:
         if (noPart && handler_) {
             handler_->addPart(spaceId, partId, false, {});
         }
-     }
+    }
 
     void removePart(GraphSpaceID spaceId, PartitionID partId) {
         auto it = partsMap_.find(spaceId);

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -45,6 +45,10 @@ public:
     virtual void removeListener(GraphSpaceID spaceId,
                                 PartitionID partId,
                                 meta::cpp2::ListenerType type) = 0;
+
+    virtual void checkRemoteListeners(GraphSpaceID spaceId,
+                                      PartitionID partId,
+                                      const std::vector<HostAddr>& remoteListeners) = 0;
 };
 
 
@@ -212,9 +216,17 @@ public:
     void fetchLeaderInfo(std::unordered_map<GraphSpaceID,
                                             std::vector<PartitionID>>& leaderParts) override;
 
-    void onListenerAdded(GraphSpaceID, PartitionID, const meta::ListenerHosts&) override;
+    void onListenerAdded(GraphSpaceID spaceId,
+                         PartitionID partId,
+                         const meta::ListenerHosts& listenerHosts) override;
 
-    void onListenerRemoved(GraphSpaceID, PartitionID, meta::cpp2::ListenerType) override;
+    void onListenerRemoved(GraphSpaceID spaceId,
+                           PartitionID partId,
+                           meta::cpp2::ListenerType type) override;
+
+    void onCheckRemoteListeners(GraphSpaceID spaceId,
+                                PartitionID partId,
+                                const std::vector<HostAddr>& remoteListeners) override;
 
 private:
     meta::MetaClient *client_{nullptr};

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -19,7 +19,7 @@ class Handler {
 public:
     virtual ~Handler() = default;
 
-    virtual void addSpace(GraphSpaceID spaceId) = 0;
+    virtual void addSpace(GraphSpaceID spaceId, bool isListener = false) = 0;
 
     virtual void addPart(GraphSpaceID spaceId,
                          PartitionID partId,
@@ -30,21 +30,21 @@ public:
                                    const std::unordered_map<std::string, std::string>& options,
                                    bool isDbOption) = 0;
 
-    virtual void removeSpace(GraphSpaceID spaceId) = 0;
+    virtual void removeSpace(GraphSpaceID spaceId, bool isListener = false) = 0;
 
     virtual void removePart(GraphSpaceID spaceId, PartitionID partId) = 0;
 
     virtual int32_t allLeader(std::unordered_map<GraphSpaceID,
                                                  std::vector<PartitionID>>& leaderIds) = 0;
 
-    /*
     virtual void addListener(GraphSpaceID spaceId,
                              PartitionID partId,
                              meta::cpp2::ListenerType type,
-                             const std::vector<HostAddr>& peers);
+                             const std::vector<HostAddr>& peers) = 0;
 
-    void removeListener(GraphSpaceID spaceId, PartitionID partId);
-    */
+    virtual void removeListener(GraphSpaceID spaceId,
+                                PartitionID partId,
+                                meta::cpp2::ListenerType type) = 0;
 };
 
 
@@ -195,9 +195,9 @@ public:
     /**
      * Implement the interfaces in MetaChangedListener
      * */
-    void onSpaceAdded(GraphSpaceID spaceId) override;
+    void onSpaceAdded(GraphSpaceID spaceId, bool isListener) override;
 
-    void onSpaceRemoved(GraphSpaceID spaceId) override;
+    void onSpaceRemoved(GraphSpaceID spaceId, bool isListener) override;
 
     void onSpaceOptionUpdated(GraphSpaceID spaceId,
                               const std::unordered_map<std::string, std::string>& options)
@@ -212,21 +212,12 @@ public:
     void fetchLeaderInfo(std::unordered_map<GraphSpaceID,
                                             std::vector<PartitionID>>& leaderParts) override;
 
-    HostAddr getLocalHost() {
-       return localHost_;
-    }
+    void onListenerAdded(GraphSpaceID, PartitionID, const meta::ListenerHosts&) override;
 
-    /**
-     * for UTs, because the port is chosen by system,
-     * we should update port after thrift setup
-     * */
-    void setLocalHost(HostAddr localHost) {
-       localHost_ = std::move(localHost);
-    }
+    void onListenerRemoved(GraphSpaceID, PartitionID, meta::cpp2::ListenerType) override;
 
 private:
     meta::MetaClient *client_{nullptr};
-    HostAddr localHost_;
 };
 
 }  // namespace kvstore

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -105,7 +105,7 @@ class MemPartManager final : public PartManager {
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
     FRIEND_TEST(NebulaStoreTest, AtomicOpBatchTest);
-    FRIEND_TEST(ListenerBasicTest, SimpleTest);
+    friend class ListenerBasicTest;
 
 public:
     MemPartManager() = default;

--- a/src/kvstore/plugins/CMakeLists.txt
+++ b/src/kvstore/plugins/CMakeLists.txt
@@ -1,1 +1,2 @@
 nebula_add_subdirectory(hbase)
+nebula_add_subdirectory(elasticsearch)

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -33,7 +33,11 @@ protected:
         return true;
     }
 
-    bool persist(LogID, TermID, LogID) override {
+    bool persistCommitLogId(LogID, TermID) override {
+        return true;
+    }
+
+    bool persistApplyId(LogID) override {
         return true;
     }
 
@@ -43,22 +47,6 @@ protected:
 
     LogID lastApplyLogId() override {
         return 0;
-    }
-
-    std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>& rows,
-                                               LogID committedLogId,
-                                               TermID committedLogTerm,
-                                               bool finished) override {
-        LOG(WARNING) << "Not implemented";
-        UNUSED(committedLogId); UNUSED(committedLogTerm); UNUSED(finished);
-        int64_t count = 0;
-        int64_t size = 0;
-        for (const auto& row : rows) {
-            count++;
-            size += row.size();
-            // todo(doodle): could decode and apply
-        }
-        return {count, size};
     }
 
     void cleanup() override {

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -29,6 +29,9 @@ public:
     }
 
 protected:
+    void init() override {
+    }
+
     bool apply(const std::vector<KV>&) override {
         return true;
     }

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -1,0 +1,60 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef KVSTORE_PLUGINS_ES_LISTENER_H_
+#define KVSTORE_PLUGINS_ES_LISTENER_H_
+
+#include "kvstore/Listener.h"
+
+namespace nebula {
+namespace kvstore {
+
+class ESListner : public Listener {
+public:
+    ESListner(GraphSpaceID spaceId,
+              PartitionID partId,
+              HostAddr localAddr,
+              const std::string& walPath,
+              std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+              std::shared_ptr<thread::GenericThreadPool> workers,
+              std::shared_ptr<folly::Executor> handlers,
+              std::shared_ptr<raftex::SnapshotManager> snapshotMan,
+              std::shared_ptr<RaftClient> clientMan)
+        : Listener(spaceId, partId, std::move(localAddr), walPath,
+                   ioPool, workers, handlers, snapshotMan, clientMan) {
+        setCallback(std::bind(&ESListner::commitLog, this,
+                              std::placeholders::_1, std::placeholders::_2),
+                    std::bind(&ESListner::updateCommit, this,
+                              std::placeholders::_1, std::placeholders::_2));
+    }
+
+protected:
+    bool commitLog(LogID, folly::StringPiece) {
+        return true;
+    }
+
+    bool updateCommit(LogID, TermID) {
+        return true;
+    }
+
+    std::pair<LogID, TermID> lastCommittedLogId() override {
+        return {0, 0};
+    }
+
+    std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>&,
+                                               LogID,
+                                               TermID,
+                                               bool) override {
+        LOG(FATAL) << "Not implemented";
+    }
+
+    void cleanup() override {
+    }
+};
+
+}  // namespace kvstore
+}  // namespace nebula
+#endif  // KVSTORE_PLUGINS_ES_LISTENER_H_

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -45,11 +45,20 @@ protected:
         return 0;
     }
 
-    std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>&,
-                                               LogID,
-                                               TermID,
-                                               bool) override {
-        LOG(FATAL) << "Not implemented";
+    std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>& rows,
+                                               LogID committedLogId,
+                                               TermID committedLogTerm,
+                                               bool finished) override {
+        LOG(WARNING) << "Not implemented";
+        UNUSED(committedLogId); UNUSED(committedLogTerm); UNUSED(finished);
+        int64_t count = 0;
+        int64_t size = 0;
+        for (const auto& row : rows) {
+            count++;
+            size += row.size();
+            // todo(doodle): could decode and apply
+        }
+        return {count, size};
     }
 
     void cleanup() override {

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -26,23 +26,23 @@ public:
               meta::SchemaManager* schemaMan)
         : Listener(spaceId, partId, std::move(localAddr), walPath,
                    ioPool, workers, handlers, snapshotMan, clientMan, schemaMan) {
-        setCallback(std::bind(&ESListener::commitLog, this,
-                              std::placeholders::_1, std::placeholders::_2),
-                    std::bind(&ESListener::updateCommit, this,
-                              std::placeholders::_1, std::placeholders::_2));
     }
 
 protected:
-    bool commitLog(LogID, folly::StringPiece) {
+    bool apply(const std::vector<KV>&) override {
         return true;
     }
 
-    bool updateCommit(LogID, TermID) {
+    bool persist(LogID, TermID, LogID) override {
         return true;
     }
 
     std::pair<LogID, TermID> lastCommittedLogId() override {
         return {0, 0};
+    }
+
+    LogID lastApplyLogId() override {
+        return 0;
     }
 
     std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>&,

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -33,11 +33,7 @@ protected:
         return true;
     }
 
-    bool persistCommitLogId(LogID, TermID) override {
-        return true;
-    }
-
-    bool persistApplyId(LogID) override {
+    bool persist(LogID, TermID, LogID) override {
         return true;
     }
 

--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -12,9 +12,9 @@
 namespace nebula {
 namespace kvstore {
 
-class ESListner : public Listener {
+class ESListener : public Listener {
 public:
-    ESListner(GraphSpaceID spaceId,
+    ESListener(GraphSpaceID spaceId,
               PartitionID partId,
               HostAddr localAddr,
               const std::string& walPath,
@@ -22,12 +22,13 @@ public:
               std::shared_ptr<thread::GenericThreadPool> workers,
               std::shared_ptr<folly::Executor> handlers,
               std::shared_ptr<raftex::SnapshotManager> snapshotMan,
-              std::shared_ptr<RaftClient> clientMan)
+              std::shared_ptr<RaftClient> clientMan,
+              meta::SchemaManager* schemaMan)
         : Listener(spaceId, partId, std::move(localAddr), walPath,
-                   ioPool, workers, handlers, snapshotMan, clientMan) {
-        setCallback(std::bind(&ESListner::commitLog, this,
+                   ioPool, workers, handlers, snapshotMan, clientMan, schemaMan) {
+        setCallback(std::bind(&ESListener::commitLog, this,
                               std::placeholders::_1, std::placeholders::_2),
-                    std::bind(&ESListner::updateCommit, this,
+                    std::bind(&ESListener::updateCommit, this,
                               std::placeholders::_1, std::placeholders::_2));
     }
 

--- a/src/kvstore/plugins/hbase/test/HBaseStoreTest.cpp
+++ b/src/kvstore/plugins/hbase/test/HBaseStoreTest.cpp
@@ -25,7 +25,7 @@ TEST(HBaseStoreTest, SimpleTest) {
     auto sm = schemaMan.get();
     CHECK_NOTNULL(sm);
     options.hbaseServer_ = HostAddr(0, 9096);
-    options.schemaMan_ = schemaMan.get()j;
+    options.schemaMan_ = schemaMan.get();
     auto hbaseStore = std::make_unique<HBaseStore>(std::move(options));
     hbaseStore->init();
 

--- a/src/kvstore/plugins/hbase/test/HBaseStoreTest.cpp
+++ b/src/kvstore/plugins/hbase/test/HBaseStoreTest.cpp
@@ -25,7 +25,7 @@ TEST(HBaseStoreTest, SimpleTest) {
     auto sm = schemaMan.get();
     CHECK_NOTNULL(sm);
     options.hbaseServer_ = HostAddr(0, 9096);
-    options.schemaMan_ = std::move(schemaMan);
+    options.schemaMan_ = schemaMan.get()j;
     auto hbaseStore = std::make_unique<HBaseStore>(std::move(options));
     hbaseStore->init();
 

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1624,6 +1624,15 @@ void RaftPart::processAppendLogRequest(
         resp.set_error_code(cpp2::ErrorCode::E_LOG_GAP);
         return;
     } else if (req.get_last_log_id_sent() < lastLogId_) {
+        // TODO(doodle): This is a potential bug which would cause data not in consensus. In most
+        // case, we would hit this path when leader append logs to follower and timeout (leader
+        // would set lastLogIdSent_ = logIdToSend_ - 1 in Host). **But follower actually received
+        // it successfully**. Which will explain when leader retry to append these logs, the LOG
+        // belows is printed, and lastLogId_ == req.get_last_log_id_sent() + 1 in the LOG.
+        //
+        // In fact we should always rollback to req.get_last_log_id_sent(), and append the logs from
+        // leader (we can't make promise that the logs in range [req.get_last_log_id_sent() + 1,
+        // lastLogId_] is same with follower). However, this makes no difference in the above case.
         LOG(INFO) << idStr_ << "Stale log! Local lastLogId " << lastLogId_
                   << ", lastLogTerm " << lastLogTerm_
                   << ", lastLogIdSent " << req.get_last_log_id_sent()

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -388,7 +388,8 @@ private:
         LogID prevLogId,
         std::vector<std::shared_ptr<Host>> hosts);
 
-    std::vector<std::shared_ptr<Host>> followers() const;
+    // peers return other peers which could vote, in other words, learner is not counted in
+    std::vector<std::shared_ptr<Host>> peers() const;
 
     bool checkAppendLogResult(AppendLogResult res);
 

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -142,6 +142,10 @@ public:
 
     void commitRemovePeer(const HostAddr& peer);
 
+    void addListener(const HostAddr& peer);
+
+    void removeListener(const HostAddr& peer);
+
     // Change the partition status to RUNNING. This is called
     // by the inherited class, when it's ready to serve
     virtual void start(std::vector<HostAddr>&& peers, bool asLearner = false);
@@ -288,10 +292,6 @@ protected:
     void addPeer(const HostAddr& peer);
 
     void removePeer(const HostAddr& peer);
-
-    void addListener(const HostAddr& peer);
-
-    void removeListener(const HostAddr& peer);
 
 private:
     // A list of <idx, resp>

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -142,9 +142,9 @@ public:
 
     void commitRemovePeer(const HostAddr& peer);
 
-    void addListener(const HostAddr& peer);
+    void addListenerPeer(const HostAddr& peer);
 
-    void removeListener(const HostAddr& peer);
+    void removeListenerPeer(const HostAddr& peer);
 
     // Change the partition status to RUNNING. This is called
     // by the inherited class, when it's ready to serve
@@ -193,6 +193,11 @@ public:
      * Reset my peers if not equals the argument
      */
     void checkAndResetPeers(const std::vector<HostAddr>& peers);
+
+    /**
+     * Add listener into peers or remove from peers
+     */
+    void checkRemoteListeners(const std::vector<HostAddr>& listeners);
 
     /*****************************************************
      *

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -228,6 +228,21 @@ protected:
          std::shared_ptr<SnapshotManager> snapshotMan,
          std::shared_ptr<thrift::ThriftClientManager<cpp2::RaftexServiceAsyncClient>> clientMan);
 
+    enum class Status {
+        STARTING = 0,   // The part is starting, not ready for service
+        RUNNING,        // The part is running
+        STOPPED,        // The part has been stopped
+        WAITING_SNAPSHOT  // Waiting for the snapshot.
+    };
+
+    enum class Role {
+        LEADER = 1,     // the leader
+        FOLLOWER,       // following a leader
+        CANDIDATE,      // Has sent AskForVote request
+        LEARNER         // It is the same with FOLLOWER,
+                        // except it does not participate in leader election
+    };
+
     const char* idStr() const {
         return idStr_.c_str();
     }
@@ -274,22 +289,11 @@ protected:
 
     void removePeer(const HostAddr& peer);
 
+    void addListener(const HostAddr& peer);
+
+    void removeListener(const HostAddr& peer);
+
 private:
-    enum class Status {
-        STARTING = 0,   // The part is starting, not ready for service
-        RUNNING,        // The part is running
-        STOPPED,        // The part has been stopped
-        WAITING_SNAPSHOT  // Waiting for the snapshot.
-    };
-
-    enum class Role {
-        LEADER = 1,     // the leader
-        FOLLOWER,       // following a leader
-        CANDIDATE,      // Has sent AskForVote request
-        LEARNER         // It is the same with FOLLOWER,
-                        // except it does not participate in leader election
-    };
-
     // A list of <idx, resp>
     // idx  -- the index of the peer
     // resp -- AskForVoteResponse

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -197,7 +197,7 @@ public:
     /**
      * Add listener into peers or remove from peers
      */
-    void checkRemoteListeners(const std::vector<HostAddr>& listeners);
+    void checkRemoteListeners(const std::set<HostAddr>& listeners);
 
     /*****************************************************
      *
@@ -222,6 +222,10 @@ public:
     bool leaseValid();
 
     bool needToCleanWal();
+
+    std::set<HostAddr> peers() const;
+
+    std::set<HostAddr> listeners() const;
 
 protected:
     // Protected constructor to prevent from instantiating directly
@@ -393,8 +397,8 @@ private:
         LogID prevLogId,
         std::vector<std::shared_ptr<Host>> hosts);
 
-    // peers return other peers which could vote, in other words, learner is not counted in
-    std::vector<std::shared_ptr<Host>> peers() const;
+    // followers return Host of which could vote, in other words, learner is not counted in
+    std::vector<std::shared_ptr<Host>> followers() const;
 
     bool checkAppendLogResult(AppendLogResult res);
 
@@ -484,8 +488,14 @@ protected:
     const GraphSpaceID spaceId_;
     const PartitionID partId_;
     const HostAddr addr_;
+    // hosts_ contains all connection, hosts_ = peers_ + listeners_
     std::vector<std::shared_ptr<Host>> hosts_;
     size_t quorum_{0};
+
+    // peers_ contanis all peers which could vote and learner, peers_ = follower + learner
+    std::set<HostAddr> peers_;
+    // all listener's role is learner (cannot promote to follower), but they are not in peers_
+    std::set<HostAddr> listeners_;
 
     // The lock is used to protect logs_ and cachingPromise_
     mutable std::mutex logsLock_;

--- a/src/kvstore/raftex/RaftexService.cpp
+++ b/src/kvstore/raftex/RaftexService.cpp
@@ -156,6 +156,8 @@ void RaftexService::waitUntilStop() {
 
 
 void RaftexService::addPartition(std::shared_ptr<RaftPart> part) {
+    // todo(doodle): If we need to start both listener and normal replica on same hosts,
+    // this class need to be aware of type.
     folly::RWSpinLock::WriteHolder wh(partsLock_);
     parts_.emplace(std::make_pair(part->spaceId(), part->partitionId()),
                    part);

--- a/src/kvstore/test/CMakeLists.txt
+++ b/src/kvstore/test/CMakeLists.txt
@@ -64,6 +64,19 @@ nebula_add_test(
 
 nebula_add_test(
     NAME
+        nebula_listener_test
+    SOURCES
+        NebulaListenerTest.cpp
+    OBJECTS
+        ${KVSTORE_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        gtest
+)
+
+nebula_add_test(
+    NAME
         rocks_engine_config_test
     SOURCES
         RocksEngineConfigTest.cpp

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -89,6 +89,12 @@ public:
     }
 
     void TearDown() override {
+        for (const auto& store : stores_) {
+            store->stop();
+        }
+        for (const auto& listener : listeners_) {
+            listener->stop();
+        }
     }
 
 protected:

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -79,26 +79,19 @@ TEST(NebulaStoreTest, SimpleTest) {
     // 1 space, 1 part, 1 replica, 1 listener
     auto initNebulaStore = [](const std::vector<HostAddr>& peers,
                               int32_t index,
-                              const std::string& path,
-                              bool asListener = false)
+                              const std::string& path)
         -> std::unique_ptr<NebulaStore> {
         auto partMan = std::make_unique<MemPartManager>();
         auto ioThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
 
         GraphSpaceID spaceId = 1;
         PartitionID partId = 1;
-        if (!asListener) {
+        {
             PartHosts ph;
             ph.spaceId_ = spaceId;
             ph.partId_ = partId;
             ph.hosts_ = peers;
             partMan->partsMap_[spaceId][partId] = std::move(ph);
-        } else {
-            ListenerHosts lh;
-            lh.spaceId_ = spaceId;
-            lh.partId_ = partId;
-            lh.hosts_ = peers;
-            partMan->listenersMap_[spaceId][partId] = std::move(lh);
         }
 
         fs::TempDir rootPath("/tmp/nebula_listener_test.XXXXXX");
@@ -131,9 +124,11 @@ TEST(NebulaStoreTest, SimpleTest) {
         stores.back()->init();
     }
 
+    /*
     // init listener replica
     auto listener = initNebulaStore(peers, replicas, rootPath.path(), true);
     listener->init();
+    */
 
     sleep(5);
 }

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -169,7 +169,7 @@ TEST_P(ListenerBasicTest, SimpleTest) {
     for (int32_t i = 0; i < listenerCount; i++) {
         listeners.emplace_back(initListener(listenerHosts, i, rootPath.path()));
         listeners.back()->init();
-        listeners.back()->spaces_.emplace(spaceId, std::make_shared<SpacePartInfo>());
+        listeners.back()->spaceListeners_.emplace(spaceId, std::make_shared<SpaceListenerInfo>());
     }
     std::unordered_map<PartitionID, std::shared_ptr<DummyListener>> dummys;
     // start dummy listener on listener hosts
@@ -194,7 +194,7 @@ TEST_P(ListenerBasicTest, SimpleTest) {
             return NebulaStore::getRaftAddr(host);
         });
         dummy->start(std::move(raftPeers));
-        listeners[index]->spaces_[spaceId]->listeners_[partId].emplace(
+        listeners[index]->spaceListeners_[spaceId]->listeners_[partId].emplace(
             meta::cpp2::ListenerType::UNKNOWN, dummy);
         dummys.emplace(partId, dummy);
     }

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -48,7 +48,11 @@ protected:
         return true;
     }
 
-    bool persist(LogID, TermID, LogID) override {
+    bool persistCommitLogId(LogID, TermID) override {
+        return true;
+    }
+
+    bool persistApplyId(LogID) override {
         return true;
     }
 
@@ -60,15 +64,7 @@ protected:
         return lastApplyLogId_;
     }
 
-    std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>&,
-                                               LogID,
-                                               TermID,
-                                               bool) override {
-        LOG(FATAL) << "Not implemented";
-    }
-
     void cleanup() override {
-        data_.clear();
     }
 
 private:

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -48,11 +48,7 @@ protected:
         return true;
     }
 
-    bool persistCommitLogId(LogID, TermID) override {
-        return true;
-    }
-
-    bool persistApplyId(LogID) override {
+    bool persist(LogID, TermID, LogID) override {
         return true;
     }
 

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -1,0 +1,130 @@
+/* Copyright (c) 2018 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/base/Base.h"
+#include "common/fs/TempDir.h"
+#include "common/fs/FileUtils.h"
+#include "common/network/NetworkUtils.h"
+#include "common/meta/Common.h"
+#include <thrift/lib/cpp/concurrency/ThreadManager.h>
+#include <gtest/gtest.h>
+#include "kvstore/NebulaStore.h"
+#include "kvstore/PartManager.h"
+
+DECLARE_uint32(raft_heartbeat_interval_secs);
+using nebula::meta::PartHosts;
+
+namespace nebula {
+namespace kvstore {
+
+class DummyListener : public Listener {
+public:
+    DummyListener(GraphSpaceID spaceId,
+                  PartitionID partId,
+                  HostAddr localAddr,
+                  const std::string& walPath,
+                  std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+                  std::shared_ptr<thread::GenericThreadPool> workers,
+                  std::shared_ptr<folly::Executor> handlers)
+        : Listener(spaceId, partId, localAddr, walPath,
+                   ioPool, workers, handlers, nullptr, nullptr) {
+        setCallback(std::bind(&DummyListener::commitLog, this,
+                              std::placeholders::_1, std::placeholders::_2),
+                    std::bind(&DummyListener::updateCommit, this,
+                              std::placeholders::_1, std::placeholders::_2));
+    }
+
+protected:
+    bool commitLog(LogID logId, folly::StringPiece logMsg) {
+        data_.emplace_back(logId, logMsg);
+        return true;
+    }
+
+    bool updateCommit(LogID, TermID) {
+        return true;
+    }
+
+    std::pair<LogID, TermID> lastCommittedLogId() override {
+        return std::make_pair(committedLogId_, term_);
+    }
+
+    std::pair<int64_t, int64_t> commitSnapshot(const std::vector<std::string>&,
+                                               LogID,
+                                               TermID,
+                                               bool) override {
+        LOG(FATAL) << "Not implemented";
+    }
+
+    void cleanup() override {
+        data_.clear();
+    }
+
+private:
+    std::vector<std::pair<LogID, std::string>> data_;
+};
+
+std::shared_ptr<apache::thrift::concurrency::PriorityThreadManager> getWorkers() {
+    auto worker =
+        apache::thrift::concurrency::PriorityThreadManager::newPriorityThreadManager(1, true);
+    worker->setNamePrefix("executor");
+    worker->start();
+    return worker;
+}
+
+TEST(NebulaStoreTest, SimpleTest) {
+    // 1 space, 1 part, 1 replica, 1 listener
+    auto initNebulaStore = [](const std::vector<HostAddr>& peers,
+                              int32_t index,
+                              const std::string& path) -> std::unique_ptr<NebulaStore> {
+        auto partMan = std::make_unique<MemPartManager>();
+        auto ioThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+
+        GraphSpaceID spaceId = 1;
+        PartitionID partId = 1;
+        PartHosts ph;
+        ph.spaceId_ = 0;
+        ph.partId_ = partId;
+        ph.hosts_ = peers;
+        partMan->partsMap_[spaceId][partId] = std::move(ph);
+
+        fs::TempDir rootPath("/tmp/nebula_listener_test.XXXXXX");
+        std::vector<std::string> paths;
+        paths.emplace_back(folly::stringPrintf("%s/disk%d", path.c_str(), index));
+
+        KVOptions options;
+        options.dataPaths_ = std::move(paths);
+        options.partMan_ = std::move(partMan);
+        HostAddr local = peers[index];
+        return std::make_unique<NebulaStore>(std::move(options),
+                                             ioThreadPool,
+                                             local,
+                                             getWorkers());
+    };
+
+    fs::TempDir rootPath("/tmp/nebula_store_test.XXXXXX");
+    int32_t replicas = 1;
+    std::string ip("127.0.0.1");
+    std::vector<HostAddr> peers;
+    for (int32_t i = 0; i < replicas; i++) {
+        peers.emplace_back(ip, network::NetworkUtils::getAvailablePort());
+    }
+    std::vector<std::unique_ptr<NebulaStore>> stores;
+    for (int32_t i = 0; i < replicas; i++) {
+        stores.emplace_back(initNebulaStore(peers, i, rootPath.path()));
+        stores.back()->init();
+    }
+}
+
+}  // namespace kvstore
+}  // namespace nebula
+
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+    return RUN_ALL_TESTS();
+}

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -41,6 +41,9 @@ public:
     }
 
 protected:
+    void init() override {
+    }
+
     bool apply(const std::vector<KV>& kvs) override {
         for (const auto& kv : kvs) {
             data_.emplace_back(kv);

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -749,15 +749,16 @@ void FileBasedWal::cleanWAL(LogID id) {
         return;
     }
 
-    // find the first wal file which first id is greater than the given log id,
-    // and clean the outdate wal files
-    auto bound = walFiles_.upper_bound(id);
-    if (bound != walFiles_.end()) {
-        for (auto iter = walFiles_.begin(); iter != std::prev(bound); iter++) {
+    // remove wal file that lastId is less than target
+    auto iter = walFiles_.begin();
+    while (iter != walFiles_.end()) {
+        if (iter->second->lastId() < id) {
             VLOG(1) << "Clean wals, Remove " << iter->second->path();
             unlink(iter->second->path());
+            iter = walFiles_.erase(iter);
+        } else {
+            break;
         }
-        walFiles_.erase(walFiles_.begin(), std::prev(bound));
     }
     firstLogId_ = walFiles_.begin()->second->firstId();
 }

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -751,9 +751,13 @@ void FileBasedWal::cleanWAL(LogID id) {
 
     // find the first wal file which first id is greater than the given log id,
     // and clean the outdate wal files
-    auto iter = walFiles_.upper_bound(id);
-    if (iter != walFiles_.end()) {
-        walFiles_.erase(walFiles_.begin(), std::prev(iter));
+    auto bound = walFiles_.upper_bound(id);
+    if (bound != walFiles_.end()) {
+        for (auto iter = walFiles_.begin(); iter != std::prev(bound); iter++) {
+            VLOG(1) << "Clean wals, Remove " << iter->second->path();
+            unlink(iter->second->path());
+        }
+        walFiles_.erase(walFiles_.begin(), std::prev(bound));
     }
     firstLogId_ = walFiles_.begin()->second->firstId();
 }

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -11,6 +11,12 @@
 #include "kvstore/wal/WalFileIterator.h"
 #include <utime.h>
 
+DEFINE_int32(wal_ttl, 14400, "Default wal ttl");
+DEFINE_int64(wal_file_size, 16 * 1024 * 1024, "Default wal file size");
+DEFINE_int32(wal_buffer_size, 8 * 1024 * 1024, "Default wal buffer size");
+DEFINE_int32(wal_buffer_num, 2, "Default wal buffer number");
+DEFINE_bool(wal_sync, false, "Whether fsync needs to be called every write");
+
 namespace nebula {
 namespace wal {
 
@@ -702,7 +708,7 @@ bool FileBasedWal::reset() {
     return true;
 }
 
-void FileBasedWal::cleanWAL(int32_t ttl) {
+void FileBasedWal::cleanWAL() {
     std::lock_guard<std::mutex> g(walFilesMutex_);
     if (walFiles_.empty()) {
         return;
@@ -718,7 +724,7 @@ void FileBasedWal::cleanWAL(int32_t ttl) {
         return;
     }
     int count = 0;
-    int walTTL = ttl == 0 ? policy_.ttl : ttl;
+    int walTTL = FLAGS_wal_ttl;
     while (it != walFiles_.end()) {
         // keep at least two wal
         if (index++ < size - 2 && (now - it->second->mtime() > walTTL)) {
@@ -737,6 +743,20 @@ void FileBasedWal::cleanWAL(int32_t ttl) {
     firstLogId_ = walFiles_.begin()->second->firstId();
 }
 
+void FileBasedWal::cleanWAL(LogID id) {
+    std::lock_guard<std::mutex> g(walFilesMutex_);
+    if (walFiles_.empty()) {
+        return;
+    }
+
+    // find the first wal file which first id is greater than the given log id,
+    // and clean the outdate wal files
+    auto iter = walFiles_.upper_bound(id);
+    if (iter != walFiles_.end()) {
+        walFiles_.erase(walFiles_.begin(), std::prev(iter));
+    }
+    firstLogId_ = walFiles_.begin()->second->firstId();
+}
 
 size_t FileBasedWal::accessAllWalInfo(std::function<bool(WalFileInfoPtr info)> fn) const {
     std::lock_guard<std::mutex> g(walFilesMutex_);

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -749,6 +749,12 @@ void FileBasedWal::cleanWAL(LogID id) {
         return;
     }
 
+    if (walFiles_.rbegin()->second->lastId() < id) {
+        LOG(WARNING) << "Try to clean wal not existed " << id
+                     << ", lastWal is " << walFiles_.rbegin()->second->lastId();
+        return;
+    }
+
     // remove wal file that lastId is less than target
     auto iter = walFiles_.begin();
     while (iter != walFiles_.end()) {

--- a/src/kvstore/wal/FileBasedWal.h
+++ b/src/kvstore/wal/FileBasedWal.h
@@ -19,10 +19,6 @@ namespace nebula {
 namespace wal {
 
 struct FileBasedWalPolicy {
-    // The life span of the log messages (number of seconds)
-    // This is only a hint, the FileBasedWal will try to keep all messages
-    // newer than ttl, but not guarantee to remove old messages right away
-    int32_t ttl = 86400;
     // The maximum size of each log message file (in byte). When the existing
     // log file reaches this size, a new file will be created
     size_t fileSize = 16 * 1024L * 1024L;
@@ -46,6 +42,7 @@ class FileBasedWal final : public Wal
     FRIEND_TEST(FileBasedWal, TTLTest);
     FRIEND_TEST(FileBasedWal, CheckLastWalTest);
     FRIEND_TEST(FileBasedWal, LinkTest);
+    FRIEND_TEST(FileBasedWal, CleanWalBeforeIdTest);
     FRIEND_TEST(WalFileIter, MultiFilesReadTest);
     friend class FileBasedWalIterator;
     friend class WalFileIterator;
@@ -106,7 +103,9 @@ public:
     // This method is *NOT* thread safe
     bool reset() override;
 
-    void cleanWAL(int32_t ttl = 0) override;
+    void cleanWAL() override;
+
+    void cleanWAL(LogID id) override;
 
     // Scan [firstLogId, lastLogId]
     // This method IS thread-safe

--- a/src/kvstore/wal/Wal.h
+++ b/src/kvstore/wal/Wal.h
@@ -50,7 +50,11 @@ public:
     // This method is *NOT* thread safe
     virtual bool reset() = 0;
 
-    virtual void cleanWAL(int32_t ttl = 0) = 0;
+    // clean time expired wal of wal_ttl
+    virtual void cleanWAL() = 0;
+
+    // clean the wal before given log id
+    virtual void cleanWAL(LogID id) = 0;
 
     // Scan [firstLogId, lastLogId]
     virtual std::unique_ptr<LogIterator> iterator(LogID firstLogId,

--- a/src/kvstore/wal/test/FileBasedWalTest.cpp
+++ b/src/kvstore/wal/test/FileBasedWalTest.cpp
@@ -9,6 +9,8 @@
 #include <gtest/gtest.h>
 #include "kvstore/wal/FileBasedWal.h"
 
+DECLARE_int32(wal_ttl);
+
 namespace nebula {
 namespace wal {
 
@@ -351,9 +353,9 @@ TEST(FileBasedWal, BackAndForth) {
 
 
 TEST(FileBasedWal, TTLTest) {
+    FLAGS_wal_ttl = 3;
     TempDir walDir("/tmp/testWal.XXXXXX");
     FileBasedWalPolicy policy;
-    policy.ttl = 3;
     policy.bufferSize = 128;
     policy.fileSize = 1024;
     policy.numBuffers = 30;
@@ -373,7 +375,7 @@ TEST(FileBasedWal, TTLTest) {
     auto startIdAfterGC
         = static_cast<FileBasedWal*>(wal.get())->walFiles_.rbegin()->second->firstId();
     auto expiredFilesNum = static_cast<FileBasedWal*>(wal.get())->walFiles_.size() - 1;
-    sleep(policy.ttl + 1);
+    sleep(FLAGS_wal_ttl + 1);
     for (int i = 101; i <= 200; i++) {
         EXPECT_TRUE(
             wal->appendLog(i /*id*/, 1 /*term*/, 0 /*cluster*/,
@@ -576,6 +578,37 @@ TEST(FileBasedWal, LinkTest) {
             wal->appendLog(1001 /*id*/, 1 /*term*/, 0 /*cluster*/,
                            folly::stringPrintf(kLongMsg, 1001)));
     EXPECT_EQ(num + 1, wal->walFiles_.size());
+}
+
+TEST(FileBasedWal, CleanWalBeforeIdTest) {
+    TempDir walDir("/tmp/testWal.XXXXXX");
+    FileBasedWalPolicy policy;
+    policy.fileSize = 1024 * 10;
+    auto wal = FileBasedWal::getWal(walDir.path(),
+                                    "",
+                                    policy,
+                                    [](LogID, TermID, ClusterID, const std::string&) {
+                                        return true;
+                                    });
+    for (LogID i = 1; i <= 1000; i++) {
+        EXPECT_TRUE(wal->appendLog(i, 1, 0, folly::stringPrintf(kLongMsg, i)));
+    }
+
+    // try to clean not existed log
+    wal->cleanWAL(1001L);
+    CHECK_EQ(1, wal->firstLogId());
+    CHECK_EQ(1000, wal->lastLogId());
+
+    LogID logToKeep = 1;
+    while (logToKeep < 1000) {
+        wal->cleanWAL(logToKeep);
+        CHECK_LE(wal->firstLogId(), logToKeep);
+        CHECK(!wal->walFiles_.empty());
+        CHECK_LE(wal->walFiles_.begin()->second->firstId(), logToKeep);
+        CHECK_GE(wal->walFiles_.begin()->second->lastId(), logToKeep);
+        logToKeep += folly::Random::rand64(10);
+    }
+    CHECK_EQ(1000, wal->lastLogId());
 }
 
 }  // namespace wal

--- a/src/kvstore/wal/test/FileBasedWalTest.cpp
+++ b/src/kvstore/wal/test/FileBasedWalTest.cpp
@@ -609,6 +609,10 @@ TEST(FileBasedWal, CleanWalBeforeIdTest) {
         logToKeep += folly::Random::rand64(10);
     }
     CHECK_EQ(1000, wal->lastLogId());
+
+    // try to clean not existed log
+    wal->cleanWAL(1L);
+    CHECK_EQ(1000, wal->lastLogId());
 }
 
 }  // namespace wal

--- a/src/meta/processors/listenerMan/ListenerProcessor.cpp
+++ b/src/meta/processors/listenerMan/ListenerProcessor.cpp
@@ -5,6 +5,9 @@
  */
 
 #include "meta/processors/listenerMan/ListenerProcessor.h"
+#include "meta/ActiveHostsMan.h"
+
+DECLARE_int32(heartbeat_interval_secs);
 
 namespace nebula {
 namespace meta {
@@ -87,12 +90,20 @@ void ListListenerProcessor::process(const cpp2::ListListenerReq& req) {
         onFinished();
         return;
     }
+
+    auto activeHosts = ActiveHostsMan::getActiveHosts(
+        kvstore_, FLAGS_heartbeat_interval_secs * 2, cpp2::HostRole::LISTENER);
     decltype(resp_.listeners) listeners;
     while (iter->valid()) {
         cpp2::ListenerInfo listener;
         listener.set_type(MetaServiceUtils::parseListenerType(iter->key()));
         listener.set_host(MetaServiceUtils::deserializeHostAddr(iter->val()));
         listener.set_part_id(MetaServiceUtils::parseListenerPart(iter->key()));
+        if (std::find(activeHosts.begin(), activeHosts.end(), listener.host) != activeHosts.end()) {
+            listener.set_status(cpp2::HostStatus::ONLINE);
+        } else {
+            listener.set_status(cpp2::HostStatus::OFFLINE);
+        }
         listeners.emplace_back(std::move(listener));
         iter->next();
     }

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -1320,14 +1320,22 @@ TEST(MetaClientTest, GroupAndZoneTest) {
 class TestListener : public MetaChangedListener {
 public:
     virtual ~TestListener() = default;
-    void onSpaceAdded(GraphSpaceID spaceId) override {
+    void onSpaceAdded(GraphSpaceID spaceId, bool isListener) override {
         LOG(INFO) << "Space " << spaceId << " added";
-        spaceNum++;
+        if (!isListener) {
+            spaceNum++;
+        } else {
+            listenerSpaceNum++;
+        }
     }
 
-    void onSpaceRemoved(GraphSpaceID spaceId) override {
+    void onSpaceRemoved(GraphSpaceID spaceId, bool isListener) override {
         LOG(INFO) << "Space " << spaceId << " removed";
-        spaceNum--;
+        if (!isListener) {
+            spaceNum--;
+        } else {
+            listenerSpaceNum--;
+        }
     }
 
     void onPartAdded(const PartHosts& partMeta) override {
@@ -1358,14 +1366,26 @@ public:
         LOG(INFO) << "Get leader distribution!";
     }
 
-    HostAddr getLocalHost() {
-        return HostAddr("0", 0);
+    void onListenerAdded(GraphSpaceID spaceId,
+                         PartitionID partId,
+                         const ListenerHosts& listenerHosts) override {
+        UNUSED(spaceId); UNUSED(partId); UNUSED(listenerHosts);
+        listenerPartNum++;
+    }
+
+    void onListenerRemoved(GraphSpaceID spaceId,
+                           PartitionID partId,
+                           cpp2::ListenerType type) override {
+        UNUSED(spaceId); UNUSED(partId); UNUSED(type);
+        listenerPartNum--;
     }
 
     int32_t spaceNum = 0;
     int32_t partNum = 0;
     int32_t partChanged = 0;
     std::unordered_map<std::string, std::string> options;
+    int32_t listenerSpaceNum = 0;
+    int32_t listenerPartNum = 0;
 };
 
 TEST(MetaClientTest, DiffTest) {
@@ -1425,6 +1445,105 @@ TEST(MetaClientTest, DiffTest) {
     sleep(FLAGS_heartbeat_interval_secs + 1);
     ASSERT_EQ(1, listener->spaceNum);
     ASSERT_EQ(9, listener->partNum);
+}
+
+TEST(MetaClientTest, ListenerDiffTest) {
+    FLAGS_heartbeat_interval_secs = 1;
+    fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
+
+    mock::MockCluster cluster;
+    cluster.startMeta(0, rootPath.path());
+    meta::MetaClientOptions options;
+    options.localHost_ = {"", 0};
+    options.role_ = meta::cpp2::HostRole::STORAGE;
+    cluster.initMetaClient(options);
+    auto* kv = cluster.metaKV_.get();
+    auto* console = cluster.metaClient_.get();
+
+    // create another meta client for listener host
+    HostAddr listenerHost("listener", 0);
+    options.localHost_ = listenerHost;
+    options.role_ = meta::cpp2::HostRole::UNKNOWN;
+    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
+    auto metaAddrs = {HostAddr(cluster.localIP(), cluster.metaServer_->port_)};
+    auto client = std::make_unique<meta::MetaClient>(threadPool, metaAddrs, options);
+    client->waitForMetadReady();
+
+    auto listener = std::make_unique<TestListener>();
+    client->registerListener(listener.get());
+
+    // register HB for storage
+    std::vector<HostAddr> hosts = {{"", 0}};
+    TestUtils::registerHB(kv, hosts);
+    {
+        // create two space
+        meta::cpp2::SpaceDesc spaceDesc;
+        spaceDesc.set_space_name("listener_space");
+        spaceDesc.set_partition_num(9);
+        spaceDesc.set_replica_factor(1);
+        auto ret = console->createSpace(spaceDesc).get();
+        ASSERT_TRUE(ret.ok()) << ret.status();
+        auto spaceId = ret.value();
+
+        spaceDesc.set_space_name("no_listener_space");
+        ret = console->createSpace(spaceDesc).get();
+        ASSERT_TRUE(ret.ok()) << ret.status();
+
+        sleep(FLAGS_heartbeat_interval_secs + 1);
+        ASSERT_EQ(0, listener->spaceNum);
+        ASSERT_EQ(0, listener->partNum);
+        ASSERT_EQ(0, listener->listenerSpaceNum);
+        ASSERT_EQ(0, listener->listenerPartNum);
+
+        // add listener hosts to space and check num
+        auto addRet = console->addListener(spaceId,
+                                           cpp2::ListenerType::ELASTICSEARCH,
+                                           {listenerHost}).get();
+        ASSERT_TRUE(addRet.ok()) << addRet.status();
+        sleep(FLAGS_heartbeat_interval_secs + 1);
+        ASSERT_EQ(0, listener->spaceNum);
+        ASSERT_EQ(0, listener->partNum);
+        ASSERT_EQ(1, listener->listenerSpaceNum);
+        ASSERT_EQ(9, listener->listenerPartNum);
+
+        // drop other space should not effect listener space
+        auto dropRet = console->dropSpace("no_listener_space").get();
+        ASSERT_TRUE(dropRet.ok()) << dropRet.status();
+        sleep(FLAGS_heartbeat_interval_secs + 1);
+        ASSERT_EQ(0, listener->spaceNum);
+        ASSERT_EQ(0, listener->partNum);
+        ASSERT_EQ(1, listener->listenerSpaceNum);
+        ASSERT_EQ(9, listener->listenerPartNum);
+
+        // remove listener hosts from space
+        auto removeRet = console->removeListener(spaceId, cpp2::ListenerType::ELASTICSEARCH).get();
+        ASSERT_TRUE(removeRet.ok()) << removeRet.status();
+        sleep(FLAGS_heartbeat_interval_secs + 1);
+        ASSERT_EQ(0, listener->spaceNum);
+        ASSERT_EQ(0, listener->partNum);
+        ASSERT_EQ(0, listener->listenerSpaceNum);
+        ASSERT_EQ(0, listener->listenerPartNum);
+
+        // add listener again
+        addRet = console->addListener(spaceId,
+                                      cpp2::ListenerType::ELASTICSEARCH,
+                                      {listenerHost}).get();
+        ASSERT_TRUE(addRet.ok()) << addRet.status();
+        sleep(FLAGS_heartbeat_interval_secs + 1);
+        ASSERT_EQ(0, listener->spaceNum);
+        ASSERT_EQ(0, listener->partNum);
+        ASSERT_EQ(1, listener->listenerSpaceNum);
+        ASSERT_EQ(9, listener->listenerPartNum);
+
+        // drop listener space
+        dropRet = console->dropSpace("listener_space").get();
+        ASSERT_TRUE(dropRet.ok()) << dropRet.status();
+        sleep(FLAGS_heartbeat_interval_secs + 1);
+        ASSERT_EQ(0, listener->spaceNum);
+        ASSERT_EQ(0, listener->partNum);
+        ASSERT_EQ(0, listener->listenerSpaceNum);
+        ASSERT_EQ(0, listener->listenerPartNum);
+    }
     client->unRegisterListener();
 }
 

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -51,6 +51,7 @@ std::unique_ptr<kvstore::KVStore> StorageServer::getStoreInstance() {
                                                 metaClient_.get());
     options.cffBuilder_ = std::make_unique<StorageCompactionFilterFactoryBuilder>(schemaMan_.get(),
                                                                                   indexMan_.get());
+    options.schemaMan_ = schemaMan_.get();
     if (FLAGS_store_type == "nebula") {
         auto nbStore = std::make_unique<kvstore::NebulaStore>(std::move(options),
                                                               ioThreadPool_,

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -112,6 +112,7 @@ bool StorageServer::start() {
     options.localHost_ = localHost_;
     options.serviceName_ = "";
     options.skipConfig_ = FLAGS_local_config;
+    // doodle: listener can't start with HostRole::STORAGE
     options.role_ = nebula::meta::cpp2::HostRole::STORAGE;
     options.gitInfoSHA_ = NEBULA_STRINGIFY(GIT_INFO_SHA);
 

--- a/src/storage/StorageServer.h
+++ b/src/storage/StorageServer.h
@@ -27,7 +27,8 @@ class StorageServer final {
 public:
     StorageServer(HostAddr localHost,
                   std::vector<HostAddr> metaAddrs,
-                  std::vector<std::string> dataPaths);
+                  std::vector<std::string> dataPaths,
+                  std::string listenerPath = "");
 
     ~StorageServer();
 
@@ -74,6 +75,7 @@ private:
     HostAddr localHost_;
     std::vector<HostAddr> metaAddrs_;
     std::vector<std::string> dataPaths_;
+    std::string listenerPath_;
 
     AdminTaskManager* taskMgr_{nullptr};
 };


### PR DESCRIPTION
Listener is more like learner in balance data. After this merged, we can add a listener of a given space, and receive logs from leader in async. Listener can decode the wal and do whatever you like, e.g., send to ElasticSearch.

Done:
1. Listener interface
2. Run listener on listener host
3. Add remote listener to raft group
4. Since listener need to decode wal, it need to hold a schema manager
5. PartManager need to be aware of listeners change
6. Listener could apply in batch, the wal of listener will be cleaned by lastApplyId.
7. Verify in daemon, it also need to be distinguish from normal storage

The basic test case mock a listener for now, see it in `NebulaListenerTest`.

todo:
1. Listener need to be aware of membership change
2. A friendly interface to tell gap between listener and leader
3. Listener need to impelement snapshot

Rely on https://github.com/vesoft-inc/nebula-common/pull/285