### PR TITLE
Encode string null in index as length in schema 

### DIFF
--- a/src/mock/MockData.cpp
+++ b/src/mock/MockData.cpp
@@ -799,12 +799,11 @@ std::vector<std::pair<PartitionID, std::string>> MockData::mockPlayerIndexKeys(b
             name = player.name_;
         }
         auto part = std::hash<std::string>()(name) % 6 + 1;
-        std::vector<Value> values;
-        values.emplace_back(encodeFixedStr(name, 20));
-        values.emplace_back(player.age_);
-        values.emplace_back(player.playing_);
-        std::vector<Value::Type> colsType;
-        auto key = IndexKeyUtils::vertexIndexKey(32, part, 1, name, values, colsType);
+        std::string values;
+        values.append(encodeFixedStr(name, 20));
+        values.append(IndexKeyUtils::encodeValue(player.age_));
+        values.append(IndexKeyUtils::encodeValue(player.playing_));
+        auto key = IndexKeyUtils::vertexIndexKey(32, part, 1, name, std::move(values));
         auto pair = std::make_pair(part, std::move(key));
         keys.emplace_back(std::move(pair));
     }
@@ -903,17 +902,16 @@ std::vector<std::pair<PartitionID, std::string>> MockData::mockServeIndexKeys() 
     std::vector<std::pair<PartitionID, std::string>> keys;
     for (auto& serve : serves_) {
         auto part = std::hash<std::string>()(serve.playerName_) % 6 + 1;
-        std::vector<Value> values;
-        values.emplace_back(encodeFixedStr(serve.playerName_, 20));
-        values.emplace_back(encodeFixedStr(serve.teamName_, 20));
-        values.emplace_back(serve.startYear_);
+        std::string values;
+        values.append(encodeFixedStr(serve.playerName_, 20));
+        values.append(encodeFixedStr(serve.teamName_, 20));
+        values.append(IndexKeyUtils::encodeValue(serve.startYear_));
         std::vector<Value::Type> colsType;
         auto key = IndexKeyUtils::edgeIndexKey(32, part, 101,
                                                serve.playerName_,
                                                serve.startYear_,
                                                serve.teamName_,
-                                               values,
-                                               colsType);
+                                               std::move(values));
         auto pair = std::make_pair(part, std::move(key));
         keys.emplace_back(std::move(pair));
     }

--- a/src/mock/MockData.cpp
+++ b/src/mock/MockData.cpp
@@ -906,7 +906,6 @@ std::vector<std::pair<PartitionID, std::string>> MockData::mockServeIndexKeys() 
         values.append(encodeFixedStr(serve.playerName_, 20));
         values.append(encodeFixedStr(serve.teamName_, 20));
         values.append(IndexKeyUtils::encodeValue(serve.startYear_));
-        std::vector<Value::Type> colsType;
         auto key = IndexKeyUtils::edgeIndexKey(32, part, 101,
                                                serve.playerName_,
                                                serve.startYear_,

--- a/src/storage/admin/RebuildEdgeIndexTask.cpp
+++ b/src/storage/admin/RebuildEdgeIndexTask.cpp
@@ -105,18 +105,20 @@ RebuildEdgeIndexTask::buildIndexGlobal(GraphSpaceID space,
             continue;
         }
 
-        std::vector<Value::Type> colsType;
         auto valuesRet = IndexKeyUtils::collectIndexValues(reader.get(),
-                                                           item->get_fields(),
-                                                           colsType);
+                                                           item->get_fields());
+        if (!valuesRet.ok()) {
+            LOG(WARNING) << "Collect index value failed";
+            iter->next();
+            continue;
+        }
         auto indexKey = IndexKeyUtils::edgeIndexKey(vidSize,
                                                     part,
                                                     item->get_index_id(),
                                                     source.data(),
                                                     ranking,
                                                     destination.data(),
-                                                    valuesRet.value(),
-                                                    std::move(colsType));
+                                                    std::move(valuesRet).value());
         data.emplace_back(std::move(indexKey), "");
         iter->next();
     }

--- a/src/storage/admin/RebuildTagIndexTask.cpp
+++ b/src/storage/admin/RebuildTagIndexTask.cpp
@@ -93,16 +93,18 @@ RebuildTagIndexTask::buildIndexGlobal(GraphSpaceID space,
             continue;
         }
 
-        std::vector<Value::Type> colsType;
         auto valuesRet = IndexKeyUtils::collectIndexValues(reader.get(),
-                                                           item->get_fields(),
-                                                           colsType);
+                                                           item->get_fields());
+        if (!valuesRet.ok()) {
+            LOG(WARNING) << "Collect index value failed";
+            iter->next();
+            continue;
+        }
         auto indexKey = IndexKeyUtils::vertexIndexKey(vidSize,
                                                       part,
                                                       item->get_index_id(),
                                                       vertex.data(),
-                                                      valuesRet.value(),
-                                                      std::move(colsType));
+                                                      std::move(valuesRet).value());
         data.emplace_back(std::move(indexKey), "");
         iter->next();
     }

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -414,13 +414,12 @@ public:
                          VertexID vId,
                          RowReader* reader,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-        std::vector<Value::Type> colsType;
