### PR TITLE
Fix fetch problem

### DIFF
--- a/src/storage/test/VertexCacheTest.cpp
+++ b/src/storage/test/VertexCacheTest.cpp
@@ -502,7 +502,7 @@ TEST(VertexCacheTest, GetVertexPropWithTTLTest) {
 
         // TODO At present, when the ttl data expires, tag returns a vid,
         // other attributes are empty value, edge returns a row with an empty value fields.
-        getVertices(env, parts, &cache, tagId, vertices, 0);
+        getVertices(env, parts, &cache, tagId, vertices, 51);
         checkCache(&cache, 51, 51, 102);
     }
 


### PR DESCRIPTION
Revert to previous behavior, this need to be fixed later because it involves one extra io, and it is weird.
For example, v1 don't have t1 and t2, but has t3. When fetch t1 and t2, it will be returned as one row as well.

Will change to #246 later.

https://github.com/vesoft-inc/nebula-graph/pull/507/checks?check_run_id=1600034306