### PR TITLE
fix FlushTask not return correct error code

### DIFF
--- a/src/kvstore/Common.h
+++ b/src/kvstore/Common.h
@@ -16,7 +16,7 @@
 namespace nebula {
 namespace kvstore {
 
-enum ResultCode {
+enum class ResultCode {
     SUCCEEDED               = 0,
     ERR_SPACE_NOT_FOUND     = -1,
     ERR_PART_NOT_FOUND      = -2,
@@ -44,6 +44,10 @@ enum ResultCode {
     ERR_PARTIAL_RESULT      = -99,
     ERR_UNKNOWN             = -100,
 };
+
+inline std::ostream& operator <<(std::ostream& os, const ResultCode& rc) {
+    return os << static_cast<int32_t>(rc);
+}
 
 class KVFilter {
 public:

--- a/src/meta/processors/jobMan/JobDescription.cpp
+++ b/src/meta/processors/jobMan/JobDescription.cpp
@@ -181,7 +181,7 @@ JobDescription::loadJobDescription(JobID iJob, nebula::kvstore::KVStore* kv) {
     auto key = makeJobKey(iJob);
     std::string val;
     auto rc = kv->get(0, 0, key, &val);
-    if (rc != nebula::kvstore::SUCCEEDED) {
+    if (rc != nebula::kvstore::ResultCode::SUCCEEDED) {
         LOG(ERROR) << "Loading Job Description Failed";
         return folly::none;
     }

--- a/src/meta/processors/jobMan/JobManager.cpp
+++ b/src/meta/processors/jobMan/JobManager.cpp
@@ -160,7 +160,7 @@ bool JobManager::runJobInternal(const JobDescription& jobDesc) {
 
 cpp2::ErrorCode JobManager::addJob(const JobDescription& jobDesc, AdminClient* client) {
     auto rc = save(jobDesc.jobKey(), jobDesc.jobVal());
-    if (rc == nebula::kvstore::SUCCEEDED) {
+    if (rc == nebula::kvstore::ResultCode::SUCCEEDED) {
         queue_->enqueue(jobDesc.getJobId());
     } else {
         LOG(ERROR) << "Add Job Failed";
@@ -175,7 +175,7 @@ JobManager::showJobs() {
     std::unique_ptr<kvstore::KVIterator> iter;
     ResultCode rc = kvStore_->prefix(kDefaultSpaceId, kDefaultPartId,
                                      JobUtil::jobPrefix(), &iter);
-    if (rc != nebula::kvstore::SUCCEEDED) {
+    if (rc != nebula::kvstore::ResultCode::SUCCEEDED) {
         return cpp2::ErrorCode::E_STORE_FAILURE;
     }
 
@@ -238,7 +238,7 @@ JobManager::showJob(JobID iJob) {
     auto jobKey = JobDescription::makeJobKey(iJob);
     std::unique_ptr<kvstore::KVIterator> iter;
     auto rc = kvStore_->prefix(kDefaultSpaceId, kDefaultPartId, jobKey, &iter);
-    if (rc != nebula::kvstore::SUCCEEDED) {
+    if (rc != nebula::kvstore::ResultCode::SUCCEEDED) {
         return cpp2::ErrorCode::E_STORE_FAILURE;
     }
 
@@ -277,7 +277,7 @@ cpp2::ErrorCode JobManager::stopJob(JobID iJob) {
 
     jobDesc->setStatus(cpp2::JobStatus::STOPPED);
     auto rc = save(jobDesc->jobKey(), jobDesc->jobVal());
-    if (rc != nebula::kvstore::SUCCEEDED) {
+    if (rc != nebula::kvstore::ResultCode::SUCCEEDED) {
         return cpp2::ErrorCode::E_SAVE_JOB_FAILURE;
     }
 
@@ -291,7 +291,7 @@ ErrorOr<cpp2::ErrorCode, JobID> JobManager::recoverJob() {
     int32_t recoveredJobNum = 0;
     std::unique_ptr<kvstore::KVIterator> iter;
     auto rc = kvStore_->prefix(kDefaultSpaceId, kDefaultPartId, JobUtil::jobPrefix(), &iter);
-    if (rc != nebula::kvstore::SUCCEEDED) {
+    if (rc != nebula::kvstore::ResultCode::SUCCEEDED) {
         LOG(ERROR) << "Can't find jobs";
         return cpp2::ErrorCode::E_NOT_FOUND;
     }
@@ -314,7 +314,7 @@ ErrorOr<cpp2::ErrorCode, JobID> JobManager::recoverJob() {
 ResultCode JobManager::save(const std::string& k, const std::string& v) {
     std::vector<kvstore::KV> data{std::make_pair(k, v)};
     folly::Baton<true, std::atomic> baton;
-    nebula::kvstore::ResultCode rc = nebula::kvstore::SUCCEEDED;
+    auto rc = nebula::kvstore::ResultCode::SUCCEEDED;
     kvStore_->asyncMultiPut(kDefaultSpaceId, kDefaultPartId, std::move(data),
                             [&] (nebula::kvstore::ResultCode code) {
                                 rc = code;

--- a/src/meta/processors/jobMan/StatisJobExecutor.cpp
+++ b/src/meta/processors/jobMan/StatisJobExecutor.cpp
@@ -21,7 +21,7 @@ kvstore::ResultCode
 StatisJobExecutor::save(const std::string& key, const std::string& val) {
     std::vector<kvstore::KV> data{std::make_pair(key, val)};
     folly::Baton<true, std::atomic> baton;
-    nebula::kvstore::ResultCode rc = nebula::kvstore::SUCCEEDED;
+    auto rc = nebula::kvstore::ResultCode::SUCCEEDED;
     kvstore_->asyncMultiPut(kDefaultSpaceId, kDefaultPartId, std::move(data),
                             [&] (nebula::kvstore::ResultCode code) {
                                 rc = code;

--- a/src/meta/test/GetStatisTest.cpp
+++ b/src/meta/test/GetStatisTest.cpp
@@ -57,7 +57,7 @@ TEST_F(GetStatisTest, StatisJob) {
     JobDescription statisJob(12, cpp2::AdminCmd::STATIS, paras);
     jobMgr->adminClient_ = adminClient_.get();
     auto rc = jobMgr->save(statisJob.jobKey(), statisJob.jobVal());
-    ASSERT_EQ(rc, nebula::kvstore::SUCCEEDED);
+    ASSERT_EQ(rc, nebula::kvstore::ResultCode::SUCCEEDED);
 
     {
         // Job is not executed, job status is QUEUE.
@@ -84,7 +84,7 @@ TEST_F(GetStatisTest, StatisJob) {
         auto res = job1->setStatus(cpp2::JobStatus::RUNNING);
         ASSERT_TRUE(res);
         auto retsav = jobMgr->save(job1->jobKey(), job1->jobVal());
-        ASSERT_EQ(retsav, nebula::kvstore::SUCCEEDED);
+        ASSERT_EQ(retsav, nebula::kvstore::ResultCode::SUCCEEDED);
     }
 
     // Run statis job, job finished.
@@ -136,7 +136,7 @@ TEST_F(GetStatisTest, StatisJob) {
     std::vector<std::string> paras1{"test_space"};
     JobDescription statisJob2(13, cpp2::AdminCmd::STATIS, paras1);
     auto rc2 = jobMgr->save(statisJob2.jobKey(), statisJob2.jobVal());
-    ASSERT_EQ(rc2, nebula::kvstore::SUCCEEDED);
+    ASSERT_EQ(rc2, nebula::kvstore::ResultCode::SUCCEEDED);
     {
         // Job is not executed, job status is QUEUE.
         // Statis data exists, but it is the result of the last statis job execution.
@@ -177,7 +177,7 @@ TEST_F(GetStatisTest, StatisJob) {
         auto res = job1->setStatus(cpp2::JobStatus::RUNNING);
         ASSERT_TRUE(res);
         auto retsav = jobMgr->save(job1->jobKey(), job1->jobVal());
-        ASSERT_EQ(retsav, nebula::kvstore::SUCCEEDED);
+        ASSERT_EQ(retsav, nebula::kvstore::ResultCode::SUCCEEDED);
     }
 
     // Remove statis data.

--- a/src/storage/admin/FlushTask.cpp
+++ b/src/storage/admin/FlushTask.cpp
@@ -20,7 +20,7 @@ FlushTask::genSubTasks() {
     auto* store = dynamic_cast<kvstore::NebulaStore*>(env_->kvstore_);
     auto errOrSpace = store->space(ctx_.parameters_.space_id);
     if (!ok(errOrSpace)) {
-        return error(errOrSpace);
+        return toStorageErr(error(errOrSpace));
     }
 
     auto space = nebula::value(errOrSpace);

--- a/src/storage/test/KVTest.cpp
+++ b/src/storage/test/KVTest.cpp
@@ -52,7 +52,7 @@ TEST(KVTest, SimpleTest) {
             std::string value;
             auto code = cluster.storageKV_->get(space, part, key, &value);
             EXPECT_EQ(folly::stringPrintf("value_%ld", part), value);
-            EXPECT_EQ(nebula::kvstore::SUCCEEDED, code);
+            EXPECT_EQ(nebula::kvstore::ResultCode::SUCCEEDED, code);
         }
     }
     {
@@ -68,7 +68,7 @@ TEST(KVTest, SimpleTest) {
                                               folly::stringPrintf("key_%ld", part));
             std::string value;
             auto code = cluster.storageKV_->get(space, part, key, &value);
-            EXPECT_EQ(nebula::kvstore::ERR_KEY_NOT_FOUND, code);
+            EXPECT_EQ(nebula::kvstore::ResultCode::ERR_KEY_NOT_FOUND, code);
         }
     }
 }


### PR DESCRIPTION
in FlushTask, if param spaceId is invalid. will return a kvstore::ResultCode
then use this(as an int, which is negative) to ctor a ErrorOr<cpp2::ErrorCode, std::vector<...>>
ResultCode will implicit as a really big size_t to ctor vector,
which throw a bad_alloc exception.
as the EitherOr class is noexcept, core.

also 

change type ResultCode from Enum to enum class, in case of any implicit error like this. 
