### PR TITLE
fix show index status "not exist" bug

### DIFF
--- a/src/meta/processors/jobMan/ListEdgeIndexStatusProcessor.cpp
+++ b/src/meta/processors/jobMan/ListEdgeIndexStatusProcessor.cpp
@@ -36,9 +36,7 @@ void ListEdgeIndexStatusProcessor::process(const cpp2::ListIndexStatusReq& req) 
                 auto spaceName = paras[1];
                 auto ret = getSpaceId(spaceName);
                 if (!ret.ok()) {
-                    handleErrorCode(cpp2::ErrorCode::E_NOT_FOUND);
-                    onFinished();
-                    return;
+                    continue;
                 }
                 auto spaceId = ret.value();
                 if (spaceId != curSpaceId) {

--- a/src/meta/processors/jobMan/ListTagIndexStatusProcessor.cpp
+++ b/src/meta/processors/jobMan/ListTagIndexStatusProcessor.cpp
@@ -36,9 +36,7 @@ void ListTagIndexStatusProcessor::process(const cpp2::ListIndexStatusReq& req) {
                 auto spaceName = paras[1];
                 auto ret = getSpaceId(spaceName);
                 if (!ret.ok()) {
-                    handleErrorCode(cpp2::ErrorCode::E_NOT_FOUND);
-                    onFinished();
-                    return;
+                    continue;
                 }
                 auto spaceId = ret.value();
                 if (spaceId != curSpaceId) {


### PR DESCRIPTION
Error msg "not exist" appears in the following steps:
1. rebuild tag/edge index in space `space_1`;
2. then switch to space `space_2`;
3. then drop space `space_1`,  
4. then execute `show tag/edge index status`