-        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields());
         if (!values.ok()) {
             return "";
         }
         return IndexKeyUtils::vertexIndexKey(planContext_->vIdLen_, partId, index->get_index_id(),
-                                             vId, values.value(), colsType);
+                                             vId, std::move(values).value());
     }
 
 private:
@@ -720,8 +719,7 @@ public:
                          RowReader* reader,
                          const cpp2::EdgeKey& edgeKey,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-        std::vector<Value::Type> colsType;
-        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+        auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields());
         if (!values.ok()) {
             return "";
         }
@@ -731,8 +729,7 @@ public:
                                            edgeKey.get_src().getStr(),
                                            edgeKey.get_ranking(),
                                            edgeKey.get_dst().getStr(),
-                                           values.value(),
-                                           colsType);
+                                           std::move(values).value());
     }
 
 private:

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -248,8 +248,7 @@ std::string AddEdgesProcessor::indexKey(PartitionID partId,
                                         RowReader* reader,
                                         const folly::StringPiece& rawKey,
                                         std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-    std::vector<Value::Type> colsType;
-    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields());
     if (!values.ok()) {
         return "";
     }
@@ -258,7 +257,7 @@ std::string AddEdgesProcessor::indexKey(PartitionID partId,
                                        NebulaKeyUtils::getSrcId(spaceVidLen_, rawKey).str(),
                                        NebulaKeyUtils::getRank(spaceVidLen_, rawKey),
                                        NebulaKeyUtils::getDstId(spaceVidLen_, rawKey).str(),
-                                       values.value(), colsType);
+                                       std::move(values).value());
 }
 
 }  // namespace storage

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -246,16 +246,14 @@ std::string AddVerticesProcessor::indexKey(PartitionID partId,
                                            VertexID vId,
                                            RowReader* reader,
                                            std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
-    std::vector<Value::Type> colsType;
-    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields(), colsType);
+    auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields());
     if (!values.ok()) {
         return "";
     }
 
     return IndexKeyUtils::vertexIndexKey(spaceVidLen_, partId,
                                          index->get_index_id(),
-                                         vId, values.value(),
-                                         colsType);
+                                         vId, std::move(values).value());
 }
 
 }  // namespace storage

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -140,10 +140,8 @@ DeleteEdgesProcessor::deleteEdges(PartitionID partId,
                             return folly::none;
                         }
                     }
-                    std::vector<Value::Type> colsType;
                     auto valuesRet = IndexKeyUtils::collectIndexValues(reader.get(),
-                                                                       index->get_fields(),
-                                                                       colsType);
+                                                                       index->get_fields());
                     if (!valuesRet.ok()) {
                         continue;
                     }
@@ -152,8 +150,7 @@ DeleteEdgesProcessor::deleteEdges(PartitionID partId,
                                                                 srcId,
                                                                 rank,
                                                                 dstId,
-                                                                valuesRet.value(),
-                                                                colsType);
+                                                                std::move(valuesRet).value());
 
                     if (env_->checkRebuilding(spaceId_, partId, indexId)) {
                         auto deleteOpKey = OperationKeyUtils::deleteOperationKey(partId);

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -156,19 +156,16 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                                 return folly::none;
                             }
                         }
