### PR TITLE
Choose default port numbers to reduce chances of conflicts

### DIFF
--- a/conf/nebula-metad.conf.default
+++ b/conf/nebula-metad.conf.default
@@ -15,18 +15,20 @@
 --logbufsecs=0
 
 ########## networking ##########
-# Meta Server Address
---meta_server_addrs=127.0.0.1:45500
-# Local ip
+# Comma separated Meta Server addresses
+--meta_server_addrs=127.0.0.1:9559
+# Local IP used to identify the nebula-metad process.
+# Change it to an address other than loopback if the service is distributed or
+# will be accessed remotely.
 --local_ip=127.0.0.1
 # Meta daemon listening port
---port=45500
+--port=9559
 # HTTP service ip
---ws_ip=127.0.0.1
+--ws_ip=0.0.0.0
 # HTTP service port
---ws_http_port=11000
+--ws_http_port=19559
 # HTTP2 service port
---ws_h2_port=11002
+--ws_h2_port=19560
 
 ########## storage ##########
 # Root data path, here should be only single path for metad

--- a/conf/nebula-metad.conf.production
+++ b/conf/nebula-metad.conf.production
@@ -15,18 +15,20 @@
 --logbufsecs=0
 
 ########## networking ##########
-# Meta Server Address
---meta_server_addrs=192.168.2.1:45500
-# Local ip
+# Comma separated Meta Server addresses
+--meta_server_addrs=192.168.2.1:9559
+# Local IP used to identify the nebula-metad process.
+# Change it to an address other than loopback if the service is distributed or
+# will be accessed remotely.
 --local_ip=192.168.2.1
 # Meta daemon listening port
---port=45500
+--port=9559
 # HTTP service ip
---ws_ip=192.168.2.1
+--ws_ip=0.0.0.0
 # HTTP service port
---ws_http_port=11000
+--ws_http_port=19559
 # HTTP2 service port
---ws_h2_port=11002
+--ws_h2_port=19560
 
 ########## storage ##########
 # Root data path, here should be only single path for metad

--- a/conf/nebula-storaged.conf.default
+++ b/conf/nebula-storaged.conf.default
@@ -15,18 +15,20 @@
 --logbufsecs=0
 
 ########## networking ##########
-# Meta server address
---meta_server_addrs=127.0.0.1:45500
-# Local ip
+# Comma separated Meta server addresses
+--meta_server_addrs=127.0.0.1:9559
+# Local IP used to identify the nebula-storaged process.
+# Change it to an address other than loopback if the service is distributed or
+# will be accessed remotely.
 --local_ip=127.0.0.1
 # Storage daemon listening port
---port=44500
+--port=9779
 # HTTP service ip
---ws_ip=127.0.0.1
+--ws_ip=0.0.0.0
 # HTTP service port
---ws_http_port=12000
+--ws_http_port=19779
 # HTTP2 service port
---ws_h2_port=12002
+--ws_h2_port=19780
 
 ######### Raft #########
 # Raft election timeout
@@ -55,7 +57,7 @@
 #   * lz4 to gain more CPU performance, with the same compression ratio with snappy
 #   * zstd to occupy less disk space
 #   * lz4hc for the read-heavy write-light scenario
---rocksdb_compression=snappy
+--rocksdb_compression=lz4
 
 # Set different compressions for different levels
 # For example, if --rocksdb_compression is snappy,

--- a/conf/nebula-storaged.conf.production
+++ b/conf/nebula-storaged.conf.production
@@ -15,18 +15,20 @@
 --logbufsecs=0
 
 ########## networking ##########
-# Meta server address
+# Comma separated Meta server addresses
 --meta_server_addrs=192.168.2.1:45500
-# Local ip
+# Local IP used to identify the nebula-storaged process.
+# Change it to an address other than loopback if the service is distributed or
+# will be accessed remotely.
 --local_ip=192.168.2.3
 # Storage daemon listening port
---port=44500
+--port=9779
 # HTTP service ip
---ws_ip=192.168.2.3
+--ws_ip=0.0.0.0
 # HTTP service port
---ws_http_port=12000
+--ws_http_port=19779
 # HTTP2 service port
---ws_h2_port=12002
+--ws_h2_port=19780
 # heartbeat with meta service
 --heartbeat_interval_secs=10
 
@@ -59,7 +61,7 @@
 #   * lz4 to gain more CPU performance, with the same compression ratio with snappy
 #   * zstd to occupy less disk space
 #   * lz4hc for the read-heavy write-light scenario
---rocksdb_compression=snappy
+--rocksdb_compression=lz4
 
 # Set different compressions for different levels
 # For example, if --rocksdb_compression is snappy,

--- a/src/meta/test/MetaHttpDownloadHandlerTest.cpp
+++ b/src/meta/test/MetaHttpDownloadHandlerTest.cpp
@@ -26,6 +26,7 @@ std::unique_ptr<hdfs::HdfsHelper> helper = std::make_unique<meta::MockHdfsOKHelp
 class MetaHttpDownloadHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
+        FLAGS_ws_ip = "127.0.0.1";
         FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";

--- a/src/meta/test/MetaHttpIngestHandlerTest.cpp
+++ b/src/meta/test/MetaHttpIngestHandlerTest.cpp
@@ -24,6 +24,7 @@ namespace meta {
 class MetaHttpIngestHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
+        FLAGS_ws_ip = "127.0.0.1";
         FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";

--- a/src/storage/test/StorageHttpAdminHandlerTest.cpp
+++ b/src/storage/test/StorageHttpAdminHandlerTest.cpp
@@ -22,6 +22,7 @@ using nebula::fs::TempDir;
 class StorageHttpAdminHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
+        FLAGS_ws_ip = "127.0.0.1";
         FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         rootPath_ = std::make_unique<fs::TempDir>("/tmp/StorageHttpAdminHandler.XXXXXX");

--- a/src/storage/test/StorageHttpDownloadHandlerTest.cpp
+++ b/src/storage/test/StorageHttpDownloadHandlerTest.cpp
@@ -24,6 +24,7 @@ std::unique_ptr<hdfs::HdfsHelper> helper = std::make_unique<storage::MockHdfsOKH
 class StorageHttpDownloadHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
+        FLAGS_ws_ip = "127.0.0.1";
         FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
 

--- a/src/storage/test/StorageHttpIngestHandlerTest.cpp
+++ b/src/storage/test/StorageHttpIngestHandlerTest.cpp
@@ -20,6 +20,7 @@ namespace storage {
 class StorageHttpIngestHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
+        FLAGS_ws_ip = "127.0.0.1";
         FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";

--- a/src/storage/test/StorageHttpStatsHandlerTest.cpp
+++ b/src/storage/test/StorageHttpStatsHandlerTest.cpp
@@ -22,6 +22,7 @@ namespace storage {
 class StorageHttpStatsHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
+        FLAGS_ws_ip = "127.0.0.1";
         FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         FLAGS_enable_rocksdb_statistics = true;


### PR DESCRIPTION
 * Change default listening port numbers of metad/storaged/web.
 * Change default compressoin algorithm from snappy to lz4.

Rule of thumb to choose ports:
 * Not registered currently in IANA, so we have chance to occupy
 * Not in the ephermeral port range, to reduce issues like conflicts and simultaneous open
 * Catchy