### PR TITLE
fix admin client leader change and bug in transfer leader

### DIFF
--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -417,6 +417,8 @@ void AdminClient::getResponse(std::vector<HostAddr> hosts,
                                         std::move(respGen));
                             return;
                         }
+                        // convert to admin addr
+                        leader = Utils::getAdminAddrFromStoreAddr(leader);
                         int32_t leaderIndex = 0;
                         for (auto& h : hosts) {
                             if (h == leader) {

--- a/src/meta/processors/partsMan/ListHostsProcessor.cpp
+++ b/src/meta/processors/partsMan/ListHostsProcessor.cpp
@@ -63,22 +63,6 @@ void ListHostsProcessor::process(const cpp2::ListHostsReq& req) {
  * it's not necessary add this interface only for gitInfoSHA
  * */
 Status ListHostsProcessor::allMetaHostsStatus() {
-    auto* partManager = kvstore_->partManager();
-    auto status = partManager->partMeta(kDefaultSpaceId, kDefaultPartId);
-    if (!status.ok()) {
-        LOG(ERROR) << "Get parts failed: " << status.status();
-        return status.status();
-    }
-    auto partMeta = status.value();
-    for (auto& host : partMeta.hosts_) {
-        cpp2::HostItem item;
-        item.set_hostAddr(std::move(host));
-        item.set_role(cpp2::HostRole::META);
-        item.set_git_info_sha(NEBULA_STRINGIFY(GIT_INFO_SHA));
-        item.set_status(cpp2::HostStatus::ONLINE);
-        hostItems_.emplace_back(item);
-    }
-
     auto errOrPart = kvstore_->part(kDefaultSpaceId, kDefaultPartId);
     if (!nebula::ok(errOrPart)) {
         return Status::SpaceNotFound();

--- a/src/meta/test/AdminClientTest.cpp
+++ b/src/meta/test/AdminClientTest.cpp
@@ -51,6 +51,7 @@ DECLARE_int32(max_retry_times_admin_op);
 namespace nebula {
 namespace meta {
 
+// todo(doodle): replace with gmock
 class TestStorageService : public storage::cpp2::StorageAdminServiceSvIf {
 public:
     folly::Future<storage::cpp2::AdminExecResp>
@@ -121,12 +122,9 @@ public:
 
 class TestStorageServiceRetry : public TestStorageService {
 public:
-    TestStorageServiceRetry(int ip, Port port) {
-        leader_ = HostAddr(std::to_string(ip), port);
-    }
-
-    TestStorageServiceRetry(std::string addr, Port port) {
-        leader_ = HostAddr(addr, port);
+    TestStorageServiceRetry(std::string addr, Port adminPort) {
+        // when leader change returned, the port is always data port
+        leader_ = Utils::getStoreAddrFromAdminAddr(HostAddr(addr, adminPort));
     }
 
     folly::Future<storage::cpp2::AdminExecResp>

--- a/src/storage/admin/AdminProcessor.h
+++ b/src/storage/admin/AdminProcessor.h
@@ -43,7 +43,6 @@ public:
         if (part->isLeader() && part->address() == host) {
             LOG(INFO) << "I am already leader of space " << spaceId
                       << " part " << partId << ", skip transLeader";
-            this->pushResultCode(cpp2::ErrorCode::E_NO_TRANSFORMED, partId);
             onFinished();
             return;
         }
@@ -90,7 +89,6 @@ public:
                         if (leader != HostAddr("", 0) && leader != store->address()) {
                             LOG(INFO) << "Found new leader of space " << spaceId
                                       << " part " << partId << ": " << leader;
-                            this->pushResultCode(cpp2::ErrorCode::E_NO_TRANSFORMED, partId);
                             onFinished();
                             return;
                         } else if (leader != HostAddr("", 0)) {


### PR DESCRIPTION
1. When leader change returned to AdminClient, the address is the data port, need to convert to admin port.
2. Introduced in #199, transfer leader should not return error in some case, actually the transfer succeed. This would incur balance leader/data failed
3. fix `show hosts meta` error which will return duplicate result.