-                        std::vector<Value::Type> colsType;
                         const auto& cols = index->get_fields();
                         auto valuesRet = IndexKeyUtils::collectIndexValues(reader.get(),
-                                                                           cols,
-                                                                           colsType);
+                                                                           cols);
                         if (!valuesRet.ok()) {
                             continue;
                         }
                         auto indexKey = IndexKeyUtils::vertexIndexKey(spaceVidLen_, partId,
                                                                       indexId,
                                                                       vertex.getStr(),
-                                                                      valuesRet.value(),
-                                                                      colsType);
+                                                                      std::move(valuesRet).value());
 
                         // Check the index is building for the specified partition or not
                         if (env_->checkRebuilding(spaceId_, partId, indexId)) {

--- a/src/storage/test/LookupIndexTest.cpp
+++ b/src/storage/test/LookupIndexTest.cpp
@@ -1640,7 +1640,7 @@ TEST(LookupIndexTest, NullableInIndexAndFilterTest) {
         ASSERT_EQ(expected, *(resp.get_data()));
     }
     {
-        // col3 and col4 is out of index
+        // col3 and col4 is out of index, need to pass as filter
         LOG(INFO) << "lookup on tag where tag.col1 == 3 and tag.col2 == \"ccc\" and col3 > 1";
         std::vector<cpp2::IndexColumnHint> columnHints;
         {
@@ -1657,16 +1657,16 @@ TEST(LookupIndexTest, NullableInIndexAndFilterTest) {
             columnHint.set_begin_value("ccc");
             columnHints.emplace_back(std::move(columnHint));
         }
-        {
-            cpp2::IndexColumnHint columnHint;
-            columnHint.set_column_name("col3");
-            columnHint.set_scan_type(cpp2::ScanType::RANGE);
-            columnHint.set_begin_value(1);
-            columnHint.set_end_value(std::numeric_limits<int64_t>::max());
-        }
+
+        RelationalExpression expr(
+            Expression::Kind::kRelGT,
+            new TagPropertyExpression(
+                new std::string("111"),
+                new std::string("col3")),
+            new ConstantExpression(Value(1)));
 
         cpp2::IndexQueryContext context;
-        context.set_filter("");
+        context.set_filter(expr.encode());
         context.set_index_id(222);
         context.set_column_hints(columnHints);
 
@@ -1683,9 +1683,7 @@ TEST(LookupIndexTest, NullableInIndexAndFilterTest) {
         EXPECT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected({"_vid"});
         // Because col3 is out of index, so col3 > 1 will be used as filter
-        // Since null is bigger than any thing, so 3_c_null_null will satisfy too
         expected.rows.emplace_back(nebula::Row({"3_c_3_c"}));
-        expected.rows.emplace_back(nebula::Row({"3_c_null_null"}));
         ASSERT_EQ(expected, *(resp.get_data()));
     }
     {
@@ -2352,6 +2350,252 @@ TEST(LookupIndexTest, NullablePropertyTest) {
         EXPECT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected({"_vid"});
         expected.rows.emplace_back(nebula::Row({"true_1_1.0_a"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == null";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"null_2_2.0_b"}));
+        expected.rows.emplace_back(nebula::Row({"all_null"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == null and tag.col_int == null";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"all_null"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == null and tag.col_int == null and "
+                     "tag.col_double == null";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_double", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"all_null"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == null and tag.col_int == null and "
+                     "tag.col_double == null and tag.col_str == null";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_double", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_str", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"all_null"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == true and tag.col_int == 4 and "
+                     "tag.col_double == null and tag.col_str == ddd";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(true), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::PREFIX, Value(4), Value()));
+        columnHints.emplace_back(
+            columnHint("col_double", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_str", cpp2::ScanType::PREFIX, Value("ddd"), Value()));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"true_4_null_d"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == false and tag.col_int == null and "
+                     "tag.col_double == 3.0 and tag.col_str < \"d\"";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(false), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_double", cpp2::ScanType::PREFIX, Value(3.0), Value()));
+        columnHints.emplace_back(columnHint(
+            "col_str", cpp2::ScanType::RANGE, Value(std::string(strColLen, '\0')), Value("d")));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"false_null_3.0_c"}));
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == null and tag.col_int == null and "
+                     "tag.col_double >= 0.0";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(columnHint("col_double",
+                                            cpp2::ScanType::RANGE,
+                                            Value(0.0),
+                                            Value(std::numeric_limits<double>::max())));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        ASSERT_EQ(expected, *(resp.get_data()));
+    }
+    {
+        LOG(INFO) << "lookup on tag where tag.col_bool == null and tag.col_int >= 0 and "
+                     "tag.col_int < 10";
+        std::vector<cpp2::IndexColumnHint> columnHints;
+        columnHints.emplace_back(
+            columnHint("col_bool", cpp2::ScanType::PREFIX, Value(NullType::__NULL__), Value()));
+        columnHints.emplace_back(
+            columnHint("col_int", cpp2::ScanType::RANGE, Value(0), Value(10)));
+
+        cpp2::IndexQueryContext context;
+        context.set_filter("");
+        context.set_index_id(222);
+        context.set_column_hints(std::move(columnHints));
+
+        cpp2::IndexSpec indices;
+        indices.set_tag_or_edge_id(111);
+        indices.set_is_edge(false);
+        indices.set_contexts({context});
+        req.set_indices(std::move(indices));
+
+        auto* processor = LookupProcessor::instance(env, nullptr, nullptr);
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_parts.size());
+        nebula::DataSet expected({"_vid"});
+        expected.rows.emplace_back(nebula::Row({"null_2_2.0_b"}));
         ASSERT_EQ(expected, *(resp.get_data()));
     }
 }

--- a/src/storage/test/LookupIndexTest.cpp
+++ b/src/storage/test/LookupIndexTest.cpp
@@ -71,17 +71,18 @@ TEST(LookupIndexTest, LookupIndexTestV1) {
 
         // setup index key
 
-        std::vector<Value> values;
-        values.emplace_back(Value(true));
-        values.emplace_back(Value(1L));
-        values.emplace_back(Value(1.1F));
-        values.emplace_back(Value(1.1F));
-        values.emplace_back(Value("row1"));
+        std::string indexVal1;
+        indexVal1.append(IndexKeyUtils::encodeValue(true));
+        indexVal1.append(IndexKeyUtils::encodeValue(1L));
+        indexVal1.append(IndexKeyUtils::encodeValue(1.1F));
+        indexVal1.append(IndexKeyUtils::encodeValue(1.1F));
+        indexVal1.append(IndexKeyUtils::encodeValue("row1"));
+        std::string indexVal2 = indexVal1;
 
-        key = IndexKeyUtils::vertexIndexKey(vIdLen.value(), 1, 3, vId1, values);
+        key = IndexKeyUtils::vertexIndexKey(vIdLen.value(), 1, 3, vId1, std::move(indexVal1));
         keyValues.emplace_back(std::move(key), "");
 
-        key = IndexKeyUtils::vertexIndexKey(vIdLen.value(), 1, 3, vId2, values);
+        key = IndexKeyUtils::vertexIndexKey(vIdLen.value(), 1, 3, vId2, std::move(indexVal2));
         keyValues.emplace_back(std::move(key), "");
 
         folly::Baton<true, std::atomic> baton;

--- a/src/storage/test/QueryTestUtils.h
+++ b/src/storage/test/QueryTestUtils.h
@@ -63,7 +63,6 @@ public:
 
             if (enableIndex) {
                 if (tagId == 1 || tagId == 2) {
-                    std::vector<Value::Type> colsType({});
                     int32_t colNum = 0;
                     IndexID indexID = 0;
 
@@ -84,7 +83,6 @@ public:
                                    indexID,
                                    values,
                                    colNum,
-                                   colsType,
                                    data);
                 }
             }
@@ -144,7 +142,6 @@ public:
 
                 if (enableIndex) {
                     if (edge.type_ == 102 || edge.type_ == 101) {
-                        std::vector<Value::Type> colsType({});
                         int32_t colNum = 0;
                         IndexID indexID = 0;
 
@@ -167,7 +164,6 @@ public:
                                         indexID,
                                         values,
                                         colNum,
-                                        colsType,
                                         data);
                     }
                 }
@@ -259,23 +255,21 @@ public:
                                IndexID indexId,
                                const std::vector<Value>& values,
                                int32_t count,
-                               const std::vector<Value::Type>& colsType,
                                std::vector<kvstore::KV>& data) {
-        std::vector<Value> row;
+        std::string row;
         for (auto i = 0; i < count; i++) {
             auto v = values[i];
             if (v.type() == Value::Type::STRING) {
-                row.emplace_back(Value(IndexKeyUtils::encodeValue(v, 20)));
+                row.append(IndexKeyUtils::encodeValue(v, 20));
             } else {
-                row.emplace_back(std::move(v));
+                row.append(IndexKeyUtils::encodeValue(v));
             }
         }
         auto index = IndexKeyUtils::vertexIndexKey(spaceVidLen,
                                                    partId,
                                                    indexId,
                                                    vId,
-                                                   row,
-                                                   colsType);
+                                                   std::move(row));
         data.emplace_back(std::move(index), "");
     }
 
@@ -287,15 +281,14 @@ public:
                                IndexID indexId,
                                const std::vector<Value>& values,
                                int32_t count,
-                               const std::vector<Value::Type>& colsType,
                                std::vector<kvstore::KV>& data) {
-        std::vector<Value> row;
+        std::string row;
         for (auto i = 0; i < count; i++) {
             auto v = values[i];
             if (v.type() == Value::Type::STRING) {
-                row.emplace_back(Value(IndexKeyUtils::encodeValue(v, 20)));
+                row.append(IndexKeyUtils::encodeValue(v, 20));
             } else {
-                row.emplace_back(std::move(v));
+                row.append(IndexKeyUtils::encodeValue(v));
             }
         }
         auto index = IndexKeyUtils::edgeIndexKey(spaceVidLen,
@@ -304,8 +297,7 @@ public:
                                                  srcId,
                                                  rank,
                                                  dstId,
-                                                 row,
-                                                 colsType);
+                                                 std::move(row));
         data.emplace_back(std::move(index), "");
     }
 

