### PR TITLE
Unify all storage interface behavior

### DIFF
--- a/src/codec/RowReaderWrapper.cpp
+++ b/src/codec/RowReaderWrapper.cpp
@@ -117,6 +117,7 @@ bool RowReaderWrapper::reset(meta::SchemaProviderIf const* schema,
 
 bool RowReaderWrapper::reset(meta::SchemaProviderIf const* schema,
                              folly::StringPiece row) noexcept {
+    currReader_ = nullptr;
     if (schema == nullptr) {
         return false;
     }
@@ -132,6 +133,7 @@ bool RowReaderWrapper::reset(meta::SchemaProviderIf const* schema,
 bool RowReaderWrapper::reset(
         const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas,
         folly::StringPiece row) noexcept {
+    currReader_ = nullptr;
     SchemaVer schemaVer;
     int32_t readerVer;
     RowReaderWrapper::getVersions(row, schemaVer, readerVer);

--- a/src/storage/context/StorageExpressionContext.cpp
+++ b/src/storage/context/StorageExpressionContext.cpp
@@ -40,24 +40,9 @@ Value StorageExpressionContext::getTagProp(const std::string& tagName,
     if (isIndex_) {
         return getIndexValue(prop, false);
     }
-    if (reader_ != nullptr) {
-        if (tagName != name_) {
-            return Value::kNullValue;
-        }
-        if (prop == kVid) {
-            auto vId = NebulaKeyUtils::getVertexId(vIdLen_, key_);
-            return isIntId_ ? vId.toString() : vId.subpiece(0, vId.find_first_of('\0')).toString();
-        } else {
-            return readValue(prop);
-        }
-    } else {
-        auto iter = tagFilters_.find(std::make_pair(tagName, prop));
-        if (iter == tagFilters_.end()) {
-            return Value::kNullValue;
-        }
-        return iter->second;
-    }
+    return getSrcProp(tagName, prop);
 }
+
 // Get the specified property from the edge, such as edgename.prop_name
 Value StorageExpressionContext::getEdgeProp(const std::string& edgeName,
                                             const std::string& prop) const {
@@ -101,7 +86,14 @@ Value StorageExpressionContext::getSrcProp(const std::string& tagName,
         if (tagName != name_) {
             return Value::kNullValue;
         }
-        return readValue(prop);
+        if (prop == kVid) {
+            auto vId = NebulaKeyUtils::getVertexId(vIdLen_, key_);
+            return isIntId_ ? vId.toString() : vId.subpiece(0, vId.find_first_of('\0')).toString();
+        } else if (prop == kTag) {
+            return NebulaKeyUtils::getTagId(vIdLen_, key_);
+        } else {
+            return readValue(prop);
+        }
     } else {
         auto iter = tagFilters_.find(std::make_pair(tagName, prop));
         if (iter == tagFilters_.end()) {

--- a/src/storage/exec/EdgeNode.h
+++ b/src/storage/exec/EdgeNode.h
@@ -26,11 +26,11 @@ public:
     }
 
     kvstore::ResultCode collectEdgePropsIfValid(NullHandler nullHandler,
-                                                EdgePropHandler valueHandler) {
+                                                PropHandler valueHandler) {
         if (!iter_ || !iter_->valid()) {
             return nullHandler(props_);
         }
-        return valueHandler(edgeType_, iter_->key(), iter_->reader(), props_);
+        return valueHandler(iter_->key(), iter_->reader(), props_);
     }
 
     bool valid() const override {

--- a/src/storage/exec/EdgeNode.h
+++ b/src/storage/exec/EdgeNode.h
@@ -65,7 +65,7 @@ protected:
              EdgeContext* ctx,
              EdgeType edgeType,
              const std::vector<PropContext>* props,
-             ExpressionContext* expCtx,
+             StorageExpressionContext* expCtx,
              Expression* exp)
         : planContext_(planCtx)
         , edgeContext_(ctx)
@@ -91,7 +91,7 @@ protected:
     EdgeContext* edgeContext_;
     EdgeType edgeType_;
     const std::vector<PropContext>* props_;
-    ExpressionContext* expCtx_;
+    StorageExpressionContext* expCtx_;
     Expression* exp_;
 
     const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>* schemas_ = nullptr;
@@ -111,7 +111,7 @@ public:
                   EdgeContext* ctx,
                   EdgeType edgeType,
                   const std::vector<PropContext>* props,
-                  ExpressionContext* expCtx = nullptr,
+                  StorageExpressionContext* expCtx = nullptr,
                   Expression* exp = nullptr)
         : EdgeNode(planCtx, ctx, edgeType, props, expCtx, exp) {}
 
@@ -160,7 +160,7 @@ public:
                    EdgeContext* ctx,
                    EdgeType edgeType,
                    const std::vector<PropContext>* props,
-                   ExpressionContext* expCtx = nullptr,
+                   StorageExpressionContext* expCtx = nullptr,
                    Expression* exp = nullptr)
         : EdgeNode(planCtx, ctx, edgeType, props, expCtx, exp) {}
 

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -95,14 +95,9 @@ protected:
 
             list.reserve(props->size());
             // collect props need to return
-            auto ret = collectEdgeProps(reader,
-                                        key,
-                                        planContext_->vIdLen_,
-                                        planContext_->isIntId_,
-                                        props,
-                                        list);
-            if (ret != kvstore::ResultCode::SUCCEEDED) {
-                return ret;
+            if (!QueryUtils::collectEdgeProps(key, planContext_->vIdLen_, planContext_->isIntId_,
+                                              reader, props, list).ok()) {
+                return kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND;
             }
 
             // add edge prop value to the target column
@@ -163,7 +158,7 @@ private:
             }
 
             auto edgeType = std::get<0>(sample);
-            auto val = std::get<1>(sample);
+            const auto& val = std::get<1>(sample);
             reader = RowReaderWrapper::getEdgePropReader(planContext_->env_->schemaMan_,
                                                          planContext_->spaceId_,
                                                          std::abs(edgeType),
@@ -172,14 +167,11 @@ private:
                 continue;
             }
 
-            auto ret = collectEdgeProps(reader.get(),
-                                        std::get<2>(sample),
-                                        planContext_->vIdLen_,
-                                        planContext_->isIntId_,
-                                        std::get<3>(sample),
-                                        list);
-            if (ret != kvstore::ResultCode::SUCCEEDED) {
-                continue;
+            const auto& key = std::get<2>(sample);
+            const auto& props = std::get<3>(sample);
+            if (!QueryUtils::collectEdgeProps(key, planContext_->vIdLen_, planContext_->isIntId_,
+                                              reader.get(), props, list).ok()) {
+                return kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND;
             }
             auto& cell = row[columnIdx].mutableList();
             cell.values.emplace_back(std::move(list));

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -42,6 +42,8 @@ public:
         }
 
         List row;
+        // vertexId is the first column
+        row.emplace_back(vId);
         auto vIdLen = planContext_->vIdLen_;
         auto isIntId = planContext_->isIntId_;
         for (auto* tagNode : tagNodes_) {

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -41,13 +41,12 @@ public:
             return ret;
         }
 
-        std::vector<Value> row;
-        // vertexId is the first column
-        row.emplace_back(vId);
+        List row;
+        auto vIdLen = planContext_->vIdLen_;
+        auto isIntId = planContext_->isIntId_;
         for (auto* tagNode : tagNodes_) {
-            const auto& tagName = tagNode->getTagName();
             ret = tagNode->collectTagPropsIfValid(
-                [&row] (const std::vector<PropContext>* props) -> kvstore::ResultCode {
+                [&row](const std::vector<PropContext>* props) -> kvstore::ResultCode {
                     for (const auto& prop : *props) {
                         if (prop.returned_) {
                             row.emplace_back(Value());
@@ -55,21 +54,13 @@ public:
                     }
                     return kvstore::ResultCode::SUCCEEDED;
                 },
-                [this, &row, &tagName] (TagID tagId,
-                                        RowReader* reader,
-                                        const std::vector<PropContext>* props)
+                [&row, vIdLen, isIntId] (folly::StringPiece key,
+                                         RowReader* reader,
+                                         const std::vector<PropContext>* props)
                 -> kvstore::ResultCode {
-                    nebula::List list;
-                    auto code = collectTagProps(tagId,
-                                                tagName,
-                                                reader,
-                                                props,
-                                                list);
-                    if (code != kvstore::ResultCode::SUCCEEDED) {
-                        return code;
-                    }
-                    for (auto& col : list.values) {
-                        row.emplace_back(std::move(col));
+                    if (!QueryUtils::collectVertexProps(key, vIdLen, isIntId,
+                                                        reader, props, row).ok()) {
+                        return kvstore::ResultCode::ERR_TAG_PROP_NOT_FOUND;
                     }
                     return kvstore::ResultCode::SUCCEEDED;
                 });
@@ -91,13 +82,11 @@ class GetEdgePropNode : public QueryNode<cpp2::EdgeKey> {
 public:
     using RelNode::execute;
 
-    GetEdgePropNode(std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes,
-                    size_t vIdLen,
-                    bool isIntId,
+    GetEdgePropNode(PlanContext *planCtx,
+                    std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes,
                     nebula::DataSet* resultDataSet)
-        : edgeNodes_(std::move(edgeNodes))
-        , vIdLen_(vIdLen)
-        , isIntId_(isIntId)
+        : planContext_(planCtx)
+        , edgeNodes_(std::move(edgeNodes))
         , resultDataSet_(resultDataSet) {}
 
     kvstore::ResultCode execute(PartitionID partId, const cpp2::EdgeKey& edgeKey) override {
@@ -106,7 +95,9 @@ public:
             return ret;
         }
 
-        std::vector<Value> row;
+        List row;
+        auto vIdLen = planContext_->vIdLen_;
+        auto isIntId = planContext_->isIntId_;
         for (auto* edgeNode : edgeNodes_) {
             ret = edgeNode->collectEdgePropsIfValid(
                 [&row] (const std::vector<PropContext>* props) -> kvstore::ResultCode {
@@ -117,24 +108,13 @@ public:
                     }
                     return kvstore::ResultCode::SUCCEEDED;
                 },
-                [this, &row] (EdgeType edgeType,
-                              folly::StringPiece key,
-                              RowReader* reader,
-                              const std::vector<PropContext>* props)
+                [&row, vIdLen, isIntId] (folly::StringPiece key,
+                                         RowReader* reader,
+                                         const std::vector<PropContext>* props)
                 -> kvstore::ResultCode {
-                    UNUSED(edgeType);
-                    nebula::List list;
-                    auto code = collectEdgeProps(reader,
-                                                 key,
-                                                 vIdLen_,
-                                                 isIntId_,
-                                                 props,
-                                                 list);
-                    if (code != kvstore::ResultCode::SUCCEEDED) {
-                        return code;
-                    }
-                    for (auto& col : list.values) {
-                        row.emplace_back(std::move(col));
+                    if (!QueryUtils::collectEdgeProps(key, vIdLen, isIntId,
+                                                      reader, props, row).ok()) {
+                        return kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND;
                     }
                     return kvstore::ResultCode::SUCCEEDED;
                 });
@@ -147,9 +127,8 @@ public:
     }
 
 private:
+    PlanContext          *planContext_;
     std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes_;
-    size_t vIdLen_;
-    bool isIntId_;
     nebula::DataSet* resultDataSet_;
 };
 

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -57,18 +57,19 @@ public:
 
         // add result of each tag node to tagResult
         for (auto* tagNode : tagNodes_) {
-            const auto& tagName = tagNode->getTagName();
             ret = tagNode->collectTagPropsIfValid(
                 [&result] (const std::vector<PropContext>*) -> kvstore::ResultCode {
                     result.values.emplace_back(Value());
                     return kvstore::ResultCode::SUCCEEDED;
                 },
-                [this, &result, &tagName] (folly::StringPiece key,
-                                           RowReader* reader,
-                                           const std::vector<PropContext>* props)
+                [this, &vId, &result, tagNode] (folly::StringPiece key,
+                                                RowReader* reader,
+                                                const std::vector<PropContext>* props)
                 -> kvstore::ResultCode {
                     nebula::List list;
                     list.reserve(props->size());
+                    const auto& tagName = tagNode->getTagName();
+                    auto tagId = tagNode->getTagId();
                     for (const auto& prop : *props) {
                         VLOG(2) << "Collect prop " << prop.name_;
                         auto value = QueryUtils::readVertexProp(
@@ -82,6 +83,10 @@ public:
                         if (prop.returned_) {
                             list.emplace_back(std::move(value).value());
                         }
+                    }
+                    if (FLAGS_enable_vertex_cache && tagContext_->vertexCache_ != nullptr) {
+                        tagContext_->vertexCache_->insert(std::make_pair(vId, tagId),
+                                                          reader->getData());
                     }
                     result.values.emplace_back(std::move(list));
                     return kvstore::ResultCode::SUCCEEDED;

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -67,25 +67,23 @@ public:
                                            RowReader* reader,
                                            const std::vector<PropContext>* props)
                 -> kvstore::ResultCode {
-                    /*
                     nebula::List list;
-                    auto code = collectTagProps(tagId,
-                                                tagName,
-                                                reader,
-                                                props,
-                                                list,
-                                                expCtx_);
-                    if (code != kvstore::ResultCode::SUCCEEDED) {
-                        return code;
+                    list.reserve(props->size());
+                    for (const auto& prop : *props) {
+                        VLOG(2) << "Collect prop " << prop.name_;
+                        auto value = QueryUtils::readVertexProp(
+                            key, planContext_->vIdLen_, planContext_->isIntId_, reader, prop);
+                        if (!value.ok()) {
+                            return kvstore::ResultCode::ERR_TAG_PROP_NOT_FOUND;
+                        }
+                        if (prop.filtered_ && expCtx_ != nullptr) {
+                            expCtx_->setTagProp(tagName, prop.name_, value.value());
+                        }
+                        if (prop.returned_) {
+                            list.emplace_back(std::move(value).value());
+                        }
                     }
                     result.values.emplace_back(std::move(list));
-                    */
-                    UNUSED(key);
-                    UNUSED(reader);
-                    UNUSED(props);
-                    UNUSED(result);
-                    UNUSED(tagName);
-                    UNUSED(expCtx_);
                     return kvstore::ResultCode::SUCCEEDED;
                 });
             if (ret != kvstore::ResultCode::SUCCEEDED) {

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -63,10 +63,11 @@ public:
                     result.values.emplace_back(Value());
                     return kvstore::ResultCode::SUCCEEDED;
                 },
-                [this, &result, &tagName] (TagID tagId,
+                [this, &result, &tagName] (folly::StringPiece key,
                                            RowReader* reader,
                                            const std::vector<PropContext>* props)
                 -> kvstore::ResultCode {
+                    /*
                     nebula::List list;
                     auto code = collectTagProps(tagId,
                                                 tagName,
@@ -78,6 +79,13 @@ public:
                         return code;
                     }
                     result.values.emplace_back(std::move(list));
+                    */
+                    UNUSED(key);
+                    UNUSED(reader);
+                    UNUSED(props);
+                    UNUSED(result);
+                    UNUSED(tagName);
+                    UNUSED(expCtx_);
                     return kvstore::ResultCode::SUCCEEDED;
                 });
             if (ret != kvstore::ResultCode::SUCCEEDED) {

--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -91,17 +91,67 @@ public:
                     dstId.toString() :
                     dstId.subpiece(0, dstId.find_first_of('\0')).toString();
             }
+            default:
+                LOG(FATAL) << "Should not read here";
         }
         return Status::Error(folly::stringPrintf("Invalid property %s", prop.name_.c_str()));
     }
 
-    static Status collectPropsInValue(RowReader* reader,
-                                      const std::vector<PropContext>* props,
-                                      nebula::List& list) {
+    static StatusOr<nebula::Value> readVertexProp(folly::StringPiece key,
+                                                  size_t vIdLen,
+                                                  bool isIntId,
+                                                  RowReader* reader,
+                                                  const PropContext& prop) {
+        switch (prop.propInKeyType_) {
+            // prop in value
+            case PropContext::PropInKeyType::NONE: {
+                return readValue(reader, prop.name_, prop.field_);
+            }
+            case PropContext::PropInKeyType::VID: {
+                auto srcId = NebulaKeyUtils::getVertexId(vIdLen, key);
+                return isIntId ?
+                    srcId.toString() :
+                    srcId.subpiece(0, srcId.find_first_of('\0')).toString();
+            }
+            case PropContext::PropInKeyType::TAG: {
+                auto tag = NebulaKeyUtils::getTagId(vIdLen, key);
+                return tag;
+            }
+            default:
+                LOG(FATAL) << "Should not read here";
+        }
+        return Status::Error(folly::stringPrintf("Invalid property %s", prop.name_.c_str()));
+    }
+
+    static Status collectVertexProps(folly::StringPiece key,
+                                     size_t vIdLen,
+                                     bool isIntId,
+                                     RowReader* reader,
+                                     const std::vector<PropContext>* props,
+                                     nebula::List& list) {
         for (const auto& prop : *props) {
-            if (prop.returned_ && prop.propInKeyType_ == PropContext::PropInKeyType::NONE) {
+            if (prop.returned_) {
                 VLOG(2) << "Collect prop " << prop.name_;
-                auto value = QueryUtils::readValue(reader, prop.name_, prop.field_);
+                auto value = QueryUtils::readVertexProp(key, vIdLen, isIntId, reader, prop);
+                if (!value.ok()) {
+                    return value.status();
+                }
+                list.emplace_back(std::move(value).value());
+            }
+        }
+        return Status::OK();
+    }
+
+    static Status collectEdgeProps(folly::StringPiece key,
+                                   size_t vIdLen,
+                                   bool isIntId,
+                                   RowReader* reader,
+                                   const std::vector<PropContext>* props,
+                                   nebula::List& list) {
+        for (const auto& prop : *props) {
+            if (prop.returned_) {
+                VLOG(2) << "Collect prop " << prop.name_;
+                auto value = QueryUtils::readEdgeProp(key, vIdLen, isIntId, reader, prop);
                 if (!value.ok()) {
                     return value.status();
                 }

--- a/src/storage/exec/StorageIterator.h
+++ b/src/storage/exec/StorageIterator.h
@@ -103,18 +103,15 @@ protected:
     // return true when the value iter to a valid edge value
     bool check() {
         reader_.reset();
-        if (FLAGS_enable_multi_versions) {
-            auto key = iter_->key();
-            auto rank = NebulaKeyUtils::getRank(planContext_->vIdLen_, key);
-            auto dstId = NebulaKeyUtils::getDstId(planContext_->vIdLen_, key);
-            if (!firstLoop_ && rank == lastRank_ && lastDstId_ == dstId) {
-                // pass old version data of same edge
-                return false;
-            }
-            firstLoop_ = false;
-            lastRank_ = rank;
-            lastDstId_ = dstId.str();
+        auto key = iter_->key();
+        auto rank = NebulaKeyUtils::getRank(planContext_->vIdLen_, key);
+        auto dstId = NebulaKeyUtils::getDstId(planContext_->vIdLen_, key);
+        if (rank == lastRank_ && lastDstId_ == dstId) {
+            // pass old version data of same edge
+            return false;
         }
+        lastRank_ = rank;
+        lastDstId_ = dstId.str();
 
         auto val = iter_->val();
         reader_.reset(*schemas_, val);
@@ -145,7 +142,6 @@ protected:
     RowReaderWrapper                                                      reader_;
     EdgeRanking                                                           lastRank_ = 0;
     VertexID                                                              lastDstId_ = "";
-    bool                                                                  firstLoop_ = true;
 };
 
 // Iterator of multiple SingleEdgeIterator, it will iterate over edges of different types

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -71,11 +71,11 @@ public:
     }
 
     kvstore::ResultCode collectTagPropsIfValid(NullHandler nullHandler,
-                                               TagPropHandler valueHandler) {
+                                               PropHandler valueHandler) {
         if (!iter_ || !iter_->valid()) {
             return nullHandler(props_);
         }
-        return valueHandler(tagId_, iter_->reader(), props_);
+        return valueHandler(iter_->key(), iter_->reader(), props_);
     }
 
     bool valid() const override {
@@ -101,6 +101,7 @@ public:
         return nullptr;
     }
 
+    // doodle: do we need it?
     const std::string& getTagName() {
         return tagName_;
     }

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -41,6 +41,7 @@ public:
     }
 
     kvstore::ResultCode execute(PartitionID partId, const VertexID& vId) override {
+        reader_.reset();
         auto ret = RelNode::execute(partId, vId);
         if (ret != kvstore::ResultCode::SUCCEEDED) {
             return ret;

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -101,7 +101,6 @@ public:
         return nullptr;
     }
 
-    // doodle: do we need it?
     const std::string& getTagName() {
         return tagName_;
     }

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -23,7 +23,7 @@ public:
             TagContext* ctx,
             TagID tagId,
             const std::vector<PropContext>* props,
-            ExpressionContext* expCtx = nullptr,
+            StorageExpressionContext* expCtx = nullptr,
             Expression* exp = nullptr)
         : planContext_(planCtx)
         , tagContext_(ctx)
@@ -50,75 +50,94 @@ public:
 
         // when update, has already evicted
         if (FLAGS_enable_vertex_cache && tagContext_->vertexCache_ != nullptr) {
-            auto result = tagContext_->vertexCache_->get(std::make_pair(vId, tagId_));
-            if (result.ok()) {
-                cacheResult_ = std::move(result).value();
-                iter_.reset(new SingleTagIterator(planContext_, cacheResult_, schemas_, &ttl_));
-                return kvstore::ResultCode::SUCCEEDED;
+            auto cache = tagContext_->vertexCache_->get(std::make_pair(vId, tagId_));
+            if (cache.ok()) {
+                key_ = NebulaKeyUtils::vertexKey(planContext_->vIdLen_, partId, vId, tagId_, 0L);
+                value_ = std::move(cache.value());
+                // if data in vertex cache is valid, don't read from kv
+                if (resetReader(vId)) {
+                    return kvstore::ResultCode::SUCCEEDED;
+                }
             }
         }
 
         std::unique_ptr<kvstore::KVIterator> iter;
-        prefix_ = NebulaKeyUtils::vertexPrefix(planContext_->vIdLen_, partId, vId, tagId_);
-        ret = planContext_->env_->kvstore_->prefix(planContext_->spaceId_, partId, prefix_, &iter);
+        auto prefix = NebulaKeyUtils::vertexPrefix(planContext_->vIdLen_, partId, vId, tagId_);
+        ret = planContext_->env_->kvstore_->prefix(planContext_->spaceId_, partId, prefix, &iter);
         if (ret == kvstore::ResultCode::SUCCEEDED && iter && iter->valid()) {
-            iter_.reset(new SingleTagIterator(planContext_, std::move(iter), tagId_,
-                                              schemas_, &ttl_));
-        } else {
-            iter_.reset();
+            key_ = iter->key().str();
+            value_ = iter->val().str();
+            resetReader(vId);
+            return kvstore::ResultCode::SUCCEEDED;
         }
         return ret;
     }
 
     kvstore::ResultCode collectTagPropsIfValid(NullHandler nullHandler,
                                                PropHandler valueHandler) {
-        if (!iter_ || !iter_->valid()) {
+        if (!valid()) {
             return nullHandler(props_);
         }
-        return valueHandler(iter_->key(), iter_->reader(), props_);
+        return valueHandler(key_, reader_.get(), props_);
     }
 
     bool valid() const override {
-        return iter_ && iter_->valid();
+        return !stopSearching_ && reader_ != nullptr;
     }
 
     void next() override {
-        iter_->next();
+        // tag only has one valid record, so stop iterate
+        stopSearching_ = true;
     }
 
     folly::StringPiece key() const override {
-        return iter_->key();
+        return key_;
     }
 
     folly::StringPiece val() const override {
-        return iter_->val();
+        return value_;
     }
 
     RowReader* reader() const override {
-        if (iter_) {
-            return iter_->reader();
-        }
-        return nullptr;
+        return reader_.get();
     }
 
     const std::string& getTagName() {
         return tagName_;
     }
 
+    TagID getTagId() {
+        return tagId_;
+    }
+
 private:
+    bool resetReader(const VertexID& vId) {
+        reader_.reset(*schemas_, value_);
+        if (!reader_ || (ttl_.hasValue() && CommonUtils::checkDataExpiredForTTL(
+            schemas_->back().get(), reader_.get(), ttl_.value().first, ttl_.value().second))) {
+            reader_.reset();
+            if (FLAGS_enable_vertex_cache && tagContext_->vertexCache_ != nullptr) {
+                tagContext_->vertexCache_->evict(std::make_pair(vId, tagId_));
+            }
+            return false;
+        }
+        return true;
+    }
+
     PlanContext                                                          *planContext_;
     TagContext                                                           *tagContext_;
     TagID                                                                 tagId_;
     const std::vector<PropContext>                                       *props_;
-    ExpressionContext                                                    *expCtx_;
+    StorageExpressionContext                                             *expCtx_;
     Expression                                                           *exp_;
-    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>* schemas_ = nullptr;
+    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>> *schemas_ = nullptr;
     folly::Optional<std::pair<std::string, int64_t>>                      ttl_;
     std::string                                                           tagName_;
 
-    std::unique_ptr<StorageIterator>                                      iter_;
-    std::string                                                           prefix_;
-    std::string                                                           cacheResult_;
+    bool                                                                  stopSearching_ = false;
+    std::string                                                           key_;
+    std::string                                                           value_;
+    RowReaderWrapper                                                      reader_;
 };
 
 }  // namespace storage

--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -46,10 +46,10 @@ public:
         row.emplace_back(insert_);
 
         for (auto& retExp : returnPropsExp_) {
-            auto& val = retExp->eval(*expCtx_);
-            auto exp = dynamic_cast<const PropertyExpression*>(retExp);
+            auto exp = static_cast<PropertyExpression*>(retExp);
+            auto& val = exp->eval(*expCtx_);
             if (exp) {
-                result_->colNames.emplace_back(folly::stringPrintf("%s:%s",
+                result_->colNames.emplace_back(folly::stringPrintf("%s.%s",
                                                exp->sym()->c_str(),
                                                exp->prop()->c_str()));
             } else {

--- a/src/storage/index/LookupBaseProcessor.h
+++ b/src/storage/index/LookupBaseProcessor.h
@@ -74,8 +74,6 @@ protected:
     std::vector<cpp2::IndexQueryContext>        contexts_{};
     std::vector<std::string>                    yieldCols_{};
     IndexFilterItem                             filterItems_;
-    // Used to identify no fields in the index
-    bool                                        noProp_{false};
     // Save schema when column is out of index, need to read from data
     std::shared_ptr<const meta::NebulaSchemaProvider> schema_;
 };

--- a/src/storage/index/LookupBaseProcessor.inl
+++ b/src/storage/index/LookupBaseProcessor.inl
@@ -38,7 +38,8 @@ cpp2::ErrorCode LookupBaseProcessor<REQ, RESP>::requestCheck(const cpp2::LookupI
         schema_ = this->env_->schemaMan_->getTagSchema(spaceId_, planContext_->tagId_);
     }
 
-    if (indices.get_contexts().empty()) {
+    if (indices.get_contexts().empty() || !req.__isset.return_columns ||
+        req.get_return_columns()->empty()) {
         return cpp2::ErrorCode::E_INVALID_OPERATION;
     }
     contexts_ = indices.get_contexts();
@@ -46,39 +47,6 @@ cpp2::ErrorCode LookupBaseProcessor<REQ, RESP>::requestCheck(const cpp2::LookupI
     // setup yield columns.
     if (req.__isset.return_columns) {
         yieldCols_ = *req.get_return_columns();
-    }
-
-    for (const auto& ctx : contexts_) {
-        const auto& indexId = ctx.get_index_id();
-        auto needFilter = ctx.__isset.filter && !ctx.get_filter().empty();
-
-        auto index = planContext_->isEdge_
-            ? this->env_->indexMan_->getEdgeIndex(spaceId_, indexId)
-            : this->env_->indexMan_->getTagIndex(spaceId_, indexId);
-        if (!index.ok()) {
-            return cpp2::ErrorCode::E_INDEX_NOT_FOUND;
-        }
-
-        auto fields = index.value()->get_fields();
-
-        // If no filed in fields, only _vid can be returned for tag.
-        // For edge, only _src, _ranking, _dst can be returned
-        if (fields.size() == 0) {
-            if (contexts_.size() != 1 || yieldCols_.size() != 0 ||
-                needFilter || ctx.get_column_hints().size() != 0) {
-                return cpp2::ErrorCode::E_INVALID_OPERATION;
-            }
-            noProp_ = true;
-        }
-    }
-
-    // setup result set columns.
-    if (planContext_->isEdge_) {
-        resultDataSet_.colNames.emplace_back(kSrc);
-        resultDataSet_.colNames.emplace_back("_ranking");
-        resultDataSet_.colNames.emplace_back(kDst);
-    } else {
-        resultDataSet_.colNames.emplace_back(kVid);
     }
 
     for (const auto& col : yieldCols_) {
@@ -91,6 +59,7 @@ cpp2::ErrorCode LookupBaseProcessor<REQ, RESP>::requestCheck(const cpp2::LookupI
 template<typename REQ, typename RESP>
 bool LookupBaseProcessor<REQ, RESP>::isOutsideIndex(Expression* filter,
                                                     const meta::cpp2::IndexItem* index) {
+    static const std::set<std::string> propsInEdgeKey{kSrc, kType, kRank, kDst};
     auto fields = index->get_fields();
     switch (filter->kind()) {
         case Expression::Kind::kLogicalOr :
@@ -122,6 +91,14 @@ bool LookupBaseProcessor<REQ, RESP>::isOutsideIndex(Expression* filter,
                 return ret;
             }
             break;
+        }
+        case Expression::Kind::kEdgeSrc:
+        case Expression::Kind::kEdgeType:
+        case Expression::Kind::kEdgeRank:
+        case Expression::Kind::kEdgeDst: {
+            auto* sExpr = static_cast<PropertyExpression*>(filter);
+            auto propName = *(sExpr->prop());
+            return propsInEdgeKey.find(propName) == propsInEdgeKey.end();
         }
         case Expression::Kind::kTagProperty:
         case Expression::Kind::kEdgeProperty: {
@@ -161,106 +138,101 @@ StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan() {
     int32_t filterId = 0;
     std::unique_ptr<IndexOutputNode<IndexID>> out;
 
-    if (noProp_) {
-        out = buildPlanBasic(contexts_[0], plan, false, {});
-         if (out == nullptr) {
+    for (const auto& ctx : contexts_) {
+        const auto& indexId = ctx.get_index_id();
+        auto needFilter = ctx.__isset.filter && !ctx.get_filter().empty();
+
+        // Check whether a data node is required.
+        // If a non-indexed column appears in the WHERE clause or YIELD clause,
+        // That means need to query the corresponding data.
+        bool needData = false;
+        auto index = planContext_->isEdge_
+            ? this->env_->indexMan_->getEdgeIndex(spaceId_, indexId)
+            : this->env_->indexMan_->getTagIndex(spaceId_, indexId);
+        if (!index.ok()) {
+            return Status::IndexNotFound();
+        }
+
+        // check nullable column
+        bool hasNullableCol = false;
+
+        auto* indexItem = index.value().get();
+        auto fields = indexItem->get_fields();
+
+        for (const auto& col : fields) {
+            if (!hasNullableCol && col.get_nullable()) {
+                hasNullableCol = true;
+                break;
+            }
+        }
+
+        for (const auto& yieldCol : yieldCols_) {
+            static const std::set<std::string> propsInKey{kVid, kTag, kSrc, kType, kRank, kDst};
+            if (propsInKey.count(yieldCol)) {
+                continue;
+            }
+            auto it = std::find_if(fields.begin(),
+                                    fields.end(),
+                                    [&yieldCol] (const auto& columnDef) {
+                                        return yieldCol == columnDef.get_name();
+                                    });
+            if (it == fields.end()) {
+                needData = true;
+                break;
+            }
+        }
+        auto colHints = ctx.get_column_hints();
+
+        // Check WHERE clause contains columns that ware not indexed
+        if (ctx.__isset.filter && !ctx.get_filter().empty()) {
+            auto filter = Expression::decode(ctx.get_filter());
+            auto isFieldsOutsideIndex = isOutsideIndex(filter.get(), indexItem);
+            if (isFieldsOutsideIndex) {
+                needData = needFilter = true;
+            }
+        }
+
+        if (!needData && !needFilter) {
+            out = buildPlanBasic(ctx, plan, hasNullableCol, fields);
+        } else if (needData && !needFilter) {
+            out = buildPlanWithData(ctx, plan);
+        } else if (!needData && needFilter) {
+            auto expr = Expression::decode(ctx.get_filter());
+            auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
+                                                                        planContext_->isIntId_,
+                                                                        hasNullableCol,
+                                                                        fields);
+            filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
+            out = buildPlanWithFilter(ctx,
+                                        plan,
+                                        filterItems_[filterId].first.get(),
+                                        filterItems_[filterId].second.get());
+            filterId++;
+        } else {
+            auto expr = Expression::decode(ctx.get_filter());
+            // Need to get columns in data, expr ctx need to be aware of schema
+            const auto& schemaName = planContext_->isEdge_ ? planContext_->edgeName_ :
+                                                                planContext_->tagName_;
+            if (schema_ == nullptr) {
+                return Status::Error("Schema not found");
+            }
+            auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
+                                                                        planContext_->isIntId_,
+                                                                        schemaName,
+                                                                        schema_.get(),
+                                                                        planContext_->isEdge_);
+            filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
+            out = buildPlanWithDataAndFilter(ctx,
+                                                plan,
+                                                filterItems_[filterId].first.get(),
+                                                filterItems_[filterId].second.get());
+            filterId++;
+        }
+        if (out == nullptr) {
             return Status::Error("Index scan plan error");
         }
         IndexAggr->addDependency(out.get());
         plan.addNode(std::move(out));
-    } else {
-        for (const auto& ctx : contexts_) {
-            const auto& indexId = ctx.get_index_id();
-            auto needFilter = ctx.__isset.filter && !ctx.get_filter().empty();
-
-            // Check whether a data node is required.
-            // If a non-indexed column appears in the WHERE clause or YIELD clause,
-            // That means need to query the corresponding data.
-            bool needData = false;
-            auto index = planContext_->isEdge_
-                ? this->env_->indexMan_->getEdgeIndex(spaceId_, indexId)
-                : this->env_->indexMan_->getTagIndex(spaceId_, indexId);
-            if (!index.ok()) {
-                return Status::IndexNotFound();
-            }
-
-            // check nullable column
-            bool hasNullableCol = false;
-
-            auto* indexItem = index.value().get();
-            auto fields = indexItem->get_fields();
-
-            for (const auto& col : fields) {
-                if (!hasNullableCol && col.get_nullable()) {
-                    hasNullableCol = true;
-                    break;
-                }
-            }
-
-            for (const auto& yieldCol : yieldCols_) {
-                auto it = std::find_if(fields.begin(),
-                                       fields.end(),
-                                       [&yieldCol] (const auto& columnDef) {
-                                           return yieldCol == columnDef.get_name();
-                                       });
-                if (it == fields.end()) {
-                    needData = true;
-                    break;
-                }
-            }
-            auto colHints = ctx.get_column_hints();
-
-            // Check WHERE clause contains columns that ware not indexed
-            if (ctx.__isset.filter && !ctx.get_filter().empty()) {
-                auto filter = Expression::decode(ctx.get_filter());
-                auto isFieldsOutsideIndex = isOutsideIndex(filter.get(), indexItem);
-                if (isFieldsOutsideIndex) {
-                    needData = needFilter = true;
-                }
-            }
-
-            if (!needData && !needFilter) {
-                out = buildPlanBasic(ctx, plan, hasNullableCol, fields);
-            } else if (needData && !needFilter) {
-                out = buildPlanWithData(ctx, plan);
-            } else if (!needData && needFilter) {
-                auto expr = Expression::decode(ctx.get_filter());
-                auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
-                                                                          planContext_->isIntId_,
-                                                                          hasNullableCol,
-                                                                          fields);
-                filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
-                out = buildPlanWithFilter(ctx,
-                                          plan,
-                                          filterItems_[filterId].first.get(),
-                                          filterItems_[filterId].second.get());
-                filterId++;
-            } else {
-                auto expr = Expression::decode(ctx.get_filter());
-                // Need to get columns in data, expr ctx need to be aware of schema
-                const auto& schemaName = planContext_->isEdge_ ? planContext_->edgeName_ :
-                                                                 planContext_->tagName_;
-                if (schema_ == nullptr) {
-                    return Status::Error("Schema not found");
-                }
-                auto exprCtx = std::make_unique<StorageExpressionContext>(planContext_->vIdLen_,
-                                                                          planContext_->isIntId_,
-                                                                          schemaName,
-                                                                          schema_.get(),
-                                                                          planContext_->isEdge_);
-                filterItems_.emplace(filterId, std::make_pair(std::move(exprCtx), std::move(expr)));
-                out = buildPlanWithDataAndFilter(ctx,
-                                                 plan,
-                                                 filterItems_[filterId].first.get(),
-                                                 filterItems_[filterId].second.get());
-                filterId++;
-            }
-            if (out == nullptr) {
-                return Status::Error("Index scan plan error");
-            }
-            IndexAggr->addDependency(out.get());
-            plan.addNode(std::move(out));
-        }
     }
     plan.addNode(std::move(IndexAggr));
     return plan;

--- a/src/storage/index/LookupBaseProcessor.inl
+++ b/src/storage/index/LookupBaseProcessor.inl
@@ -172,10 +172,10 @@ StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan() {
                 continue;
             }
             auto it = std::find_if(fields.begin(),
-                                    fields.end(),
-                                    [&yieldCol] (const auto& columnDef) {
-                                        return yieldCol == columnDef.get_name();
-                                    });
+                                   fields.end(),
+                                   [&yieldCol] (const auto& columnDef) {
+                                       return yieldCol == columnDef.get_name();
+                                   });
             if (it == fields.end()) {
                 needData = true;
                 break;

--- a/src/storage/index/LookupProcessor.cpp
+++ b/src/storage/index/LookupProcessor.cpp
@@ -43,6 +43,17 @@ void LookupProcessor::process(const cpp2::LookupIndexRequest& req) {
 }
 
 void LookupProcessor::onProcessFinished() {
+    if (planContext_->isEdge_) {
+        std::transform(resultDataSet_.colNames.begin(),
+                       resultDataSet_.colNames.end(),
+                       resultDataSet_.colNames.begin(),
+                       [this](const auto& col) { return planContext_->edgeName_ + "." + col; });
+    } else {
+        std::transform(resultDataSet_.colNames.begin(),
+                       resultDataSet_.colNames.end(),
+                       resultDataSet_.colNames.begin(),
+                       [this](const auto& col) { return planContext_->tagName_ + "." + col; });
+    }
     resp_.set_data(std::move(resultDataSet_));
 }
 

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -116,7 +116,7 @@ StoragePlan<cpp2::EdgeKey> GetPropProcessor::buildEdgePlan(nebula::DataSet* resu
         edges.emplace_back(edge.get());
         plan.addNode(std::move(edge));
     }
-    auto output = std::make_unique<GetEdgePropNode>(edges, spaceVidLen_, isIntId_, result);
+    auto output = std::make_unique<GetEdgePropNode>(planContext_.get(), edges, result);
     for (auto* edge : edges) {
         output->addDependency(edge);
     }
@@ -124,34 +124,26 @@ StoragePlan<cpp2::EdgeKey> GetPropProcessor::buildEdgePlan(nebula::DataSet* resu
     return plan;
 }
 
-cpp2::ErrorCode GetPropProcessor::checkColumnNames(const std::vector<std::string>& colNames) {
-    // Column names for the pass-in data. When getting the vertex props, the first
-    // column has to be "_vid", when getting the edge props, the first four columns
-    // have to be "_src", "_type", "_rank", and "_dst"
-    if (colNames.size() != 1 && colNames.size() != 4) {
+cpp2::ErrorCode GetPropProcessor::checkRequest(const cpp2::GetPropRequest& req) {
+    if (!req.__isset.vertex_props && !req.__isset.edge_props) {
+        return cpp2::ErrorCode::E_INVALID_OPERATION;
+    } else if (req.__isset.vertex_props && req.__isset.edge_props) {
         return cpp2::ErrorCode::E_INVALID_OPERATION;
     }
-    if (colNames.size() == 1 && colNames[0] == kVid) {
+    if (req.__isset.vertex_props) {
         isEdge_ = false;
-        return cpp2::ErrorCode::SUCCEEDED;
-    } else if (colNames.size() == 4 &&
-               colNames[0] == kSrc &&
-               colNames[1] == kType &&
-               colNames[2] == kRank &&
-               colNames[3] == kDst) {
+    } else {
         isEdge_ = true;
-        return cpp2::ErrorCode::SUCCEEDED;
     }
-    return cpp2::ErrorCode::E_INVALID_OPERATION;
+    return cpp2::ErrorCode::SUCCEEDED;
 }
 
 cpp2::ErrorCode GetPropProcessor::checkAndBuildContexts(const cpp2::GetPropRequest& req) {
-    auto code = checkColumnNames(req.column_names);
+    auto code = checkRequest(req);
     if (code != cpp2::ErrorCode::SUCCEEDED) {
         return code;
     }
     if (!isEdge_) {
-        resultDataSet_.colNames.emplace_back(kVid);
         code = getSpaceVertexSchema();
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return code;

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -99,7 +99,8 @@ StoragePlan<VertexID> GetPropProcessor::buildTagPlan(nebula::DataSet* result) {
         tags.emplace_back(tag.get());
         plan.addNode(std::move(tag));
     }
-    auto output = std::make_unique<GetTagPropNode>(planContext_.get(), tags, result);
+    auto output = std::make_unique<GetTagPropNode>(
+        planContext_.get(), tags, result, tagContext_.vertexCache_);
     for (auto* tag : tags) {
         output->addDependency(tag);
     }

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -203,6 +203,7 @@ cpp2::ErrorCode GetPropProcessor::buildEdgeContext(const cpp2::GetPropRequest& r
 }
 
 void GetPropProcessor::buildTagColName(const std::vector<cpp2::VertexProp>& tagProps) {
+    resultDataSet_.colNames.emplace_back(kVid);
     for (const auto& tagProp : tagProps) {
         auto tagId = tagProp.tag;
         auto tagName = tagContext_.tagNames_[tagId];

--- a/src/storage/query/GetPropProcessor.h
+++ b/src/storage/query/GetPropProcessor.h
@@ -41,7 +41,7 @@ protected:
 
     cpp2::ErrorCode checkAndBuildContexts(const cpp2::GetPropRequest& req) override;
 
-    cpp2::ErrorCode checkColumnNames(const std::vector<std::string>& colNames);
+    cpp2::ErrorCode checkRequest(const cpp2::GetPropRequest& req);
 
     cpp2::ErrorCode buildTagContext(const cpp2::GetPropRequest& req);
 

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -30,11 +30,13 @@ namespace storage {
 struct PropContext {
 public:
     enum class PropInKeyType {
-        NONE = 0x00,
-        SRC = 0x01,
-        TYPE = 0x02,
-        RANK = 0x03,
-        DST = 0x04,
+        NONE    = 0x00,
+        VID     = 0x01,
+        TAG     = 0x02,
+        SRC     = 0x03,
+        TYPE    = 0x04,
+        RANK    = 0x05,
+        DST     = 0x06,
     };
 
     explicit PropContext(const char* name)
@@ -58,7 +60,11 @@ public:
     }
 
     void setPropInKey() {
-        if (name_ == kSrc) {
+        if (name_ == kVid) {
+            propInKeyType_ = PropContext::PropInKeyType::VID;
+        } else if (name_ == kTag) {
+            propInKeyType_ = PropContext::PropInKeyType::TAG;
+        } else if (name_ == kSrc) {
             propInKeyType_ = PropContext::PropInKeyType::SRC;
         } else if (name_ == kType) {
             propInKeyType_ = PropContext::PropInKeyType::TYPE;
@@ -146,11 +152,9 @@ protected:
     cpp2::ErrorCode getSpaceEdgeSchema();
 
     // build tagContexts_ according to return props
-    cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps,
-                                      bool returnNoProps = false);
+    cpp2::ErrorCode handleVertexProps(std::vector<cpp2::VertexProp>& tagProps);
     // build edgeContexts_ according to return props
-    cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps,
-                                    bool returnNoProps = false);
+    cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps);
 
     cpp2::ErrorCode buildFilter(const REQ& req);
     cpp2::ErrorCode buildYields(const REQ& req);

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -46,10 +46,6 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleVertexProps(
         } else {
             // if the list of property names is empty, then all properties on the given tag
             // will be returned
-            addReturnPropContext(ctxs, kVid, nullptr);
-            addReturnPropContext(ctxs, kTag, nullptr);
-            vertexProp.props.emplace_back(kVid);
-            vertexProp.props.emplace_back(kTag);
             auto count = tagSchema->getNumFields();
             for (size_t i = 0; i < count; i++) {
                 auto name = tagSchema->getFieldName(i);
@@ -100,14 +96,6 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::handleEdgeProps(
         } else {
             // if the list of property names is empty, then all properties on the given edgeType
             // will be returned
-            addReturnPropContext(ctxs, kSrc, nullptr);
-            addReturnPropContext(ctxs, kType, nullptr);
-            addReturnPropContext(ctxs, kRank, nullptr);
-            addReturnPropContext(ctxs, kDst, nullptr);
-            edgeProp.props.emplace_back(kSrc);
-            edgeProp.props.emplace_back(kType);
-            edgeProp.props.emplace_back(kRank);
-            edgeProp.props.emplace_back(kDst);
             auto count = edgeSchema->getNumFields();
             for (size_t i = 0; i < count; i++) {
                 auto name = edgeSchema->getFieldName(i);
@@ -201,8 +189,6 @@ std::vector<cpp2::VertexProp> QueryBaseProcessor<REQ, RESP>::buildAllTagProps() 
     for (const auto& entry : tagContext_.schemas_) {
         cpp2::VertexProp tagProp;
         tagProp.tag = entry.first;
-        tagProp.props.emplace_back(kVid);
-        tagProp.props.emplace_back(kTag);
         const auto& schema = entry.second.back();
         auto count = schema->getNumFields();
         for (size_t i = 0; i < count; i++) {
@@ -226,13 +212,6 @@ std::vector<cpp2::EdgeProp> QueryBaseProcessor<REQ, RESP>::buildAllEdgeProps(
         if (direction == cpp2::EdgeDirection::IN_EDGE) {
             edgeProp.type = -edgeProp.type;
         }
-
-        // add default property in key
-        edgeProp.props.emplace_back(kSrc);
-        edgeProp.props.emplace_back(kType);
-        edgeProp.props.emplace_back(kRank);
-        edgeProp.props.emplace_back(kDst);
-
         const auto& schema = entry.second.back();
         auto count = schema->getNumFields();
         for (size_t i = 0; i < count; i++) {

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -195,12 +195,15 @@ void QueryBaseProcessor<REQ, RESP>::buildEdgeTTLInfo() {
     }
 }
 
+// doodle
 template<typename REQ, typename RESP>
 std::vector<cpp2::VertexProp> QueryBaseProcessor<REQ, RESP>::buildAllTagProps() {
     std::vector<cpp2::VertexProp> result;
     for (const auto& entry : tagContext_.schemas_) {
         cpp2::VertexProp tagProp;
         tagProp.tag = entry.first;
+        tagProp.props.emplace_back(kVid);
+        tagProp.props.emplace_back(kTag);
         const auto& schema = entry.second.back();
         auto count = schema->getNumFields();
         for (size_t i = 0; i < count; i++) {
@@ -214,6 +217,7 @@ std::vector<cpp2::VertexProp> QueryBaseProcessor<REQ, RESP>::buildAllTagProps() 
     return result;
 }
 
+// doodle
 template<typename REQ, typename RESP>
 std::vector<cpp2::EdgeProp> QueryBaseProcessor<REQ, RESP>::buildAllEdgeProps(
         const cpp2::EdgeDirection& direction) {

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -424,6 +424,10 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::checkExp(const Expression* exp,
             CHECK(!iter->second.empty());
             const auto& tagSchema = iter->second.back();
 
+            if (*propName == kVid || *propName == kTag) {
+                return cpp2::ErrorCode::SUCCEEDED;
+            }
+
             auto field = tagSchema->field(*propName);
             if (field == nullptr) {
                 VLOG(1) << "Can't find related prop " << *propName << " on tag " << *tagName;
@@ -466,6 +470,11 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::checkExp(const Expression* exp,
             }
             CHECK(!iter->second.empty());
             const auto& edgeSchema = iter->second.back();
+
+            if (*propName == kSrc || *propName == kType ||
+                *propName == kRank || *propName == kDst) {
+                return cpp2::ErrorCode::SUCCEEDED;
+            }
 
             const meta::SchemaProviderIf::Field* field = nullptr;
             if (exp->kind() == Expression::Kind::kEdgeProperty) {

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -195,7 +195,6 @@ void QueryBaseProcessor<REQ, RESP>::buildEdgeTTLInfo() {
     }
 }
 
-// doodle
 template<typename REQ, typename RESP>
 std::vector<cpp2::VertexProp> QueryBaseProcessor<REQ, RESP>::buildAllTagProps() {
     std::vector<cpp2::VertexProp> result;
@@ -217,7 +216,6 @@ std::vector<cpp2::VertexProp> QueryBaseProcessor<REQ, RESP>::buildAllTagProps() 
     return result;
 }
 
-// doodle
 template<typename REQ, typename RESP>
 std::vector<cpp2::EdgeProp> QueryBaseProcessor<REQ, RESP>::buildAllEdgeProps(
         const cpp2::EdgeDirection& direction) {

--- a/src/storage/query/ScanEdgeProcessor.h
+++ b/src/storage/query/ScanEdgeProcessor.h
@@ -30,9 +30,10 @@ private:
 
     cpp2::ErrorCode checkAndBuildContexts(const cpp2::ScanEdgeRequest& req) override;
 
+    void buildEdgeColName(const std::vector<cpp2::EdgeProp>& edgeProps);
+
     void onProcessFinished() override;
 
-    bool returnNoProps_{false};
     PartitionID partId_;
 };
 

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -129,7 +129,6 @@ cpp2::ErrorCode ScanVertexProcessor::checkAndBuildContexts(const cpp2::ScanVerte
     return ret;
 }
 
-// doodle: could unify
 void ScanVertexProcessor::buildTagColName(const std::vector<cpp2::VertexProp>& tagProps) {
     for (const auto& tagProp : tagProps) {
         auto tagId = tagProp.tag;

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -129,6 +129,7 @@ cpp2::ErrorCode ScanVertexProcessor::checkAndBuildContexts(const cpp2::ScanVerte
     return ret;
 }
 
+// doodle: could unify
 void ScanVertexProcessor::buildTagColName(const std::vector<cpp2::VertexProp>& tagProps) {
     for (const auto& tagProp : tagProps) {
         auto tagId = tagProp.tag;

--- a/src/storage/query/ScanVertexProcessor.h
+++ b/src/storage/query/ScanVertexProcessor.h
@@ -30,9 +30,10 @@ private:
 
     cpp2::ErrorCode checkAndBuildContexts(const cpp2::ScanVertexRequest& req) override;
 
+    void buildTagColName(const std::vector<cpp2::VertexProp>& tagProps);
+
     void onProcessFinished() override;
 
-    bool returnNoProps_{false};
     PartitionID partId_;
 };
 

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -52,7 +52,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<EdgeType> over = {serve};
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
-        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore"});
+        tags.emplace_back(player, std::vector<std::string>{"name", "age", "avgScore", kVid, kTag});
         edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear",
                                                            kSrc, kType, kRank, kDst});
         auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
@@ -91,7 +91,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<EdgeType> over = {-serve};
         std::vector<std::pair<TagID, std::vector<std::string>>> tags;
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
-        tags.emplace_back(team, std::vector<std::string>{"name"});
+        tags.emplace_back(team, std::vector<std::string>{"name", kVid, kTag});
         edges.emplace_back(-serve, std::vector<std::string>{
                            "playerName", "startYear", "teamCareer",
                            kSrc, kType, kRank, kDst});
@@ -267,7 +267,7 @@ TEST(GetNeighborsTest, PropertyTest) {
         std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
         tags.emplace_back(player, std::vector<std::string>{
             "name", "age", "playing", "career", "startYear", "endYear", "games",
-            "avgScore", "serveTeams", "country", "champions"});
+            "avgScore", "serveTeams", "country", "champions", kVid, kTag});
         edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear",
             "playerName", "teamCareer", "teamGames", "teamAvgScore", "type", "champions",
             kSrc, kType, kRank, kDst});
@@ -787,7 +787,7 @@ TEST(GetNeighborsTest, TtlTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - teammate, - serve, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 10);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 10);
     }
     sleep(FLAGS_mock_ttl_duration + 1);
     {
@@ -962,7 +962,7 @@ TEST(GetNeighborsTest, ReturnAllPropertyTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, serve, teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 7);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 7);
     }
     {
         LOG(INFO) << "ReturnAllPropertyInTagAndEdge";
@@ -983,7 +983,7 @@ TEST(GetNeighborsTest, ReturnAllPropertyTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, -serve, teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 7);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 7);
     }
 }
 
@@ -1012,7 +1012,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 3);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 3);
     }
     {
         LOG(INFO) << "GoFromPlayerOverAll";
@@ -1030,7 +1030,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - teammate, - serve, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 10);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 10);
     }
     {
         LOG(INFO) << "GoFromTeamOverAll";
@@ -1048,7 +1048,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - teammate, - serve, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 10);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 10);
     }
     {
         LOG(INFO) << "GoFromPlayerOverInEdge";
@@ -1066,7 +1066,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - serve, - teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 8);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 8);
     }
     {
         LOG(INFO) << "GoFromPlayerOverOutEdge";
@@ -1084,7 +1084,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 8);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 8);
     }
     {
         LOG(INFO) << "GoFromMultiPlayerOverAll";
@@ -1102,7 +1102,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - teammate, - serve, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 3, 10);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 3, 10);
     }
     {
         LOG(INFO) << "GoFromMultiTeamOverAll";
@@ -1120,7 +1120,7 @@ TEST(GetNeighborsTest, GoOverAllTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - teammate, - serve, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 3, 10);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 3, 10);
     }
 }
 
@@ -1150,7 +1150,7 @@ TEST(GetNeighborsTest, MultiVersionTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         // vId, stat, player, team, general tag, - teammate, - serve, + serve, + teammate, expr
-        QueryTestUtils::checkResponse(resp.vertices, vertices, 1, 10);
+        QueryTestUtils::checkResponse(resp.vertices, vertices, over, tags, edges, 1, 10);
     }
     FLAGS_enable_multi_versions = false;
 }

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -227,12 +227,11 @@ TEST(GetPropTest, AllPropertyInOneSchemaTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected;
-        expected.colNames = {kVid, std::string("1.").append(kVid), std::string("1.").append(kTag),
-                             "1.name", "1.age", "1.playing", "1.career",
+        expected.colNames = {kVid, "1.name", "1.age", "1.playing", "1.career",
                              "1.startYear", "1.endYear", "1.games", "1.avgScore",
                              "1.serveTeams", "1.country", "1.champions"};
-        nebula::Row row({"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, false, 19, 1997, 2016,
-                         1392, 19.0, 1, "America", 5});
+        nebula::Row row({"Tim Duncan", "Tim Duncan", 44, false, 19,
+                         1997, 2016, 1392, 19.0, 1, "America", 5});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.props);
     }
@@ -258,15 +257,10 @@ TEST(GetPropTest, AllPropertyInOneSchemaTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected;
-        expected.colNames = {"101._src", "101._type", "101._rank", "101._dst",
-                             "101.playerName", "101.teamName", "101.startYear", "101.endYear",
+        expected.colNames = {"101.playerName", "101.teamName", "101.startYear", "101.endYear",
                              "101.teamCareer", "101.teamGames", "101.teamAvgScore", "101.type",
                              "101.champions"};
-        nebula::Row row({"Tim Duncan",  // src
-                         101,           // type
-                         1997,          // rank
-                         "Spurs",       // dst
-                         "Tim Duncan", "Spurs", 1997, 2016, 19, 1392, 19.000000, "zzzzz", 5});
+        nebula::Row row({"Tim Duncan", "Spurs", 1997, 2016, 19, 1392, 19.000000, "zzzzz", 5});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.props);
     }
@@ -296,17 +290,17 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
         {
             std::vector<nebula::Row> expected;
             nebula::Row row;
-            // The first one is kVid, and player have 2 + 11 properties in key and value
-            std::vector<Value> values{"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, false, 19,
+            // The first one is kVid, and player 11 properties in value
+            std::vector<Value> values{"Tim Duncan", "Tim Duncan", 44, false, 19,
                                       1997, 2016, 1392, 19.0, 1, "America", 5};
-            // team: kVid, kTag and 1 property, tag3: kVid, kTag and 11 property, in total 16
-            for (size_t i = 0; i < 16; i++) {
+            // team: 1 property, tag3: 11 property, in total 12
+            for (size_t i = 0; i < 12; i++) {
                 values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));
-            // kVid, player: 2 + 11, team: 2 + 1, tag3: 2 + 11
-            ASSERT_EQ(1 + 13 + 3 + 13, resp.props.colNames.size());
+            // kVid, player: 11, team: 1, tag3: 11
+            ASSERT_EQ(1 + 11 + 1 + 11, resp.props.colNames.size());
             verifyResult(expected, resp.props);
         }
     }
@@ -335,18 +329,14 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
             nebula::Row row;
             std::vector<Value> values;
             // -teammate
-            for (size_t i = 0; i < 5 + 4; i++) {
+            for (size_t i = 0; i < 5; i++) {
                 values.emplace_back(Value());
             }
             // -serve
-            for (size_t i = 0; i < 9 + 4; i++) {
+            for (size_t i = 0; i < 9; i++) {
                 values.emplace_back(Value());
             }
             // serve
-            values.emplace_back("Tim Duncan");    // src
-            values.emplace_back(101);             // type
-            values.emplace_back(1997);            // rank
-            values.emplace_back("Spurs");         // dst
             values.emplace_back("Tim Duncan");
             values.emplace_back("Spurs");
             values.emplace_back(1997);
@@ -357,7 +347,7 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
             values.emplace_back("zzzzz");
             values.emplace_back(5);
             // teammate
-            for (size_t i = 0; i < 5 + 4; i++) {
+            for (size_t i = 0; i < 5; i++) {
                 values.emplace_back(Value());
             }
             row.values = std::move(values);
@@ -400,17 +390,17 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
         {
             std::vector<nebula::Row> expected;
             nebula::Row row;
-            // The first one is kVid, and player have 2 + 11 properties in key and value
-            std::vector<Value> values{"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, false, 19,
+            // The first one is kVid, and player have 11 properties in key and value
+            std::vector<Value> values{"Tim Duncan", "Tim Duncan", 44, false, 19,
                                       1997, 2016, 1392, 19.0, 1, "America", 5};
-            // team: kVid, kTag and 1 property, tag3: kVid, kTag and 11 property, in total 16
-            for (size_t i = 0; i < 16; i++) {
+            // team: 1 property, tag3: 11 property, in total 12
+            for (size_t i = 0; i < 12; i++) {
                 values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));
-            // kVid, player: 2 + 11, team: 2 + 1, tag3: 2 + 11
-            ASSERT_EQ(1 + 13 + 3 + 13, resp.props.colNames.size());
+            // kVid, player: 11, team: 1, tag3: 11
+            ASSERT_EQ(1 + 11 + 1 + 11, resp.props.colNames.size());
             verifyResult(expected, resp.props);
         }
     }

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -117,8 +117,8 @@ TEST(GetPropTest, PropertyTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected;
-        expected.colNames = {"1.name", "1.age", "1.avgScore"};
-        nebula::Row row({"Tim Duncan", 44, 19.0});
+        expected.colNames = {kVid, "1.name", "1.age", "1.avgScore"};
+        nebula::Row row({"Tim Duncan", "Tim Duncan", 44, 19.0});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.props);
     }
@@ -136,9 +136,9 @@ TEST(GetPropTest, PropertyTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected;
-        expected.colNames = {std::string("1.").append(kVid), std::string("1.").append(kTag),
+        expected.colNames = {kVid, std::string("1.").append(kVid), std::string("1.").append(kTag),
                              "1.name", "1.age", "1.avgScore"};
-        nebula::Row row({"Tim Duncan", 1, "Tim Duncan", 44, 19.0});
+        nebula::Row row({"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, 19.0});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.props);
     }
@@ -227,12 +227,12 @@ TEST(GetPropTest, AllPropertyInOneSchemaTest) {
 
         ASSERT_EQ(0, resp.result.failed_parts.size());
         nebula::DataSet expected;
-        expected.colNames = {std::string("1.").append(kVid), std::string("1.").append(kTag),
+        expected.colNames = {kVid, std::string("1.").append(kVid), std::string("1.").append(kTag),
                              "1.name", "1.age", "1.playing", "1.career",
                              "1.startYear", "1.endYear", "1.games", "1.avgScore",
                              "1.serveTeams", "1.country", "1.champions"};
-        nebula::Row row({"Tim Duncan", 1, "Tim Duncan", 44, false, 19, 1997, 2016, 1392, 19.0, 1,
-                         "America", 5});
+        nebula::Row row({"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, false, 19, 1997, 2016,
+                         1392, 19.0, 1, "America", 5});
         expected.rows.emplace_back(std::move(row));
         ASSERT_EQ(expected, resp.props);
     }
@@ -296,16 +296,17 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
         {
             std::vector<nebula::Row> expected;
             nebula::Row row;
-            // The first two is kVid and kTag
-            std::vector<Value> values {"Tim Duncan", 1, "Tim Duncan", 44, false, 19, 1997, 2016,
-                                       1392, 19.0, 1, "America", 5};
-            // team: kVid, kTag and 1 property, tag3: kVid, kTag and 11 property, total 16
+            // The first one is kVid, and player have 2 + 11 properties in key and value
+            std::vector<Value> values{"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, false, 19,
+                                      1997, 2016, 1392, 19.0, 1, "America", 5};
+            // team: kVid, kTag and 1 property, tag3: kVid, kTag and 11 property, in total 16
             for (size_t i = 0; i < 16; i++) {
                 values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));
-            ASSERT_EQ(13 + 3 + 13, resp.props.colNames.size());
+            // kVid, player: 2 + 11, team: 2 + 1, tag3: 2 + 11
+            ASSERT_EQ(1 + 13 + 3 + 13, resp.props.colNames.size());
             verifyResult(expected, resp.props);
         }
     }
@@ -399,16 +400,17 @@ TEST(GetPropTest, AllPropertyInAllSchemaTest) {
         {
             std::vector<nebula::Row> expected;
             nebula::Row row;
-            // The first two is kVid and kTag
-            std::vector<Value> values {"Tim Duncan", 1, "Tim Duncan", 44, false, 19, 1997, 2016,
-                                       1392, 19.0, 1, "America", 5};
-            // team: kVid, kTag and 1 property, tag3: kVid, kTag and 11 property, total 16
+            // The first one is kVid, and player have 2 + 11 properties in key and value
+            std::vector<Value> values{"Tim Duncan", "Tim Duncan", 1, "Tim Duncan", 44, false, 19,
+                                      1997, 2016, 1392, 19.0, 1, "America", 5};
+            // team: kVid, kTag and 1 property, tag3: kVid, kTag and 11 property, in total 16
             for (size_t i = 0; i < 16; i++) {
                 values.emplace_back(Value());
             }
             row.values = std::move(values);
             expected.emplace_back(std::move(row));
-            ASSERT_TRUE(resp.__isset.props);
+            // kVid, player: 2 + 11, team: 2 + 1, tag3: 2 + 11
+            ASSERT_EQ(1 + 13 + 3 + 13, resp.props.colNames.size());
             verifyResult(expected, resp.props);
         }
     }

--- a/src/storage/test/QueryTestUtils.h
+++ b/src/storage/test/QueryTestUtils.h
@@ -441,11 +441,11 @@ public:
                 std::vector<std::string> cols;
                 folly::split(":", colNames[i + 2], cols);
                 if (tags[i].first == 1) {
-                    // 2 for _tag and tag name, 2 for kVid and kTag, 11 for property
-                    ASSERT_EQ(2 + 2 + 11, cols.size());
+                    // 2 for _tag and tag name, 11 for property
+                    ASSERT_EQ(2 + 11, cols.size());
                 } else if (tags[i].first == 2) {
-                    // 2 for _tag and tag name, 2 for kVid and kTag, 1 for property
-                    ASSERT_EQ(2 + 2 + 1, cols.size());
+                    // 2 for _tag and tag name, 1 for property
+                    ASSERT_EQ(2 + 1, cols.size());
                 }
                 continue;
             }
@@ -460,11 +460,11 @@ public:
                 std::vector<std::string> cols;
                 folly::split(":", colNames[i + 2 + tags.size()], cols);
                 if (edges[i].first == 101 || edges[i].first == -101) {
-                    // 2 for _edge and edge name, 4 for kSrc kType kRank kDst, 9 for property
-                    ASSERT_EQ(2 + 4 + 9, cols.size());
+                    // 2 for _edge and edge name, 9 for property
+                    ASSERT_EQ(2 + 9, cols.size());
                 } else if (edges[i].first == 102 || edges[i].first == -102) {
-                    // 2 for _edge and edge name, 4 for kSrc kType kRank kDst, 5 for property
-                    ASSERT_EQ(2 + 4 + 5, cols.size());
+                    // 2 for _edge and edge name, 5 for property
+                    ASSERT_EQ(2 + 5, cols.size());
                 }
                 continue;
             }
@@ -484,28 +484,26 @@ public:
         // if no property specified, would return all props
         if (props.empty()) {
             ASSERT_EQ(player.name_, values[0].getStr());
-            ASSERT_EQ(1, values[1].getInt());
-            ASSERT_EQ(player.name_, values[2].getStr());
-            ASSERT_EQ(player.age_, values[3].getInt());
-            ASSERT_EQ(player.playing_, values[4].getBool());
-            ASSERT_EQ(player.career_, values[5].getInt());
-            ASSERT_EQ(player.startYear_, values[6].getInt());
-            ASSERT_EQ(player.endYear_, values[7].getInt());
-            ASSERT_EQ(player.games_, values[8].getInt());
-            ASSERT_EQ(player.avgScore_, values[9].getFloat());
-            ASSERT_EQ(player.serveTeams_, values[10].getInt());
+            ASSERT_EQ(player.age_, values[1].getInt());
+            ASSERT_EQ(player.playing_, values[2].getBool());
+            ASSERT_EQ(player.career_, values[3].getInt());
+            ASSERT_EQ(player.startYear_, values[4].getInt());
+            ASSERT_EQ(player.endYear_, values[5].getInt());
+            ASSERT_EQ(player.games_, values[6].getInt());
+            ASSERT_EQ(player.avgScore_, values[7].getFloat());
+            ASSERT_EQ(player.serveTeams_, values[8].getInt());
             int32_t hasTtl = FLAGS_mock_ttl_col ? 1 : 0;
             if (player.country_.empty()) {
                 // default value
-                ASSERT_EQ("America", values[11 + hasTtl].getStr());
+                ASSERT_EQ("America", values[9 + hasTtl].getStr());
             } else {
-                ASSERT_EQ(player.country_, values[11 + hasTtl].getStr());
+                ASSERT_EQ(player.country_, values[9 + hasTtl].getStr());
             }
             if (player.champions_ == 0) {
                 // 0 means not initialized, should return null
-                ASSERT_EQ(NullType::__NULL__, values[12 + hasTtl].getNull());
+                ASSERT_EQ(NullType::__NULL__, values[10 + hasTtl].getNull());
             } else {
-                ASSERT_EQ(player.champions_, values[12 + hasTtl].getInt());
+                ASSERT_EQ(player.champions_, values[10 + hasTtl].getInt());
             }
             return;
         }
@@ -559,8 +557,6 @@ public:
         // if no property specified, would return all props
         if (props.empty()) {
             ASSERT_EQ(team, values[0].getStr());
-            ASSERT_EQ(2, values[1].getInt());
-            ASSERT_EQ(team, values[2].getStr());
             return;
         }
         ASSERT_EQ(props.size(), values.size());
@@ -587,10 +583,10 @@ public:
             auto iter = std::find_if(serves.begin(), serves.end(), [&] (const auto& serve) {
                 // Find corresponding record by team name and start year,
                 // in case a player serve the same team more than once.
-                // The teamName and startYear would be in col 5 and 6, the first four
+                // The teamName and startYear would be in col 1 and 2, the first four
                 // property would be property in key
-                return serve.teamName_ == values[1 + 4].getStr() &&
-                       serve.startYear_ == values[2 + 4].getInt();
+                return serve.teamName_ == values[1].getStr() &&
+                       serve.startYear_ == values[2].getInt();
             });
             ASSERT_TRUE(iter != serves.end());
             checkAllPropertyOfServe(edgeType, *iter, values);
@@ -615,10 +611,10 @@ public:
             auto iter = std::find_if(serves.begin(), serves.end(), [&] (const auto& serve) {
                 // Find corresponding record by player name and start year,
                 // in case a player serve the same team more than once.
-                // The playerName and startYear would be in col 4 and 6, the first four
+                // The playerName and startYear would be in col 0 and 2, the first four
                 // property would be property in key
-                return serve.playerName_ == values[0 + 4].getStr() &&
-                       serve.startYear_ == values[2 + 4].getInt();
+                return serve.playerName_ == values[0].getStr() &&
+                       serve.startYear_ == values[2].getInt();
             });
             ASSERT_TRUE(iter != serves.end());
             checkAllPropertyOfServe(edgeType, *iter, values);
@@ -636,37 +632,26 @@ public:
     static void checkAllPropertyOfServe(EdgeType edgeType,
                                         const mock::Serve& serve,
                                         const std::vector<Value>& values) {
-        // property in key
-        if (edgeType > 0) {
-            ASSERT_EQ(serve.playerName_, values[0].getStr());
-            ASSERT_EQ(edgeType, values[1].getInt());
-            ASSERT_EQ(serve.startYear_, values[2].getInt());
-            ASSERT_EQ(serve.teamName_, values[3].getStr());
-        } else {
-            ASSERT_EQ(serve.teamName_, values[0].getStr());
-            ASSERT_EQ(edgeType, values[1].getInt());
-            ASSERT_EQ(serve.startYear_, values[2].getInt());
-            ASSERT_EQ(serve.playerName_, values[3].getStr());
-        }
+        UNUSED(edgeType);
         // property in value
-        ASSERT_EQ(serve.playerName_, values[4].getStr());
-        ASSERT_EQ(serve.teamName_, values[5].getStr());
-        ASSERT_EQ(serve.startYear_, values[6].getInt());
-        ASSERT_EQ(serve.endYear_, values[7].getInt());
-        ASSERT_EQ(serve.teamCareer_, values[8].getInt());
-        ASSERT_EQ(serve.teamGames_, values[9].getInt());
-        ASSERT_EQ(serve.teamAvgScore_, values[10].getFloat());
+        ASSERT_EQ(serve.playerName_, values[0].getStr());
+        ASSERT_EQ(serve.teamName_, values[1].getStr());
+        ASSERT_EQ(serve.startYear_, values[2].getInt());
+        ASSERT_EQ(serve.endYear_, values[3].getInt());
+        ASSERT_EQ(serve.teamCareer_, values[4].getInt());
+        ASSERT_EQ(serve.teamGames_, values[5].getInt());
+        ASSERT_EQ(serve.teamAvgScore_, values[6].getFloat());
         int32_t hasTtl = FLAGS_mock_ttl_col ? 1 : 0;
         if (serve.type_.empty()) {
-            ASSERT_EQ("trade", values[11 + hasTtl].getStr());
+            ASSERT_EQ("trade", values[7 + hasTtl].getStr());
         } else {
-            ASSERT_EQ(serve.type_, values[11 + hasTtl].getStr());
+            ASSERT_EQ(serve.type_, values[7 + hasTtl].getStr());
         }
         if (serve.champions_ == 0) {
             // 0 means not initialized, should return null
-            ASSERT_EQ(NullType::__NULL__, values[12 + hasTtl].getNull());
+            ASSERT_EQ(NullType::__NULL__, values[8 + hasTtl].getNull());
         } else {
-            ASSERT_EQ(serve.champions_, values[12 + hasTtl].getInt());
+            ASSERT_EQ(serve.champions_, values[8 + hasTtl].getInt());
         }
     }
 
@@ -749,22 +734,15 @@ public:
                               const std::vector<std::string>& props,
                               const std::vector<Value>& values) {
         if (props.empty()) {
-            auto player1 = values[4].getStr();
-            auto player2 = values[5].getStr();
+            auto player1 = values[0].getStr();
+            auto player2 = values[1].getStr();
             const auto& teammate = findTeammate(player1, player2);
-            // property in key
-            ASSERT_TRUE(teammate.player1_ == values[0].getStr() ||
-                        teammate.player2_ == values[0].getStr());
-            ASSERT_EQ(edgeType, values[1].getInt());
-            ASSERT_EQ(teammate.startYear_, values[2].getInt());
-            ASSERT_TRUE(teammate.player1_ == values[3].getStr() ||
-                        teammate.player2_ == values[3].getStr());
             // property in value
-            ASSERT_EQ(teammate.player1_, values[4].getStr());
-            ASSERT_EQ(teammate.player2_, values[5].getStr());
-            ASSERT_EQ(teammate.teamName_, values[6].getStr());
-            ASSERT_EQ(teammate.startYear_, values[7].getInt());
-            ASSERT_EQ(teammate.endYear_, values[8].getInt());
+            ASSERT_EQ(teammate.player1_, values[0].getStr());
+            ASSERT_EQ(teammate.player2_, values[1].getStr());
+            ASSERT_EQ(teammate.teamName_, values[2].getStr());
+            ASSERT_EQ(teammate.startYear_, values[3].getInt());
+            ASSERT_EQ(teammate.endYear_, values[4].getInt());
             return;
         }
         // Make sure _src and _dst is the first two props

--- a/src/storage/test/ScanEdgePropBenchmark.cpp
+++ b/src/storage/test/ScanEdgePropBenchmark.cpp
@@ -137,8 +137,9 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             ASSERT_TRUE(schema != nullptr);
             auto wrapper = std::make_unique<RowReaderWrapper>();
             ASSERT_TRUE(wrapper->reset(schema.get(), val, readerVer));
-            auto code = node.collectEdgeProps(wrapper.get(), key, vIdLen, isIntId, &props, list);
-            ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
+            auto code = QueryUtils::collectEdgeProps(key, vIdLen, isIntId,
+                                                     wrapper.get(), &props, list);
+            ASSERT_TRUE(code.ok());
             result.mutableList().values.emplace_back(std::move(list));
         }
         LOG(WARNING) << "ProcessEdgeProps with schema from map: process " << edgeRowCount
@@ -163,8 +164,9 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             reader = RowReaderWrapper::getEdgePropReader(env->schemaMan_, spaceId,
                                                          std::abs(edgeType), val);
             ASSERT_TRUE(reader.get() != nullptr);
-            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, isIntId, &props, list);
-            ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
+            auto code = QueryUtils::collectEdgeProps(key, vIdLen, isIntId,
+                                                     reader.get(), &props, list);
+            ASSERT_TRUE(code.ok());
             result.mutableList().values.emplace_back(std::move(list));
         }
         LOG(WARNING) << "ProcessEdgeProps without reader reset: process " << edgeRowCount
@@ -189,8 +191,9 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             reader = RowReaderWrapper::getEdgePropReader(env->schemaMan_, spaceId,
                                                          std::abs(edgeType), val);
             ASSERT_TRUE(reader.get() != nullptr);
-            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, isIntId, &props, list);
-            ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
+            auto code = QueryUtils::collectEdgeProps(key, vIdLen, isIntId,
+                                                     reader.get(), &props, list);
+            ASSERT_TRUE(code.ok());
             result.mutableList().values.emplace_back(std::move(list));
         }
         LOG(WARNING) << "ProcessEdgeProps with reader reset: process " << edgeRowCount
@@ -227,8 +230,9 @@ TEST_P(ScanEdgePropBench, ProcessEdgeProps) {
             } else {
                 ASSERT_TRUE(reader->reset(schemas, val));
             }
-            auto code = node.collectEdgeProps(reader.get(), key, vIdLen, isIntId, &props, list);
-            ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, code);
+            auto code = QueryUtils::collectEdgeProps(key, vIdLen, isIntId,
+                                                     reader.get(), &props, list);
+            ASSERT_TRUE(code.ok());
             result.mutableList().values.emplace_back(std::move(list));
         }
         LOG(WARNING) << "ProcessEdgeProps using local schmeas: process " << edgeRowCount

--- a/src/storage/test/ScanEdgeTest.cpp
+++ b/src/storage/test/ScanEdgeTest.cpp
@@ -52,8 +52,9 @@ void checkResponse(const nebula::DataSet& dataSet,
     }
     totalRowCount += dataSet.rows.size();
     for (const auto& row : dataSet.rows) {
+        // always pass name or kSrc at first
         auto srcId = row.values[0].getStr();
-        auto edgeType = row.values[1].getInt();
+        auto edgeType = edge.first;
         ASSERT_EQ(expectColumnCount, row.values.size());
         auto props = edge.second;
         switch (edgeType) {
@@ -119,8 +120,8 @@ TEST(ScanEdgeTest, PropertyTest) {
             auto resp = std::move(f).get();
 
             ASSERT_EQ(0, resp.result.failed_parts.size());
-            // all 9 columns in value and 4 columns in key
-            checkResponse(resp.edge_data, edge, 4 + 9, totalRowCount);
+            // all 9 columns in value
+            checkResponse(resp.edge_data, edge, 9, totalRowCount);
         }
         CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
     }

--- a/src/storage/test/ScanEdgeTest.cpp
+++ b/src/storage/test/ScanEdgeTest.cpp
@@ -18,7 +18,6 @@ cpp2::ScanEdgeRequest buildRequest(
         const std::string& cursor,
         const std::pair<EdgeType, std::vector<std::string>>& edge,
         int32_t rowLimit = 100,
-        bool returnNoColumns = false,
         int64_t startTime = 0,
         int64_t endTime = std::numeric_limits<int64_t>::max(),
         bool onlyLatestVer = false) {
@@ -33,7 +32,6 @@ cpp2::ScanEdgeRequest buildRequest(
         edgeProp.props.emplace_back(std::move(prop));
     }
     req.set_return_columns(std::move(edgeProp));
-    req.set_no_columns(returnNoColumns);
     req.set_limit(rowLimit);
     req.set_start_time(startTime);
     req.set_end_time(endTime);
@@ -43,20 +41,28 @@ cpp2::ScanEdgeRequest buildRequest(
 
 void checkResponse(const nebula::DataSet& dataSet,
                    const std::pair<EdgeType, std::vector<std::string>> edge,
-                   std::unordered_map<TagID, size_t>& expectColumnCount,
+                   size_t expectColumnCount,
                    size_t& totalRowCount) {
+    ASSERT_EQ(dataSet.colNames.size(), expectColumnCount);
+    if (!edge.second.empty()) {
+        ASSERT_EQ(dataSet.colNames.size(), edge.second.size());
+        for (size_t i = 0; i < dataSet.colNames.size(); i++) {
+            ASSERT_EQ(dataSet.colNames[i], std::to_string(edge.first) + "." + edge.second[i]);
+        }
+    }
     totalRowCount += dataSet.rows.size();
     for (const auto& row : dataSet.rows) {
         auto srcId = row.values[0].getStr();
         auto edgeType = row.values[1].getInt();
-        auto expectCol = expectColumnCount[edgeType];
-        ASSERT_EQ(expectCol, row.values.size());
+        ASSERT_EQ(expectColumnCount, row.values.size());
         auto props = edge.second;
         switch (edgeType) {
             case 101: {
                 // out edge serve
                 auto iter = mock::MockData::playerServes_.find(srcId);
                 CHECK(iter != mock::MockData::playerServes_.end());
+                // doodle
+                /*
                 std::vector<Value> values;
                 if (expectCol == 4 + 9) {
                     // return all columns, collect all columns
@@ -71,6 +77,8 @@ void checkResponse(const nebula::DataSet& dataSet,
                     }
                     QueryTestUtils::checkOutServe(edgeType, props, iter->second, values);
                 }
+                */
+                QueryTestUtils::checkOutServe(edgeType, props, iter->second, row.values, 4, 5);
                 break;
             }
             case -101: {
@@ -78,6 +86,8 @@ void checkResponse(const nebula::DataSet& dataSet,
                 auto iter = mock::MockData::teamServes_.find(srcId);
                 CHECK(iter != mock::MockData::teamServes_.end());
                 std::vector<Value> values;
+                // doodle
+                /*
                 if (expectCol == 4 + 9) {
                     // return all columns, collect all columns
                     for (size_t i = 0; i < row.values.size(); i++) {
@@ -91,6 +101,8 @@ void checkResponse(const nebula::DataSet& dataSet,
                     }
                     QueryTestUtils::checkInServe(edgeType, props, iter->second, values);
                 }
+                */
+                QueryTestUtils::checkInServe(edgeType, props, iter->second, row.values);
                 break;
             }
             default:
@@ -114,10 +126,8 @@ TEST(ScanEdgeTest, PropertyTest) {
     {
         LOG(INFO) << "Scan one edge with some properties in one batch";
         size_t totalRowCount = 0;
-        auto edge =
-            std::make_pair(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 3);
+        auto edge = std::make_pair(serve, std::vector<std::string>{
+            kSrc, kType, kRank, kDst, "teamName", "startYear", "endYear"});
         for (PartitionID partId = 1; partId <= totalParts; partId++) {
             auto req = buildRequest(partId, "", edge);
             auto* processor = ScanEdgeProcessor::instance(env, nullptr);
@@ -126,7 +136,7 @@ TEST(ScanEdgeTest, PropertyTest) {
             auto resp = std::move(f).get();
 
             ASSERT_EQ(0, resp.result.failed_parts.size());
-            checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
+            checkResponse(resp.edge_data, edge, edge.second.size(), totalRowCount);
         }
         CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
     }
@@ -134,8 +144,6 @@ TEST(ScanEdgeTest, PropertyTest) {
         LOG(INFO) << "Scan one edge with all properties in one batch";
         size_t totalRowCount = 0;
         auto edge = std::make_pair(serve, std::vector<std::string>{});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 9);
         for (PartitionID partId = 1; partId <= totalParts; partId++) {
             auto req = buildRequest(partId, "", edge);
             auto* processor = ScanEdgeProcessor::instance(env, nullptr);
@@ -144,25 +152,8 @@ TEST(ScanEdgeTest, PropertyTest) {
             auto resp = std::move(f).get();
 
             ASSERT_EQ(0, resp.result.failed_parts.size());
-            checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
-        }
-        CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
-    }
-    {
-        LOG(INFO) << "Scan one edge with no properties in one batch";
-        size_t totalRowCount = 0;
-        auto edge = std::make_pair(serve, std::vector<std::string>{});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 0);
-        for (PartitionID partId = 1; partId <= totalParts; partId++) {
-            auto req = buildRequest(partId, "", edge, 100, true);
-            auto* processor = ScanEdgeProcessor::instance(env, nullptr);
-            auto f = processor->getFuture();
-            processor->process(req);
-            auto resp = std::move(f).get();
-
-            ASSERT_EQ(0, resp.result.failed_parts.size());
-            checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
+            // all 9 columns in value and 4 columns in key
+            checkResponse(resp.edge_data, edge, 4 + 9, totalRowCount);
         }
         CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
     }
@@ -182,10 +173,8 @@ TEST(ScanEdgeTest, CursorTest) {
     {
         LOG(INFO) << "Scan one edge with some properties with limit = 5";
         size_t totalRowCount = 0;
-        auto edge =
-            std::make_pair(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 3);
+        auto edge = std::make_pair(serve, std::vector<std::string>{
+            kSrc, kType, kRank, kDst, "teamName", "startYear", "endYear"});
         for (PartitionID partId = 1; partId <= totalParts; partId++) {
             bool hasNext = true;
             std::string cursor = "";
@@ -197,7 +186,7 @@ TEST(ScanEdgeTest, CursorTest) {
                 auto resp = std::move(f).get();
 
                 ASSERT_EQ(0, resp.result.failed_parts.size());
-                checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
+                checkResponse(resp.edge_data, edge, edge.second.size(), totalRowCount);
                 hasNext = resp.get_has_next();
                 if (hasNext) {
                     CHECK(resp.__isset.next_cursor);
@@ -210,10 +199,8 @@ TEST(ScanEdgeTest, CursorTest) {
     {
         LOG(INFO) << "Scan one edge with some properties with limit = 1";
         size_t totalRowCount = 0;
-        auto edge =
-            std::make_pair(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 3);
+        auto edge = std::make_pair(serve, std::vector<std::string>{
+            kSrc, kType, kRank, kDst, "teamName", "startYear", "endYear"});
         for (PartitionID partId = 1; partId <= totalParts; partId++) {
             bool hasNext = true;
             std::string cursor = "";
@@ -225,7 +212,7 @@ TEST(ScanEdgeTest, CursorTest) {
                 auto resp = std::move(f).get();
 
                 ASSERT_EQ(0, resp.result.failed_parts.size());
-                checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
+                checkResponse(resp.edge_data, edge, edge.second.size(), totalRowCount);
                 hasNext = resp.get_has_next();
                 if (hasNext) {
                     CHECK(resp.__isset.next_cursor);
@@ -255,20 +242,18 @@ TEST(ScanEdgeTest, OnlyLatestVerTest) {
     {
         LOG(INFO) << "Scan one edge with some properties only latest version";
         size_t totalRowCount = 0;
-        auto edge =
-            std::make_pair(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 3);
+        auto edge = std::make_pair(serve, std::vector<std::string>{
+            kSrc, kType, kRank, kDst, "teamName", "startYear", "endYear"});
         for (PartitionID partId = 1; partId <= totalParts; partId++) {
             auto req = buildRequest(
-                partId, "", edge, 100, false, 0, std::numeric_limits<int64_t>::max(), true);
+                partId, "", edge, 100, 0, std::numeric_limits<int64_t>::max(), true);
             auto* processor = ScanEdgeProcessor::instance(env, nullptr);
             auto f = processor->getFuture();
             processor->process(req);
             auto resp = std::move(f).get();
 
             ASSERT_EQ(0, resp.result.failed_parts.size());
-            checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
+            checkResponse(resp.edge_data, edge, edge.second.size(), totalRowCount);
         }
         CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
     }
@@ -276,20 +261,18 @@ TEST(ScanEdgeTest, OnlyLatestVerTest) {
     {
         LOG(INFO) << "Scan one edge with some properties all version";
         size_t totalRowCount = 0;
-        auto edge =
-            std::make_pair(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
-        std::unordered_map<TagID, size_t> expectColumnCount;
-        expectColumnCount.emplace(serve, 4 + 3);
+        auto edge = std::make_pair(serve, std::vector<std::string>{
+            kSrc, kType, kRank, kDst, "teamName", "startYear", "endYear"});
         for (PartitionID partId = 1; partId <= totalParts; partId++) {
             auto req = buildRequest(
-                partId, "", edge, 100, false, 0, std::numeric_limits<int64_t>::max(), true);
+                partId, "", edge, 100, 0, std::numeric_limits<int64_t>::max(), true);
             auto* processor = ScanEdgeProcessor::instance(env, nullptr);
             auto f = processor->getFuture();
             processor->process(req);
             auto resp = std::move(f).get();
 
             ASSERT_EQ(0, resp.result.failed_parts.size());
-            checkResponse(resp.edge_data, edge, expectColumnCount, totalRowCount);
+            checkResponse(resp.edge_data, edge, edge.second.size(), totalRowCount);
         }
         CHECK_EQ(mock::MockData::serves_.size(), totalRowCount);
     }

--- a/src/storage/test/ScanEdgeTest.cpp
+++ b/src/storage/test/ScanEdgeTest.cpp
@@ -61,23 +61,6 @@ void checkResponse(const nebula::DataSet& dataSet,
                 // out edge serve
                 auto iter = mock::MockData::playerServes_.find(srcId);
                 CHECK(iter != mock::MockData::playerServes_.end());
-                // doodle
-                /*
-                std::vector<Value> values;
-                if (expectCol == 4 + 9) {
-                    // return all columns, collect all columns
-                    for (size_t i = 0; i < row.values.size(); i++) {
-                        values.emplace_back(std::move(row.values[i]));
-                    }
-                    QueryTestUtils::checkOutServe(edgeType, props, iter->second, values);
-                } else if (expectCol > 4) {
-                    // return some properties, collect properites starting from fifth column
-                    for (size_t i = 4; i < row.values.size(); i++) {
-                        values.emplace_back(std::move(row.values[i]));
-                    }
-                    QueryTestUtils::checkOutServe(edgeType, props, iter->second, values);
-                }
-                */
                 QueryTestUtils::checkOutServe(edgeType, props, iter->second, row.values, 4, 5);
                 break;
             }
@@ -86,22 +69,6 @@ void checkResponse(const nebula::DataSet& dataSet,
                 auto iter = mock::MockData::teamServes_.find(srcId);
                 CHECK(iter != mock::MockData::teamServes_.end());
                 std::vector<Value> values;
-                // doodle
-                /*
-                if (expectCol == 4 + 9) {
-                    // return all columns, collect all columns
-                    for (size_t i = 0; i < row.values.size(); i++) {
-                        values.emplace_back(std::move(row.values[i]));
-                    }
-                    QueryTestUtils::checkInServe(edgeType, props, iter->second, values);
-                } else if (expectCol > 4) {
-                    // return some properties, collect properites starting from fifth column
-                    for (size_t i = 4; i < row.values.size(); i++) {
-                        values.emplace_back(std::move(row.values[i]));
-                    }
-                    QueryTestUtils::checkInServe(edgeType, props, iter->second, values);
-                }
-                */
                 QueryTestUtils::checkInServe(edgeType, props, iter->second, row.values);
                 break;
             }

--- a/src/storage/test/ScanVertexTest.cpp
+++ b/src/storage/test/ScanVertexTest.cpp
@@ -52,8 +52,9 @@ void checkResponse(const nebula::DataSet& dataSet,
     }
     totalRowCount += dataSet.rows.size();
     for (const auto& row : dataSet.rows) {
+        // always pass player name or kVid at first
         auto vId = row.values[0].getStr();
-        auto tagId = row.values[1].getInt();
+        auto tagId = tag.first;
         ASSERT_EQ(expectColumnCount, row.values.size());
         auto props = tag.second;
         switch (tagId) {
@@ -120,8 +121,8 @@ TEST(ScanVertexTest, PropertyTest) {
             auto resp = std::move(f).get();
 
             ASSERT_EQ(0, resp.result.failed_parts.size());
-            // all 11 columns in value and 2 columns in key
-            checkResponse(resp.vertex_data, tag, 2 + 11, totalRowCount);
+            // all 11 columns in value
+            checkResponse(resp.vertex_data, tag, 11, totalRowCount);
         }
         CHECK_EQ(mock::MockData::players_.size(), totalRowCount);
     }

--- a/src/storage/test/ScanVertexTest.cpp
+++ b/src/storage/test/ScanVertexTest.cpp
@@ -63,17 +63,6 @@ void checkResponse(const nebula::DataSet& dataSet,
                                          mock::MockData::players_.end(),
                                          [&] (const auto& player) { return player.name_ == vId; });
                 CHECK(iter != mock::MockData::players_.end());
-                // doodle
-                /*
-                if (expectCol > 2) {
-                    std::vector<Value> values;
-                    // properties starts from the third column
-                    for (size_t i = 2; i < row.values.size(); i++) {
-                        values.emplace_back(std::move(row.values[i]));
-                    }
-                    QueryTestUtils::checkPlayer(props, *iter, values);
-                }
-                */
                 QueryTestUtils::checkPlayer(props, *iter, row.values);
                 break;
             }
@@ -82,19 +71,6 @@ void checkResponse(const nebula::DataSet& dataSet,
                 auto iter = std::find(mock::MockData::teams_.begin(),
                                       mock::MockData::teams_.end(),
                                       vId);
-                // doodle
-                /*
-                CHECK(iter != mock::MockData::teams_.end());
-                if (expectCol > 2) {
-                    std::vector<Value> values;
-                    // properties starts from the third column
-                    for (size_t i = 2; i < row.values.size(); i++) {
-                        values.emplace_back(std::move(row.values[i]));
-                    }
-                    ASSERT_EQ(1, values.size());
-                    ASSERT_EQ(*iter, values[0].getStr());
-                }
-                */
                 QueryTestUtils::checkTeam(props, *iter, row.values);
                 break;
             }

--- a/src/storage/test/UpdateEdgeTest.cpp
+++ b/src/storage/test/UpdateEdgeTest.cpp
@@ -91,6 +91,33 @@ static bool mockEdgeData(storage::StorageEnv* env, int32_t totalParts, int32_t s
     return true;
 }
 
+void addEdgePropInKey(std::vector<std::string>& returnCols) {
+    {
+        auto* edge = new std::string("101");
+        auto* prop = new std::string(kSrc);
+        EdgePropertyExpression exp(edge, prop);
+        returnCols.emplace_back(Expression::encode(exp));
+    }
+    {
+        auto* edge = new std::string("101");
+        auto* prop = new std::string(kType);
+        EdgePropertyExpression exp(edge, prop);
+        returnCols.emplace_back(Expression::encode(exp));
+    }
+    {
+        auto* edge = new std::string("101");
+        auto* prop = new std::string(kRank);
+        EdgePropertyExpression exp(edge, prop);
+        returnCols.emplace_back(Expression::encode(exp));
+    }
+    {
+        auto* edge = new std::string("101");
+        auto* prop = new std::string(kDst);
+        EdgePropertyExpression exp(edge, prop);
+        returnCols.emplace_back(Expression::encode(exp));
+    }
+}
+
 // No filter, update success
 TEST(UpdateEdgeTest, No_Filter_Test) {
     fs::TempDir rootPath("/tmp/UpdateEdgeTest.XXXXXX");
@@ -164,6 +191,8 @@ TEST(UpdateEdgeTest, No_Filter_Test) {
         EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
         tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+        addEdgePropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
         req.set_insertable(false);
 
@@ -175,20 +204,28 @@ TEST(UpdateEdgeTest, No_Filter_Test) {
 
         LOG(INFO) << "Check the results...";
         EXPECT_EQ(0, resp.result.failed_parts.size());
-        EXPECT_EQ(5, resp.props.colNames.size());
+        EXPECT_EQ(9, resp.props.colNames.size());
         EXPECT_EQ("_inserted", resp.props.colNames[0]);
-        EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-        EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-        EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-        EXPECT_EQ("101:type", resp.props.colNames[4]);
+        EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+        EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+        EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+        EXPECT_EQ("101.type", resp.props.colNames[4]);
+        EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+        EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+        EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+        EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
         EXPECT_EQ(1, resp.props.rows.size());
-        EXPECT_EQ(5, resp.props.rows[0].values.size());
+        EXPECT_EQ(9, resp.props.rows[0].values.size());
         EXPECT_EQ(false, resp.props.rows[0].values[0].getBool());
         EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
         EXPECT_EQ("Spurs", resp.props.rows[0].values[2].getStr());
         EXPECT_EQ(20, resp.props.rows[0].values[3].getInt());
         EXPECT_EQ("trade", resp.props.rows[0].values[4].getStr());
+        EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[5].getStr());
+        EXPECT_EQ(101, resp.props.rows[0].values[6].getInt());
+        EXPECT_EQ(1997, resp.props.rows[0].values[7].getInt());
+        EXPECT_EQ("Spurs", resp.props.rows[0].values[8].getStr());
 
         // get serve from kvstore directly
         auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);
@@ -272,6 +309,8 @@ TEST(UpdateEdgeTest, No_Filter_Test) {
         EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
         tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+        addEdgePropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
         req.set_insertable(false);
 
@@ -283,20 +322,28 @@ TEST(UpdateEdgeTest, No_Filter_Test) {
 
         LOG(INFO) << "Check the results...";
         EXPECT_EQ(0, resp.result.failed_parts.size());
-        EXPECT_EQ(5, resp.props.colNames.size());
+        EXPECT_EQ(9, resp.props.colNames.size());
         EXPECT_EQ("_inserted", resp.props.colNames[0]);
-        EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-        EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-        EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-        EXPECT_EQ("101:type", resp.props.colNames[4]);
+        EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+        EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+        EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+        EXPECT_EQ("101.type", resp.props.colNames[4]);
+        EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+        EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+        EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+        EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
         EXPECT_EQ(1, resp.props.rows.size());
-        EXPECT_EQ(5, resp.props.rows[0].values.size());
+        EXPECT_EQ(9, resp.props.rows[0].values.size());
         EXPECT_EQ(false, resp.props.rows[0].values[0].getBool());
         EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
         EXPECT_EQ("Spurs", resp.props.rows[0].values[2].getStr());
         EXPECT_EQ(20, resp.props.rows[0].values[3].getInt());
         EXPECT_EQ("trade", resp.props.rows[0].values[4].getStr());
+        EXPECT_EQ("Spurs", resp.props.rows[0].values[5].getStr());
+        EXPECT_EQ(-101, resp.props.rows[0].values[6].getInt());
+        EXPECT_EQ(1997, resp.props.rows[0].values[7].getInt());
+        EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[8].getStr());
 
         // get serve from kvstore directly
         auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);
@@ -417,6 +464,8 @@ TEST(UpdateEdgeTest, Filter_Yield_Test) {
     EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
     tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+    addEdgePropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(false);
 
@@ -430,22 +479,30 @@ TEST(UpdateEdgeTest, Filter_Yield_Test) {
     EXPECT_EQ(1, resp.result.failed_parts.size());
 
     // Note: If filtered out, the result is old
-    EXPECT_EQ(5, resp.props.colNames.size());
+    EXPECT_EQ(9, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-    EXPECT_EQ("101:type", resp.props.colNames[4]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.type", resp.props.colNames[4]);
+    EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+    EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+    EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+    EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
     // filter, return old value
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(5, resp.props.rows[0].values.size());
+    EXPECT_EQ(9, resp.props.rows[0].values.size());
 
     EXPECT_EQ(false, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ("Spurs", resp.props.rows[0].values[2].getStr());
     EXPECT_EQ(19, resp.props.rows[0].values[3].getInt());
     EXPECT_EQ("zzzzz", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[5].getStr());
+    EXPECT_EQ(101, resp.props.rows[0].values[6].getInt());
+    EXPECT_EQ(1997, resp.props.rows[0].values[7].getInt());
+    EXPECT_EQ("Spurs", resp.props.rows[0].values[8].getStr());
 
     // get serve from kvstore directly
     // Because no update, the value is old
@@ -558,6 +615,8 @@ TEST(UpdateEdgeTest, Insertable_Test) {
     EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
     tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+    addEdgePropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(true);
 
@@ -569,20 +628,28 @@ TEST(UpdateEdgeTest, Insertable_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(5, resp.props.colNames.size());
+    EXPECT_EQ(9, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-    EXPECT_EQ("101:type", resp.props.colNames[4]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.type", resp.props.colNames[4]);
+    EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+    EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+    EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+    EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(5, resp.props.rows[0].values.size());
+    EXPECT_EQ(9, resp.props.rows[0].values.size());
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ("Lakers", resp.props.rows[0].values[2].getStr());
     EXPECT_EQ(1, resp.props.rows[0].values[3].getInt());
     EXPECT_EQ("trade", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[5].getStr());
+    EXPECT_EQ(101, resp.props.rows[0].values[6].getInt());
+    EXPECT_EQ(2016, resp.props.rows[0].values[7].getInt());
+    EXPECT_EQ("Lakers", resp.props.rows[0].values[8].getStr());
 
     // get serve from kvstore directly
     auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);
@@ -956,6 +1023,8 @@ TEST(UpdateEdgeTest, Insertable_Filter_value_Test) {
     EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
     tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+    addEdgePropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(true);
 
@@ -967,21 +1036,29 @@ TEST(UpdateEdgeTest, Insertable_Filter_value_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(5, resp.props.colNames.size());
+    EXPECT_EQ(9, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-    EXPECT_EQ("101:type", resp.props.colNames[4]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.type", resp.props.colNames[4]);
+    EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+    EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+    EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+    EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(5, resp.props.rows[0].values.size());
+    EXPECT_EQ(9, resp.props.rows[0].values.size());
 
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ("Lakers", resp.props.rows[0].values[2].getStr());
     EXPECT_EQ(1, resp.props.rows[0].values[3].getInt());
     EXPECT_EQ("trade", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[5].getStr());
+    EXPECT_EQ(101, resp.props.rows[0].values[6].getInt());
+    EXPECT_EQ(2016, resp.props.rows[0].values[7].getInt());
+    EXPECT_EQ("Lakers", resp.props.rows[0].values[8].getStr());
 
     // get serve from kvstore directly
     auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);
@@ -1262,6 +1339,8 @@ TEST(UpdateEdgeTest, TTL_Insert_No_Exist_Test) {
     EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
     tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+    addEdgePropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(true);
 
@@ -1275,21 +1354,29 @@ TEST(UpdateEdgeTest, TTL_Insert_No_Exist_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(5, resp.props.colNames.size());
+    EXPECT_EQ(9, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-    EXPECT_EQ("101:type", resp.props.colNames[4]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.type", resp.props.colNames[4]);
+    EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+    EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+    EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+    EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(5, resp.props.rows[0].values.size());
+    EXPECT_EQ(9, resp.props.rows[0].values.size());
 
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ("Spurs", resp.props.rows[0].values[2].getStr());
     EXPECT_EQ(1, resp.props.rows[0].values[3].getInt());
     EXPECT_EQ("trade", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ("Tim", resp.props.rows[0].values[5].getStr());
+    EXPECT_EQ(101, resp.props.rows[0].values[6].getInt());
+    EXPECT_EQ(1997, resp.props.rows[0].values[7].getInt());
+    EXPECT_EQ("Spurs", resp.props.rows[0].values[8].getStr());
 
     // get serve from kvstore directly
     auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);
@@ -1396,6 +1483,8 @@ TEST(UpdateEdgeTest, TTL_Insert_Test) {
     EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
     tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+    addEdgePropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(true);
 
@@ -1409,21 +1498,29 @@ TEST(UpdateEdgeTest, TTL_Insert_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(5, resp.props.colNames.size());
+    EXPECT_EQ(9, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-    EXPECT_EQ("101:type", resp.props.colNames[4]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.type", resp.props.colNames[4]);
+    EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[5]);
+    EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[6]);
+    EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[7]);
+    EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[8]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(5, resp.props.rows[0].values.size());
+    EXPECT_EQ(9, resp.props.rows[0].values.size());
 
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ("Spurs", resp.props.rows[0].values[2].getStr());
     EXPECT_EQ(40, resp.props.rows[0].values[3].getInt());
     EXPECT_EQ("trade", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[5].getStr());
+    EXPECT_EQ(101, resp.props.rows[0].values[6].getInt());
+    EXPECT_EQ(1997, resp.props.rows[0].values[7].getInt());
+    EXPECT_EQ("Spurs", resp.props.rows[0].values[8].getStr());
 
     // get serve from kvstore directly
     auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);
@@ -1534,6 +1631,7 @@ TEST(UpdateEdgeTest, Yield_Key_Test) {
     EdgePropertyExpression edgePropExp4(yEdge4, yProp4);
     tmpProps.emplace_back(Expression::encode(edgePropExp4));
 
+    // same as pass by EdgePropertyExpression
     auto* yEdge5 = new std::string("101");
     EdgeSrcIdExpression edgeSrcIdExp5(yEdge5);
     tmpProps.emplace_back(Expression::encode(edgeSrcIdExp5));
@@ -1563,14 +1661,14 @@ TEST(UpdateEdgeTest, Yield_Key_Test) {
     EXPECT_EQ(0, resp.result.failed_parts.size());
     EXPECT_EQ(9, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
-    EXPECT_EQ("101:type", resp.props.colNames[4]);
-    EXPECT_EQ("101:_src", resp.props.colNames[5]);
-    EXPECT_EQ("101:_dst", resp.props.colNames[6]);
-    EXPECT_EQ("101:_rank", resp.props.colNames[7]);
-    EXPECT_EQ("101:_type", resp.props.colNames[8]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.type", resp.props.colNames[4]);
+    EXPECT_EQ("101._src", resp.props.colNames[5]);
+    EXPECT_EQ("101._dst", resp.props.colNames[6]);
+    EXPECT_EQ("101._rank", resp.props.colNames[7]);
+    EXPECT_EQ("101._type", resp.props.colNames[8]);
 
     EXPECT_EQ(1, resp.props.rows.size());
     EXPECT_EQ(9, resp.props.rows[0].values.size());
@@ -1902,6 +2000,8 @@ TEST(UpdateEdgeTest, Insertable_In_Set_Test) {
     EdgePropertyExpression edgePropExp3(yEdge3, yProp3);
     tmpProps.emplace_back(Expression::encode(edgePropExp3));
 
+    addEdgePropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(true);
 
@@ -1913,18 +2013,26 @@ TEST(UpdateEdgeTest, Insertable_In_Set_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(8, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("101:playerName", resp.props.colNames[1]);
-    EXPECT_EQ("101:teamName", resp.props.colNames[2]);
-    EXPECT_EQ("101:teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ("101.playerName", resp.props.colNames[1]);
+    EXPECT_EQ("101.teamName", resp.props.colNames[2]);
+    EXPECT_EQ("101.teamCareer", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("101.").append(kSrc), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("101.").append(kType), resp.props.colNames[5]);
+    EXPECT_EQ(std::string("101.").append(kRank), resp.props.colNames[6]);
+    EXPECT_EQ(std::string("101.").append(kDst), resp.props.colNames[7]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(4, resp.props.rows[0].values.size());
+    EXPECT_EQ(8, resp.props.rows[0].values.size());
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ("Lakers", resp.props.rows[0].values[2].getStr());
     EXPECT_EQ(1, resp.props.rows[0].values[3].getInt());
+    EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(101, resp.props.rows[0].values[5].getInt());
+    EXPECT_EQ(2016, resp.props.rows[0].values[6].getInt());
+    EXPECT_EQ("Lakers", resp.props.rows[0].values[7].getStr());
 
     // get serve from kvstore directly
     auto prefix = NebulaKeyUtils::edgePrefix(spaceVidLen, partId, srcId, edgeType, rank, dstId);

--- a/src/storage/test/UpdateVertexTest.cpp
+++ b/src/storage/test/UpdateVertexTest.cpp
@@ -90,6 +90,21 @@ static bool mockVertexData(storage::StorageEnv* env, int32_t totalParts, int32_t
     return true;
 }
 
+void addTagPropInKey(std::vector<std::string>& returnCols) {
+    {
+        auto* tag = new std::string("1");
+        auto* prop = new std::string(kVid);
+        SourcePropertyExpression exp(tag, prop);
+        returnCols.emplace_back(Expression::encode(exp));
+    }
+    {
+        auto* tag = new std::string("1");
+        auto* prop = new std::string(kTag);
+        SourcePropertyExpression exp(tag, prop);
+        returnCols.emplace_back(Expression::encode(exp));
+    }
+}
+
 // not filter, update success
 TEST(UpdateVertexTest, No_Filter_Test) {
     fs::TempDir rootPath("/tmp/UpdateVertexTest.XXXXXX");
@@ -152,6 +167,8 @@ TEST(UpdateVertexTest, No_Filter_Test) {
     SourcePropertyExpression sourcePropExp3(yTag3, yProp3);
     tmpProps.emplace_back(Expression::encode(sourcePropExp3));
 
+    addTagPropInKey(tmpProps);
+
     req.set_return_props(std::move(tmpProps));
     req.set_insertable(false);
 
@@ -163,19 +180,23 @@ TEST(UpdateVertexTest, No_Filter_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(6, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
-    EXPECT_EQ("1:country", resp.props.colNames[3]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ("1.country", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[5]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(4, resp.props.rows[0].values.size());
+    EXPECT_EQ(6, resp.props.rows[0].values.size());
 
     EXPECT_EQ(false, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(45, resp.props.rows[0].values[2].getInt());
     EXPECT_EQ("China", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[5].getInt());
 
     // get player from kvstore directly
     auto prefix = NebulaKeyUtils::vertexPrefix(spaceVidLen, partId, vertexId, tagId);
@@ -278,6 +299,8 @@ TEST(UpdateVertexTest, Filter_Yield_Test2) {
         SourcePropertyExpression sourcePropExp3(yTag3, yProp3);
         tmpProps.emplace_back(Expression::encode(sourcePropExp3));
 
+        addTagPropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
         req.set_insertable(false);
     }
@@ -292,17 +315,22 @@ TEST(UpdateVertexTest, Filter_Yield_Test2) {
     EXPECT_EQ(1, resp.result.failed_parts.size());
 
     // Note: If filtered out, the result is old
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(6, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
-    EXPECT_EQ("1:country", resp.props.colNames[3]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ("1.country", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[5]);
 
     EXPECT_EQ(1, resp.props.rows.size());
+    EXPECT_EQ(6, resp.props.rows[0].values.size());
     EXPECT_EQ(false, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(44, resp.props.rows[0].values[2].getInt());
     EXPECT_EQ("America", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[5].getInt());
 
     // get player from kvstore directly
     // Because no update, the value is old
@@ -383,6 +411,8 @@ TEST(UpdateVertexTest, Insertable_Test) {
         SourcePropertyExpression sourcePropExp3(yTag3, yProp3);
         tmpProps.emplace_back(Expression::encode(sourcePropExp3));
 
+        addTagPropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
         req.set_insertable(true);
     }
@@ -395,17 +425,22 @@ TEST(UpdateVertexTest, Insertable_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(6, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
-    EXPECT_EQ("1:country", resp.props.colNames[3]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ("1.country", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[5]);
 
     EXPECT_EQ(1, resp.props.rows.size());
+    EXPECT_EQ(6, resp.props.rows[0].values.size());
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(20, resp.props.rows[0].values[2].getInt());
     EXPECT_EQ("America", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[5].getInt());
 
     // get player from kvstore directly
     auto prefix = NebulaKeyUtils::vertexPrefix(spaceVidLen, partId, vertexId, tagId);
@@ -711,6 +746,8 @@ TEST(UpdateVertexTest, Insertable_Filter_Value_Test) {
         SourcePropertyExpression sourcePropExp3(yTag3, yProp3);
         tmpProps.emplace_back(Expression::encode(sourcePropExp3));
 
+        addTagPropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
         req.set_insertable(true);
     }
@@ -723,17 +760,21 @@ TEST(UpdateVertexTest, Insertable_Filter_Value_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(6, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
-    EXPECT_EQ("1:country", resp.props.colNames[3]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ("1.country", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[5]);
 
     EXPECT_EQ(1, resp.props.rows.size());
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(20, resp.props.rows[0].values[2].getInt());
     EXPECT_EQ("America", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[5].getInt());
 
     // get player from kvstore directly
     auto prefix = NebulaKeyUtils::vertexPrefix(spaceVidLen, partId, vertexId, tagId);
@@ -966,6 +1007,8 @@ TEST(UpdateVertexTest, TTL_Insert_No_Exist_Test) {
         SourcePropertyExpression sourcePropExp3(yTag3, yProp3);
         tmpProps.emplace_back(Expression::encode(sourcePropExp3));
 
+        addTagPropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
     }
     req.set_insertable(true);
@@ -980,19 +1023,24 @@ TEST(UpdateVertexTest, TTL_Insert_No_Exist_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(6, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
-    EXPECT_EQ("1:country", resp.props.colNames[3]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ("1.country", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[5]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(4, resp.props.rows[0].values.size());
+    EXPECT_EQ(6, resp.props.rows[0].values.size());
 
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(20, resp.props.rows[0].values[2].getInt());
     EXPECT_EQ("America", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ("Tim", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[5].getInt());
+
 
     // get player from kvstore directly
     auto prefix = NebulaKeyUtils::vertexPrefix(spaceVidLen, partId, vertexId, tagId);
@@ -1085,6 +1133,8 @@ TEST(UpdateVertexTest, TTL_Insert_Test) {
         SourcePropertyExpression sourcePropExp3(yTag3, yProp3);
         tmpProps.emplace_back(Expression::encode(sourcePropExp3));
 
+        addTagPropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
     }
     req.set_insertable(true);
@@ -1099,19 +1149,23 @@ TEST(UpdateVertexTest, TTL_Insert_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(4, resp.props.colNames.size());
+    EXPECT_EQ(6, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
-    EXPECT_EQ("1:country", resp.props.colNames[3]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ("1.country", resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[4]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[5]);
 
     EXPECT_EQ(1, resp.props.rows.size());
-    EXPECT_EQ(4, resp.props.rows[0].values.size());
+    EXPECT_EQ(6, resp.props.rows[0].values.size());
 
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(50L, resp.props.rows[0].values[2].getInt());
     EXPECT_EQ("China", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ("Tim Duncan", resp.props.rows[0].values[4].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[5].getInt());
 
     // Get player from kvstore directly, ttl expired data can be readed
     // First record is inserted record data
@@ -1277,6 +1331,8 @@ TEST(UpdateVertexTest, Insertable_In_Set_Test) {
         SourcePropertyExpression sourcePropExp2(yTag2, yProp2);
         tmpProps.emplace_back(Expression::encode(sourcePropExp2));
 
+        addTagPropInKey(tmpProps);
+
         req.set_return_props(std::move(tmpProps));
         req.set_insertable(true);
     }
@@ -1289,15 +1345,20 @@ TEST(UpdateVertexTest, Insertable_In_Set_Test) {
 
     LOG(INFO) << "Check the results...";
     EXPECT_EQ(0, resp.result.failed_parts.size());
-    EXPECT_EQ(3, resp.props.colNames.size());
+    EXPECT_EQ(5, resp.props.colNames.size());
     EXPECT_EQ("_inserted", resp.props.colNames[0]);
-    EXPECT_EQ("1:name", resp.props.colNames[1]);
-    EXPECT_EQ("1:age", resp.props.colNames[2]);
+    EXPECT_EQ("1.name", resp.props.colNames[1]);
+    EXPECT_EQ("1.age", resp.props.colNames[2]);
+    EXPECT_EQ(std::string("1.").append(kVid), resp.props.colNames[3]);
+    EXPECT_EQ(std::string("1.").append(kTag), resp.props.colNames[4]);
 
     EXPECT_EQ(1, resp.props.rows.size());
+    EXPECT_EQ(5, resp.props.rows[0].values.size());
     EXPECT_EQ(true, resp.props.rows[0].values[0].getBool());
     EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[1].getStr());
     EXPECT_EQ(10, resp.props.rows[0].values[2].getInt());
+    EXPECT_EQ("Brandon Ingram", resp.props.rows[0].values[3].getStr());
+    EXPECT_EQ(1, resp.props.rows[0].values[4].getInt());
 
     // get player from kvstore directly
     auto prefix = NebulaKeyUtils::vertexPrefix(spaceVidLen, partId, vertexId, tagId);


### PR DESCRIPTION
Modify according to https://github.com/vesoft-inc/nebula-common/pull/323.

Another involved change is the vertex cache. We only add to cache when read, and evict in all other operations.