### PR TITLE
fix storage server stop, fix meta client related ut would hang

### DIFF
--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -1684,7 +1684,7 @@ private:
 
 TEST(MetaClientTest, SimpleTest) {
     FLAGS_heartbeat_interval_secs = 3600;
-    auto localIp = network::NetworkUtils::getHostname();
+    auto localIp = "127.0.0.1";
 
     auto mockMetad = std::make_unique<mock::RpcServer>();
     auto handler = std::make_shared<TestMetaService>();

--- a/src/meta/test/MockAdminClient.h
+++ b/src/meta/test/MockAdminClient.h
@@ -10,8 +10,6 @@
 #include <gmock/gmock.h>
 #include "meta/processors/admin/AdminClient.h"
 
-#pragma GCC diagnostic ignored "-Wsuggest-override"
-
 namespace nebula {
 namespace meta {
 

--- a/src/mock/MockCluster.cpp
+++ b/src/mock/MockCluster.cpp
@@ -59,7 +59,7 @@ MockCluster::memPartMan(GraphSpaceID spaceId, const std::vector<PartitionID>& pa
 
 // static
 std::string MockCluster::localIP() {
-    return network::NetworkUtils::getHostname();
+    return "127.0.0.1";
 }
 
 // static
@@ -104,7 +104,8 @@ void MockCluster::startMeta(int32_t port,
     metaServer_ = std::make_unique<RpcServer>();
     auto handler = std::make_shared<meta::MetaServiceHandler>(metaKV_.get(),
                                                               clusterId_);
-    metaServer_->start("meta", port, handler);
+    // initKV would replace hostname and port if necessary, so we need to change to the real addr
+    metaServer_->start("meta", metaKV_->address().port, handler);
     LOG(INFO) << "The Meta Daemon started on port " << metaServer_->port_;
 }
 

--- a/src/mock/MockCluster.h
+++ b/src/mock/MockCluster.h
@@ -52,7 +52,7 @@ public:
 
     void startAll();
 
-    void startMeta(int32_t port, const std::string& rootPath, std::string hostname = "");
+    void startMeta(int32_t port, const std::string& rootPath, std::string hostname = "127.0.0.1");
 
     void startStorage(HostAddr addr,
                       const std::string& rootPath,

--- a/src/storage/StorageServer.h
+++ b/src/storage/StorageServer.h
@@ -76,7 +76,6 @@ private:
     std::unique_ptr<meta::IndexManager> indexMan_;
     std::unique_ptr<storage::StorageEnv> env_;
 
-    std::atomic_bool stopped_{false};
     HostAddr localHost_;
     std::vector<HostAddr> metaAddrs_;
     std::vector<std::string> dataPaths_;

--- a/src/storage/test/KVClientTest.cpp
+++ b/src/storage/test/KVClientTest.cpp
@@ -39,12 +39,10 @@ TEST(KVClientTest, SimpleTest) {
     auto storagePort = network::NetworkUtils::getAvailablePort();
     HostAddr storageAddr{storageName, storagePort};
 
-    auto metaName = network::NetworkUtils::getHostname();
     int32_t metaPort = 0;
-    cluster.startMeta(metaPort, metaPath.path(), metaName);
+    cluster.startMeta(metaPort, metaPath.path());
     meta::MetaClientOptions options;
     options.localHost_ = storageAddr;
-    // options.inStoraged_ = true;
     options.role_ = meta::cpp2::HostRole::STORAGE;
     cluster.initMetaClient(options);
     cluster.startStorage(storageAddr, stoagePath.path(), true);

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -49,7 +49,6 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     meta::MetaClientOptions options;
     options.localHost_ = localHost;
     options.clusterId_ = kClusterId;
-    // options.inStoraged_ = true;
     options.role_ = meta::cpp2::HostRole::STORAGE;
     auto mClient = std::make_unique<meta::MetaClient>(threadPool,
                                                       std::move(addrs),


### PR DESCRIPTION
1. Ut would hang if hostname does not parsed correctly.
2. Fix storage server stop reentrant
3. Delete the pragma ... see https://github.com/vesoft-inc/nebula-common/pull/365.