--- a/src/utils/IndexKeyUtils.cpp
+++ b/src/utils/IndexKeyUtils.cpp
@@ -26,13 +26,7 @@ std::string IndexKeyUtils::encodeValues(std::vector<Value>&& values,
             // string index need to fill with '\0' if length is less than schema
             if (cols[i].type.type == meta::cpp2::PropertyType::FIXED_STRING) {
                 auto len = static_cast<size_t>(*cols[i].type.get_type_length());
-                std::string str = values[i].moveStr();
-                if (len > str.size()) {
-                    str.append(len - str.size(), '\0');
-                } else {
-                    str = str.substr(0, len);
-                }
-                index.append(str);
+                index.append(encodeValue(values[i], len));
             } else {
                 index.append(encodeValue(values[i]));
             }

--- a/src/utils/IndexKeyUtils.h
+++ b/src/utils/IndexKeyUtils.h
@@ -394,7 +394,7 @@ public:
                     break;
                 }
                 case Value::Type::DATETIME: {
-                    len = sizeof(int32_t) * 2 + sizeof(int16_t) + sizeof(int8_t) * 5;
+                    len = sizeof(int32_t) + sizeof(int16_t) + sizeof(int8_t) * 5;
                     break;
                 }
                 default:

--- a/src/utils/IndexKeyUtils.h
+++ b/src/utils/IndexKeyUtils.h
@@ -83,7 +83,7 @@ public:
                 break;
             }
             case Value::Type::DATETIME: {
-                len = sizeof(int32_t) * 2 + sizeof(int16_t) + sizeof(int8_t) * 5;
+                len = sizeof(int32_t) + sizeof(int16_t) + sizeof(int8_t) * 5;
                 break;
             }
             default :

--- a/src/utils/IndexKeyUtils.h
+++ b/src/utils/IndexKeyUtils.h
@@ -55,7 +55,7 @@ public:
         return Value::Type::__EMPTY__;
     }
 
