### PR TITLE
Fixed index rebuilding task

### DIFF
--- a/src/storage/admin/RebuildEdgeIndexTask.cpp
+++ b/src/storage/admin/RebuildEdgeIndexTask.cpp
@@ -93,8 +93,8 @@ RebuildEdgeIndexTask::buildIndexGlobal(GraphSpaceID space,
             iter->next();
             continue;
         } else {
-            currentSrcVertex = source.data();
-            currentDstVertex = destination.data();
+            currentSrcVertex = source.toString();
+            currentDstVertex = destination.toString();
             currentRanking = ranking;
         }
 
@@ -115,9 +115,9 @@ RebuildEdgeIndexTask::buildIndexGlobal(GraphSpaceID space,
         auto indexKey = IndexKeyUtils::edgeIndexKey(vidSize,
                                                     part,
                                                     item->get_index_id(),
-                                                    source.data(),
+                                                    source.toString(),
                                                     ranking,
-                                                    destination.data(),
+                                                    destination.toString(),
                                                     std::move(valuesRet).value());
         data.emplace_back(std::move(indexKey), "");
         iter->next();

--- a/src/storage/admin/RebuildTagIndexTask.cpp
+++ b/src/storage/admin/RebuildTagIndexTask.cpp
@@ -84,7 +84,7 @@ RebuildTagIndexTask::buildIndexGlobal(GraphSpaceID space,
             iter->next();
             continue;
         } else {
-            currentVertex = vertex.data();
+            currentVertex = vertex.toString();
         }
 
         reader = RowReaderWrapper::getTagPropReader(env_->schemaMan_, space, tagID, val);
@@ -103,7 +103,7 @@ RebuildTagIndexTask::buildIndexGlobal(GraphSpaceID space,
         auto indexKey = IndexKeyUtils::vertexIndexKey(vidSize,
                                                       part,
                                                       item->get_index_id(),
-                                                      vertex.data(),
+                                                      vertex.toString(),
                                                       std::move(valuesRet).value());
         data.emplace_back(std::move(indexKey), "");
         iter->next();


### PR DESCRIPTION
The index rebuilding task _keeps_ running and never finishes. The reasons are:
 * The rebuilding job is executed in a ThreadPoolExecutor.
 * The status is marked as RUNNING when a job is scheduled.
 * The job throws an exception during execution.
 * The ThreadPoolExecutor catches the exception and abort the job silently.
 * The status of the job has no chance to be updated.
 * Type of the exception is `std::length_error`, thrown by `std::string::apend(size_t, char)`.
 * The root cause is regarding a sized buffer as a null terminated string.