### PR TITLE
fix a UT caused heap-use-after-free problem of job manager

### DIFF
--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -75,6 +75,9 @@ TEST_F(JobManagerTest, addJob) {
 
 
 TEST_F(JobManagerTest, AddRebuildTagIndexJob) {
+    // For preventting job schedule in JobManager
+    jobMgr->status_ = JobManager::Status::STOPPED;
+
     std::vector<std::string> paras{"tag_index_name", "test_space"};
     JobDescription job(11, cpp2::AdminCmd::REBUILD_TAG_INDEX, paras);
     auto rc = jobMgr->addJob(job, adminClient_.get());
@@ -85,6 +88,9 @@ TEST_F(JobManagerTest, AddRebuildTagIndexJob) {
 
 
 TEST_F(JobManagerTest, AddRebuildEdgeIndexJob) {
+    // For preventting job schedule in JobManager
+    jobMgr->status_ = JobManager::Status::STOPPED;
+
     std::vector<std::string> paras{"edge_index_name", "test_space"};
     JobDescription job(11, cpp2::AdminCmd::REBUILD_EDGE_INDEX, paras);
     auto rc = jobMgr->addJob(job, adminClient_.get());
@@ -94,6 +100,9 @@ TEST_F(JobManagerTest, AddRebuildEdgeIndexJob) {
 }
 
 TEST_F(JobManagerTest, StatisJob) {
+    // For preventting job schedule in JobManager
+    jobMgr->status_ = JobManager::Status::STOPPED;
+
     std::vector<std::string> paras{"test_space"};
     JobDescription job(12, cpp2::AdminCmd::STATS, paras);
     auto rc = jobMgr->addJob(job, adminClient_.get());


### PR DESCRIPTION
after import the jobManager::currJob_, 
some test of jobMgr who calls JobManager::runJobInternal may lead to data race, 
(the background job manger thread VS the manual called  runJobInternal)
so disable the background schedule thread of job manager in those UT

```
    ==11127==ERROR: AddressSanitizer: heap-use-after-free on address 0x61100000a238 at pc 0x000002fbd2a7 bp 0x7ffd6368db90 sp 0x7ffd6368db88
READ of size 8 at 0x61100000a238 thread T0
    #0 0x2fbd2a6 in std::_Hashtable<nebula::HostAddr, std::pair<nebula::HostAddr const, nebula::meta::cpp2::StatisItem>, std::allocator<std::pair<nebula::HostAddr const, nebula::meta::cpp2::StatisItem> >, std::__detail::_Select1st, std::equal_to<nebula::HostAddr>, std::hash<nebula::HostAddr>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_begin() const /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/hashtable.h:384:58
    #1 0x2fc1080 in std::_Hashtable<nebula::HostAddr, std::pair<nebula::HostAddr const, nebula::meta::cpp2::StatisItem>, std::allocator<std::pair<nebula::HostAddr const, nebula::meta::cpp2::StatisItem> >, std::__detail::_Select1st, std::equal_to<nebula::HostAddr>, std::hash<nebula::HostAddr>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::begin() /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/hashtable.h:505:25
    #2 0x2fb995f in std::unordered_map<nebula::HostAddr, nebula::meta::cpp2::StatisItem, std::hash<nebula::HostAddr>, std::equal_to<nebula::HostAddr>, std::allocator<std::pair<nebula::HostAddr const, nebula::meta::cpp2::StatisItem> > >::begin() /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/unordered_map.h:325:21
    #3 0x2fb89e6 in nebula::meta::StatisJobExecutor::finish(bool) /__w/nebula-storage/nebula-storage/src/meta/processors/jobMan/StatisJobExecutor.cpp:76:22
    #4 0x2f0fe9e in nebula::meta::JobManager::runJobInternal(nebula::meta::JobDescription const&) /__w/nebula-storage/nebula-storage/src/meta/processors/jobMan/JobManager.cpp:163:15

freed by thread T195 here:
    #0 0x273fd37 in operator delete(void*) /usr/src/nebula-package/toolset-build/source/llvm-9.0.0/projects/compiler-rt/lib/asan/asan_new_delete.cc:160:3
    #1 0x2fbbab7 in nebula::meta::StatisJobExecutor::~StatisJobExecutor() /__w/nebula-storage/nebula-storage/src/meta/processors/jobMan/StatisJobExecutor.h:17:7
    #2 0x2f33a6f in std::default_delete<nebula::meta::MetaJobExecutor>::operator()(nebula::meta::MetaJobExecutor*) const /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/unique_ptr.h:81:2
    #3 0x2f4c7de in std::unique_ptr<nebula::meta::MetaJobExecutor, std::default_delete<nebula::meta::MetaJobExecutor> >::reset(nebula::meta::MetaJobExecutor*) /opt/vesoft/toolset/clang/9.0.0/lib/gcc/x86_64-vesoft-linux/9.2.0/../../../../include/c++/9.2.0/bits/unique_ptr.h:394:4

previously allocated by thread T0 here:
    #0 0x273f367 in operator new(unsigned long) /usr/src/nebula-package/toolset-build/source/llvm-9.0.0/projects/compiler-rt/lib/asan/asan_new_delete.cc:99:3
    #1 0x2f867c1 in nebula::meta::MetaJobExecutorFactory::createMetaJobExecutor(nebula::meta::JobDescription const&, nebula::kvstore::KVStore*, nebula::meta::AdminClient*) /__w/nebula-storage/nebula-storage/src/meta/processors/jobMan/MetaJobExecutor.cpp:59:19
    #2 0x2f0eeca in nebula::meta::JobManager::runJobInternal(nebula::meta::JobDescription const&) /__w/nebula-storage/nebula-storage/src/meta/processors/jobMan/JobManager.cpp:121:16
    #3 0x2746d7c in nebula::meta::JobManagerTest_StatisJob_Test::TestBody() /__w/nebula-storage/nebula-storage/src/meta/test/JobManagerTest.cpp:101:27
    #4 0x5ec548c in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/__w/nebula-storage/nebula-storage/build/bin/test/job_manager_test+0x5ec548c)
```