-    static std::string encodeNullValue(Value::Type type) {
+    static std::string encodeNullValue(Value::Type type, const int16_t* strLen) {
         size_t len = 0;
         switch (type) {
             case Value::Type::INT: {
@@ -71,7 +71,7 @@ public:
                 break;
             }
             case Value::Type::STRING: {
-                len = 1;
+                len = static_cast<size_t>(*strLen);
                 break;
             }
             case Value::Type::TIME: {
@@ -368,6 +368,7 @@ public:
             if (hasNullableCol && col.get_name() == prop && nullableBit.test(nullableColPosit)) {
                 return Value(NullType::__NULL__);
             }
+            // doodle: mark
             switch (IndexKeyUtils::toValueType(col.type.get_type())) {
                 case Value::Type::BOOL: {
                     len = sizeof(bool);
@@ -454,11 +455,14 @@ public:
     /**
      * Generate vertex|edge index key for kv store
      **/
+    // doodle
+    /*
     static void encodeValues(const std::vector<Value>& values, std::string& raw);
 
     static void encodeValuesWithNull(const std::vector<Value>& values,
                                      const std::vector<Value::Type>& colsType,
                                      std::string& raw);
+    */
 
     /**
      * param valueTypes ： column type of each index column. If there are no nullable columns
@@ -466,8 +470,7 @@ public:
      **/
     static std::string vertexIndexKey(size_t vIdLen, PartitionID partId,
                                       IndexID indexId, VertexID vId,
-                                      const std::vector<Value>& values,
-                                      const std::vector<Value::Type>& valueTypes = {});
+                                      std::string&& values);
 
     /**
      * param valueTypes ： column type of each index column. If there are no nullable columns
@@ -476,17 +479,15 @@ public:
     static std::string edgeIndexKey(size_t vIdLen, PartitionID partId,
                                     IndexID indexId, VertexID srcId,
                                     EdgeRanking rank, VertexID dstId,
-                                    const std::vector<Value>& values,
-                                    const std::vector<Value::Type>& valueTypes = {});
+                                    std::string&& values);
 
     static std::string indexPrefix(PartitionID partId, IndexID indexId);
 
     static std::string indexPrefix(PartitionID partId);
 
-    static StatusOr<std::vector<Value>>
+    static StatusOr<std::string>
     collectIndexValues(RowReader* reader,
-                       const std::vector<nebula::meta::cpp2::ColumnDef>& cols,
-                       std::vector<Value::Type>& colsType);
+                       const std::vector<nebula::meta::cpp2::ColumnDef>& cols);
 
 private:
     IndexKeyUtils() = delete;

--- a/src/utils/test/IndexKeyUtilsTest.cpp
+++ b/src/utils/test/IndexKeyUtilsTest.cpp
@@ -4,9 +4,9 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
+#include <gtest/gtest.h>
 #include "common/base/Base.h"
 #include "utils/IndexKeyUtils.h"
-#include <gtest/gtest.h>
 
 namespace nebula {
 
@@ -16,17 +16,17 @@ VertexID getStringId(int64_t vId) {
     return id;
 }
 
-std::vector<Value> getIndexValues() {
-    std::vector<Value> values;
-    values.emplace_back(Value("str"));
-    values.emplace_back(Value(true));
-    values.emplace_back(Value(12L));
-    values.emplace_back(Value(12.12f));
+std::string getIndexValues() {
+    std::string values;
+    values.append(IndexKeyUtils::encodeValue(Value("str")));
+    values.append(IndexKeyUtils::encodeValue(Value(true)));
+    values.append(IndexKeyUtils::encodeValue(Value(12L)));
+    values.append(IndexKeyUtils::encodeValue(Value(12.12f)));
     Date d = {2020, 1, 20};
-    values.emplace_back(Value(std::move(d)));
+    values.append(IndexKeyUtils::encodeValue(Value(std::move(d))));
 
     DateTime dt = {2020, 4, 11, 12, 30, 22, 1111};
-    values.emplace_back(std::move(dt));
+    values.append(IndexKeyUtils::encodeValue(std::move(dt)));
     return values;
 }
 
@@ -144,7 +144,7 @@ TEST(IndexKeyUtilsTest, encodeDouble) {
 
 TEST(IndexKeyUtilsTest, vertexIndexKeyV1) {
     auto values = getIndexValues();
-    auto key = IndexKeyUtils::vertexIndexKey(8, 1, 1, getStringId(1), values);
+    auto key = IndexKeyUtils::vertexIndexKey(8, 1, 1, getStringId(1), std::move(values));
     ASSERT_EQ(1, IndexKeyUtils::getIndexId(key));
     ASSERT_EQ(getStringId(1), IndexKeyUtils::getIndexVertexID(8, key));
     ASSERT_EQ(true, IndexKeyUtils::isIndexKey(key));
@@ -152,7 +152,7 @@ TEST(IndexKeyUtilsTest, vertexIndexKeyV1) {
 
 TEST(IndexKeyUtilsTest, vertexIndexKeyV2) {
     auto values = getIndexValues();
-    auto key = IndexKeyUtils::vertexIndexKey(100, 1, 1, "vertex_1_1_1_1", values);
+    auto key = IndexKeyUtils::vertexIndexKey(100, 1, 1, "vertex_1_1_1_1", std::move(values));
     ASSERT_EQ(1, IndexKeyUtils::getIndexId(key));
 
     VertexID vid = "vertex_1_1_1_1";
@@ -163,7 +163,8 @@ TEST(IndexKeyUtilsTest, vertexIndexKeyV2) {
 
 TEST(IndexKeyUtilsTest, edgeIndexKeyV1) {
     auto values = getIndexValues();
-    auto key = IndexKeyUtils::edgeIndexKey(8, 1, 1, getStringId(1), 1, getStringId(2), values);
+    auto key =
+        IndexKeyUtils::edgeIndexKey(8, 1, 1, getStringId(1), 1, getStringId(2), std::move(values));
     ASSERT_EQ(1, IndexKeyUtils::getIndexId(key));
     ASSERT_EQ(getStringId(1), IndexKeyUtils::getIndexSrcId(8, key));
     ASSERT_EQ(1, IndexKeyUtils::getIndexRank(8, key));
@@ -174,7 +175,7 @@ TEST(IndexKeyUtilsTest, edgeIndexKeyV1) {
 TEST(IndexKeyUtilsTest, edgeIndexKeyV2) {
     VertexID vid = "vertex_1_1_1_1";
     auto values = getIndexValues();
-    auto key = IndexKeyUtils::edgeIndexKey(100, 1, 1, vid, 1, vid, values);
+    auto key = IndexKeyUtils::edgeIndexKey(100, 1, 1, vid, 1, vid, std::move(values));
     ASSERT_EQ(1, IndexKeyUtils::getIndexId(key));
     vid.append(100 - vid.size(), '\0');
     ASSERT_EQ(vid, IndexKeyUtils::getIndexSrcId(100, key));
@@ -184,16 +185,25 @@ TEST(IndexKeyUtilsTest, edgeIndexKeyV2) {
 }
 
 TEST(IndexKeyUtilsTest, nullableValue) {
-    {
-        std::string raw;
-        std::vector<Value> values;
-        std::vector<Value::Type> colsType;
-        for (int64_t j = 1; j <= 6; j++) {
-            auto type = Value::Type(1UL << j);
-            values.emplace_back(Value(NullType::__NULL__));
-            colsType.emplace_back(type);
+    auto nullCol = [](const std::string& name, const meta::cpp2::PropertyType type) {
+        meta::cpp2::ColumnDef col;
+        col.name = name;
+        col.type.set_type(type);
+        col.set_nullable(true);
+        if (type == meta::cpp2::PropertyType::FIXED_STRING) {
+            col.type.set_type_length(10);
         }
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
+        return col;
+    };
+    {
+        std::vector<Value> values;
+        std::vector<nebula::meta::cpp2::ColumnDef> cols;
+        for (int64_t j = 1; j <= 6; j++) {
+            values.emplace_back(Value(NullType::__NULL__));
+            cols.emplace_back(
+                nullCol(folly::stringPrintf("col%ld", j), meta::cpp2::PropertyType::BOOL));
+        }
+        auto raw = IndexKeyUtils::encodeValues(std::move(values), std::move(cols));
         u_short s = 0xfc00; /* the binary is '11111100 00000000'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
@@ -201,15 +211,15 @@ TEST(IndexKeyUtilsTest, nullableValue) {
         ASSERT_EQ(expected, result);
     }
     {
-        std::string raw;
         std::vector<Value> values;
-        std::vector<Value::Type> colsType;
-        auto type = Value::Type::BOOL;
         values.emplace_back(Value(true));
-        colsType.emplace_back(type);
         values.emplace_back(Value(NullType::__NULL__));
-        colsType.emplace_back(type);
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
+        std::vector<nebula::meta::cpp2::ColumnDef> cols;
+        for (int64_t j = 1; j <= 2; j++) {
+            cols.emplace_back(
+                nullCol(folly::stringPrintf("col%ld", j), meta::cpp2::PropertyType::BOOL));
+        }
+        auto raw = IndexKeyUtils::encodeValues(std::move(values), std::move(cols));
         u_short s = 0x4000; /* the binary is '01000000 00000000'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
@@ -217,26 +227,31 @@ TEST(IndexKeyUtilsTest, nullableValue) {
         ASSERT_EQ(expected, result);
     }
     {
-        std::string raw;
         std::vector<Value> values;
         values.emplace_back(Value(true));
         values.emplace_back(Value(false));
-        IndexKeyUtils::encodeValues(std::move(values), raw);
-        ASSERT_EQ(2, raw.size());
+        std::vector<nebula::meta::cpp2::ColumnDef> cols;
+        for (int64_t j = 1; j <= 2; j++) {
+            cols.emplace_back(
+                nullCol(folly::stringPrintf("col%ld", j), meta::cpp2::PropertyType::BOOL));
+        }
+        auto raw = IndexKeyUtils::encodeValues(std::move(values), std::move(cols));
+        u_short s = 0x0000; /* the binary is '01000000 00000000'*/
+        std::string expected;
+        expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
+        auto result = raw.substr(raw.size() - sizeof(u_short), sizeof(u_short));
+        ASSERT_EQ(expected, result);
     }
     {
-        std::string raw;
         std::vector<Value> values;
-        std::vector<Value::Type> colsType;
-        for (int64_t i = 0; i <2; i++) {
-            for (int64_t j = 1; j <= 6; j++) {
-                auto type = Value::Type(1UL << j);
-                values.emplace_back(Value(NullType::__NULL__));
-                colsType.emplace_back(type);
-            }
+        std::vector<nebula::meta::cpp2::ColumnDef> cols;
+        for (int64_t i = 0; i < 12; i++) {
+            values.emplace_back(Value(NullType::__NULL__));
+            cols.emplace_back(
+                nullCol(folly::stringPrintf("col%ld", i), meta::cpp2::PropertyType::INT64));
         }
 
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
+        auto raw = IndexKeyUtils::encodeValues(std::move(values), std::move(cols));
         u_short s = 0xfff0; /* the binary is '11111111 11110000'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
@@ -244,8 +259,16 @@ TEST(IndexKeyUtilsTest, nullableValue) {
         ASSERT_EQ(expected, result);
     }
     {
-        std::string raw;
+        std::vector<meta::cpp2::PropertyType> types;
+        types.emplace_back(meta::cpp2::PropertyType::BOOL);
+        types.emplace_back(meta::cpp2::PropertyType::INT64);
+        types.emplace_back(meta::cpp2::PropertyType::FLOAT);
+        types.emplace_back(meta::cpp2::PropertyType::STRING);
+        types.emplace_back(meta::cpp2::PropertyType::DATE);
+        types.emplace_back(meta::cpp2::PropertyType::DATETIME);
+
         std::vector<Value> values;
+        std::vector<nebula::meta::cpp2::ColumnDef> cols;
         std::unordered_map<Value::Type, Value> mockValues;
         {
             mockValues[Value::Type::BOOL] = Value(true);
@@ -257,20 +280,16 @@ TEST(IndexKeyUtilsTest, nullableValue) {
             DateTime dt = {2020, 4, 11, 12, 30, 22, 1111};
             mockValues[Value::Type::DATETIME] = Value(dt);
         }
-        std::vector<Value::Type> colsType;
-        for (int64_t i = 0; i <2; i++) {
-            for (int64_t j = 1; j <= 6; j++) {
-                auto type = Value::Type(1UL << j);
-                if (j%2 == 1) {
-                    values.emplace_back(Value(NullType::__NULL__));
-                } else {
-                    values.emplace_back(mockValues[type]);
-                }
-                colsType.emplace_back(type);
+        for (const auto& entry : mockValues) {
+            values.emplace_back(Value(NullType::__NULL__));
+            values.emplace_back(entry.second);
+        }
+        for (int64_t i = 0; i < 2; i++) {
+            for (int64_t j = 0; j < 6; j++) {
+                cols.emplace_back(nullCol(folly::stringPrintf("col_%ld_%ld", i, j), types[j]));
             }
         }
-
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
+        auto raw = IndexKeyUtils::encodeValues(std::move(values), cols);
         u_short s = 0xaaa0; /* the binary is '10101010 10100000'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
@@ -278,14 +297,14 @@ TEST(IndexKeyUtilsTest, nullableValue) {
         ASSERT_EQ(expected, result);
     }
     {
-        std::string raw;
         std::vector<Value> values;
-        std::vector<Value::Type> colsType;
-        for (int64_t i = 0; i <9; i++) {
+        std::vector<nebula::meta::cpp2::ColumnDef> cols;
+        for (int64_t i = 0; i < 9; i++) {
             values.emplace_back(Value(NullType::__NULL__));
-            colsType.emplace_back(Value::Type::BOOL);
+            cols.emplace_back(
+                nullCol(folly::stringPrintf("col%ld", i), meta::cpp2::PropertyType::BOOL));
         }
-        IndexKeyUtils::encodeValuesWithNull(std::move(values), std::move(colsType), raw);
+        auto raw = IndexKeyUtils::encodeValues(std::move(values), std::move(cols));
         u_short s = 0xff80; /* the binary is '11111111 10000000'*/
         std::string expected;
         expected.append(reinterpret_cast<const char*>(&s), sizeof(u_short));
@@ -326,14 +345,6 @@ TEST(IndexKeyUtilsTest, getValueFromIndexKeyTest) {
     Date d = {2020, 1, 20};
     DateTime dt = {2020, 4, 11, 12, 30, 22, 1111};
     auto null = Value(NullType::__NULL__);
-    std::vector<Value::Type> valueTypes = {
-        Value::Type::BOOL,
-        Value::Type::INT,
-        Value::Type::FLOAT,
-        Value::Type::STRING,
-        Value::Type::DATE,
-        Value::Type::DATETIME
-    };
 
     std::vector<meta::cpp2::ColumnDef> cols;
     {
@@ -373,6 +384,47 @@ TEST(IndexKeyUtilsTest, getValueFromIndexKeyTest) {
         col.type.set_type(meta::cpp2::PropertyType::DATETIME);
         cols.emplace_back(col);
     }
+
+    // vertices test without nullable column
+    {
+        std::vector<std::pair<VertexID, std::vector<Value>>> vertices = {
+            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
+            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
+        };
+        auto expected = vertices;
+
+        std::vector<std::string> indexKeys;
+        for (auto& row : vertices) {
+            auto values = IndexKeyUtils::encodeValues(std::move(row.second), cols);
+            indexKeys.emplace_back(IndexKeyUtils::vertexIndexKey(
+                vIdLen, partId, indexId, row.first, std::move(values)));
+        }
+
+        verifyDecodeIndexKey(false, false, vIdLen, expected, indexKeys, cols);
+    }
+
+    // edges test without nullable column
+    {
+        std::vector<std::pair<VertexID, std::vector<Value>>> edges = {
+            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
+            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
+        };
+        auto expected = edges;
+
+        std::vector<std::string> indexKeys;
+        for (auto& row : edges) {
+            auto values = IndexKeyUtils::encodeValues(std::move(row.second), cols);
+            indexKeys.emplace_back(IndexKeyUtils::edgeIndexKey(
+                vIdLen, partId, indexId, row.first, 0, row.first, std::move(values)));
+        }
+
+        verifyDecodeIndexKey(true, false, vIdLen, expected, indexKeys, cols);
+    }
+
+    for (auto& col : cols) {
+        col.set_nullable(true);
+    }
+
     // vertices test with nullable
     {
         std::vector<std::pair<VertexID, std::vector<Value>>> vertices = {
@@ -384,32 +436,17 @@ TEST(IndexKeyUtilsTest, getValueFromIndexKeyTest) {
             {"6", {Value(true), Value(6L), Value(6.1f), null, Value(d), Value(dt)}},
             {"7", {Value(false), Value(7L), Value(7.1f), Value("row7"), null, Value(dt)}},
             {"8", {Value(true), Value(8L), Value(8.1f), Value("row8"), Value(d), null}},
-            {"9", {null, null, null, null, null, null}}
-        };
-        std::vector<std::string> indexKeys;
+            {"9", {null, null, null, null, null, null}}};
+        auto expected = vertices;
 
-        for (const auto& row : vertices) {
+        std::vector<std::string> indexKeys;
+        for (auto& row : vertices) {
+            auto values = IndexKeyUtils::encodeValues(std::move(row.second), cols);
             auto key = IndexKeyUtils::vertexIndexKey(
-                vIdLen, partId, indexId, row.first, row.second, valueTypes);
+                vIdLen, partId, indexId, row.first, std::move(values));
             indexKeys.emplace_back(key);
         }
-        verifyDecodeIndexKey(false, true, vIdLen, vertices, indexKeys, cols);
-    }
-
-    // vertices test without nullable column
-    {
-        std::vector<std::pair<VertexID, std::vector<Value>>> vertices = {
-            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
-            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
-        };
-
-        std::vector<std::string> indexKeys;
-        for (const auto& row : vertices) {
-            indexKeys.emplace_back(IndexKeyUtils::vertexIndexKey(
-                vIdLen, partId, indexId, row.first, row.second, valueTypes));
-        }
-
-        verifyDecodeIndexKey(false, false, vIdLen, vertices, indexKeys, cols);
+        verifyDecodeIndexKey(false, true, vIdLen, expected, indexKeys, cols);
     }
 
     // edges test with nullable
@@ -425,34 +462,20 @@ TEST(IndexKeyUtilsTest, getValueFromIndexKeyTest) {
             {"8", {Value(true), Value(8L), Value(8.1f), Value("row8"), Value(d), null}},
             {"9", {null, null, null, null, null, null}}
         };
-        std::vector<std::string> indexKeys;
+        auto expected = edges;
 
-        for (const auto& row : edges) {
+        std::vector<std::string> indexKeys;
+        for (auto& row : edges) {
+            auto values = IndexKeyUtils::encodeValues(std::move(row.second), cols);
             indexKeys.emplace_back(IndexKeyUtils::edgeIndexKey(
-                vIdLen, partId, indexId, row.first, 0, row.first, row.second, valueTypes));
+                vIdLen, partId, indexId, row.first, 0, row.first, std::move(values)));
         }
 
-        verifyDecodeIndexKey(true, true, vIdLen, edges, indexKeys, cols);
-    }
-
-    // edges test without nullable column
-    {
-        std::vector<std::pair<VertexID, std::vector<Value>>> edges = {
-            {"1", {Value(false), Value(1L), Value(1.1f), Value("row1"), Value(d), Value(dt)}},
-            {"2", {Value(true), Value(2L), Value(2.1f), Value("row2"), Value(d), Value(dt)}},
-        };
-        std::vector<std::string> indexKeys;
-
-        for (const auto& row : edges) {
-            indexKeys.emplace_back(IndexKeyUtils::edgeIndexKey(
-                vIdLen, partId, indexId, row.first, 0, row.first, row.second, valueTypes));
-        }
-
-        verifyDecodeIndexKey(true, false, vIdLen, edges, indexKeys, cols);
+        verifyDecodeIndexKey(true, true, vIdLen, expected, indexKeys, cols);
     }
 }
-}  // namespace nebula
 
+}   // namespace nebula
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Some bug fix and optimization of `IndexKeyUtils`:
1. null string will only encode as one byte, which make index scan not available (same as 1.0), for now we will encode as length of schema.
2. the length of `datetime` is wrong
3. we could support `lookup ... where tag.col == null` in storage
4. reduce one string copy in lookup

Besides, some code in `IndexKeyUtils` has been refactored, e.g. `collectIndexValues`, `vertexIndexKey`, `edgeIndexKey` and `encodeValues`. Previously we need an `colsType` to tell whether index has nullable column, which is unnecessary for now.

