### PR TITLE
bugfix: FlushTask not return the correct error code type. 

### DIFF
--- a/src/storage/admin/AdminTaskManager.cpp
+++ b/src/storage/admin/AdminTaskManager.cpp
@@ -111,10 +111,11 @@ void AdminTaskManager::schedule() {
         auto task = it->second;
         auto errOrSubTasks = task->genSubTasks();
         if (!nebula::ok(errOrSubTasks)) {
-            LOG(ERROR) << "genSubTasks() failed=" << static_cast<int>(nebula::error(errOrSubTasks));
+            auto code = static_cast<int>(nebula::error(errOrSubTasks));
+            LOG(ERROR) << "genSubTasks() failed, err=" << code;
             task->finish(nebula::error(errOrSubTasks));
             tasks_.erase(handle);
-            return;
+            continue;
         }
 
         auto subTasks = nebula::value(errOrSubTasks);

--- a/src/storage/admin/AdminTaskManager.cpp
+++ b/src/storage/admin/AdminTaskManager.cpp
@@ -112,7 +112,8 @@ void AdminTaskManager::schedule() {
         auto errOrSubTasks = task->genSubTasks();
         if (!nebula::ok(errOrSubTasks)) {
             auto code = static_cast<int>(nebula::error(errOrSubTasks));
-            LOG(ERROR) << "genSubTasks() failed, err=" << code;
+            LOG(ERROR) << folly::sformat(
+                "job {}, genSubTask failed, err={}", task->getJobId(), code);
             task->finish(nebula::error(errOrSubTasks));
             tasks_.erase(handle);
             continue;

--- a/src/storage/test/AdminTaskManagerTest.cpp
+++ b/src/storage/test/AdminTaskManagerTest.cpp
@@ -33,8 +33,6 @@ namespace storage {
  *      6.2 cancel_a_task_while_some_sub_task_running
  * */
 
-// using ResultCode = nebula::kvstore::ResultCode;
-using ResultCode = cpp2::ErrorCode;
 using ErrOrSubTasks = ErrorOr<cpp2::ErrorCode, std::vector<AdminSubTask>>;
 
 auto suc = cpp2::ErrorCode::SUCCEEDED;
@@ -208,10 +206,10 @@ TEST(TaskManagerTest, happy_path_task1_sub1) {
 
     mockTask->setJobId(jobId);
     mockTask->setTaskId(jobId);
-    folly::Promise<ResultCode> pTaskFini;
+    folly::Promise<cpp2::ErrorCode> pTaskFini;
     auto fTaskFini = pTaskFini.getFuture();
 
-    auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+    auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
         LOG(INFO) << "taskCallback";
         pTaskFini.setValue(ret);
     };
@@ -248,10 +246,10 @@ TEST(TaskManagerTest, run_a_medium_task_before_a_huge_task) {
 
         mockTask->setJobId(jobId);
         mockTask->setTaskId(jobId);
-        folly::Promise<ResultCode> pro;
-        folly::Future<ResultCode> fut = pro.getFuture();
+        folly::Promise<cpp2::ErrorCode> pro;
+        folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-        auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+        auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
             pro.setValue(ret);
         };
         mockTask->setCallback(taskCallback);
@@ -281,10 +279,10 @@ TEST(TaskManagerTest, happy_path) {
             int jobId = ++gJobId;
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -310,10 +308,10 @@ TEST(TaskManagerTest, happy_path) {
             int jobId = ++gJobId;
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -336,13 +334,13 @@ TEST(TaskManagerTest, happy_path) {
             size_t numSubTask = 3;
             std::shared_ptr<AdminTask> task = std::make_shared<HookableTask>();
             HookableTask* mockTask = dynamic_cast<HookableTask*>(task.get());
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
             int jobId = ++gJobId;
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -368,10 +366,10 @@ TEST(TaskManagerTest, happy_path) {
             int jobId = ++gJobId;
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -396,10 +394,10 @@ TEST(TaskManagerTest, happy_path) {
             int jobId = ++gJobId;
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -424,10 +422,10 @@ TEST(TaskManagerTest, happy_path) {
             int jobId = ++gJobId;
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -453,10 +451,10 @@ TEST(TaskManagerTest, happy_path) {
 
             mockTask->setJobId(jobId);
             mockTask->setTaskId(jobId);
-            folly::Promise<ResultCode> pro;
-            folly::Future<ResultCode> fut = pro.getFuture();
+            folly::Promise<cpp2::ErrorCode> pro;
+            folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-            auto taskCallback = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+            auto taskCallback = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
                 pro.setValue(ret);
             };
             mockTask->setCallback(taskCallback);
@@ -487,10 +485,10 @@ TEST(TaskManagerTest, gen_sub_task_failed) {
             return cpp2::ErrorCode::E_INVALID_TASK_PARA;
         };
 
-        folly::Promise<ResultCode> pro;
-        folly::Future<ResultCode> fut = pro.getFuture();
+        folly::Promise<cpp2::ErrorCode> pro;
+        folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
 
-        auto cb = [&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+        auto cb = [&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
             pro.setValue(ret);
         };
 
@@ -528,15 +526,15 @@ TEST(TaskManagerTest, some_subtask_failed) {
         mockTask->setJobId(jobId);
         mockTask->setTaskId(jobId);
 
-        folly::Promise<ResultCode> pro;
-        folly::Future<ResultCode> fut = pro.getFuture();
+        folly::Promise<cpp2::ErrorCode> pro;
+        folly::Future<cpp2::ErrorCode> fut = pro.getFuture();
         for (size_t i = 0; i < totalSubTask; ++i) {
             mockTask->addSubTask([&]() {
                 ++subTaskCalled;
                 return i == totalSubTask / 2 ? suc : errCode;
             });
         }
-        mockTask->setCallback([&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+        mockTask->setCallback([&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
             pro.setValue(ret);
         });
         taskMgr->addAsyncTask(task);
@@ -561,8 +559,8 @@ TEST(TaskManagerTest, cancel_a_running_task_with_only_1_sub_task) {
     folly::Promise<int> pTaskRun;
     auto fTaskRun = pTaskRun.getFuture();
 
-    folly::Promise<ResultCode> pFinish;
-    folly::Future<ResultCode> fFinish = pFinish.getFuture();
+    folly::Promise<cpp2::ErrorCode> pFinish;
+    folly::Future<cpp2::ErrorCode> fFinish = pFinish.getFuture();
 
     folly::Promise<int> pCancel;
     folly::Future<int> fCancel = pCancel.getFuture();
@@ -575,7 +573,7 @@ TEST(TaskManagerTest, cancel_a_running_task_with_only_1_sub_task) {
         return suc;
     });
 
-    mockTask->setCallback([&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+    mockTask->setCallback([&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
         LOG(INFO) << "task finish()";
         pFinish.setValue(ret);
     });
@@ -600,14 +598,14 @@ TEST(TaskManagerTest, cancel_1_task_in_a_2_tasks_queue) {
 
     auto err = cpp2::ErrorCode::E_USER_CANCEL;
 
-    folly::Promise<ResultCode> pTask1;
+    folly::Promise<cpp2::ErrorCode> pTask1;
     auto fTask1 = pTask1.getFuture();
 
     folly::Promise<int> pRunTask1;
     auto fRunTask1 = pRunTask1.getFuture();
 
-    folly::Promise<ResultCode> pTask2;
-    folly::Future<ResultCode> fTask2 = pTask2.getFuture();
+    folly::Promise<cpp2::ErrorCode> pTask2;
+    folly::Future<cpp2::ErrorCode> fTask2 = pTask2.getFuture();
 
     folly::Promise<int> pCancelTask2;
     folly::Future<int> fCancelTask2 = pCancelTask2.getFuture();
@@ -625,7 +623,7 @@ TEST(TaskManagerTest, cancel_1_task_in_a_2_tasks_queue) {
     task1->addSubTask([&]() {
         return suc;
     });
-    task1->setCallback([&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+    task1->setCallback([&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
         LOG(INFO) << "finish task1()";
         pTask1.setValue(ret);
     });
@@ -637,7 +635,7 @@ TEST(TaskManagerTest, cancel_1_task_in_a_2_tasks_queue) {
     task2->addSubTask([&]() {
         return suc;
     });
-    task2->setCallback([&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+    task2->setCallback([&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
         LOG(INFO) << "finish task2()";
         pTask2.setValue(ret);
     });
@@ -663,7 +661,7 @@ TEST(TaskManagerTest, cancel_a_task_before_all_sub_task_running) {
     auto err = cpp2::ErrorCode::E_USER_CANCEL;
 
     int jobId = ++gJobId;
-    folly::Promise<ResultCode> pFiniTask0;
+    folly::Promise<cpp2::ErrorCode> pFiniTask0;
     auto fFiniTask0 = pFiniTask0.getFuture();
 
     folly::Promise<int> pRunTask;
@@ -687,7 +685,7 @@ TEST(TaskManagerTest, cancel_a_task_before_all_sub_task_running) {
         return suc;
     });
 
-    task0->setCallback([&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+    task0->setCallback([&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
         pFiniTask0.setValue(ret);
     });
 
@@ -706,14 +704,69 @@ TEST(TaskManagerTest, cancel_a_task_before_all_sub_task_running) {
     taskMgr->shutdown();
 }
 
+TEST(TaskManagerTest, task_run_after_a_gen_sub_task_failed) {
+    auto taskMgr = AdminTaskManager::instance();
+    taskMgr->init();
+
+    std::shared_ptr<AdminTask> vtask1 = std::make_shared<HookableTask>();
+    std::shared_ptr<AdminTask> vtask2 = std::make_shared<HookableTask>();
+
+    HookableTask* task1 = dynamic_cast<HookableTask*>(vtask1.get());
+    HookableTask* task2 = dynamic_cast<HookableTask*>(vtask2.get());
+
+    task1->setJobId(++gJobId);
+    task2->setJobId(++gJobId);
+
+    folly::Promise<int> p0;
+    folly::Promise<int> p1;
+    folly::Promise<int> p2;
+
+    auto f0 = p0.getFuture();
+    auto f1 = p1.getFuture();
+    auto f2 = p2.getFuture();
+
+    task1->fGenSubTasks = [&]() mutable {
+        LOG(INFO) << "before f1.wait()";
+        f1.wait();
+        LOG(INFO) << "after f1.wait()";
+        return cpp2::ErrorCode::E_INVALID_TASK_PARA;
+    };
+    task1->setCallback([&](cpp2::ErrorCode, nebula::meta::cpp2::StatisItem&){
+        LOG(INFO) << "before p2.setValue()";
+        p2.setValue(1);
+        LOG(INFO) << "after p2.setValue()";
+    });
+    task2->addSubTask([&]() mutable {
+        LOG(INFO) << "before f2.wait()";
+        f2.wait();
+        LOG(INFO) << "after f2.wait()";
+        return cpp2::ErrorCode::SUCCEEDED;
+    });
+    task2->setCallback([&](cpp2::ErrorCode, nebula::meta::cpp2::StatisItem&){
+        LOG(INFO) << "before p0.setValue()";
+        p0.setValue(1);
+        LOG(INFO) << "after p0.setValue()";
+    });
+
+    taskMgr->addAsyncTask(vtask1);
+    taskMgr->addAsyncTask(vtask2);
+    p1.setValue(1);
+
+    LOG(INFO) << "before p0.setValue()";
+    f0.wait();
+    LOG(INFO) << "after p0.setValue()";
+
+    taskMgr->shutdown();
+}
+
 TEST(TaskManagerTest, cancel_a_task_while_some_sub_task_running) {
     auto taskMgr = AdminTaskManager::instance();
     taskMgr->init();
     auto usr_cancel = cpp2::ErrorCode::E_USER_CANCEL;
     int jobId = ++gJobId;
 
-    folly::Promise<ResultCode> task1_p;
-    folly::Future<ResultCode> task1_f = task1_p.getFuture();
+    folly::Promise<cpp2::ErrorCode> task1_p;
+    folly::Future<cpp2::ErrorCode> task1_f = task1_p.getFuture();
 
     folly::Promise<int> cancle_p;
     folly::Future<int> cancel = cancle_p.getFuture();
@@ -738,7 +791,7 @@ TEST(TaskManagerTest, cancel_a_task_while_some_sub_task_running) {
         return suc;
     });
 
-    task1->setCallback([&](ResultCode ret, nebula::meta::cpp2::StatisItem&) {
+    task1->setCallback([&](cpp2::ErrorCode ret, nebula::meta::cpp2::StatisItem&) {
         task1_p.setValue(ret);
     });
 


### PR DESCRIPTION
in FlushTask, if param spaceId is invalid. 
will return a kvstore::ResultCode

then use this(as an int, which is negative) to ctor a ErrorOr<cpp2::ErrorCode, std::vector<...>>

ResultCode will implicit as a really big size_t to ctor vector, 

which throw a bad_alloc exception. 

as the EitherOr class is noexcept, core.