### PR TITLE
fixed the bug for restore meta.

### DIFF
--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -208,6 +208,9 @@ public:
     virtual ResultCode restoreFromFiles(GraphSpaceID spaceId,
                                         const std::vector<std::string>& files) = 0;
 
+    virtual ResultCode multiPutWitoutReplicator(GraphSpaceID spaceId,
+                                                std::vector<KV> keyValues) = 0;
+
 protected:
     KVStore() = default;
 };

--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -208,7 +208,7 @@ public:
     virtual ResultCode restoreFromFiles(GraphSpaceID spaceId,
                                         const std::vector<std::string>& files) = 0;
 
-    virtual ResultCode multiPutWitoutReplicator(GraphSpaceID spaceId,
+    virtual ResultCode multiPutWithoutReplicator(GraphSpaceID spaceId,
                                                 std::vector<KV> keyValues) = 0;
 
 protected:

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -1105,6 +1105,24 @@ ResultCode NebulaStore::restoreFromFiles(GraphSpaceID spaceId,
     return ResultCode::SUCCEEDED;
 }
 
+ResultCode NebulaStore::multiPutWitoutReplicator(GraphSpaceID spaceId, std::vector<KV> keyValues) {
+    auto spaceRet = space(spaceId);
+    if (!ok(spaceRet)) {
+        LOG(ERROR) << "Get Space " << spaceId << " Failed";
+        return error(spaceRet);
+    }
+    auto space = nebula::value(spaceRet);
+
+    for (auto& engine : space->engines_) {
+        auto ret = engine->multiPut(keyValues);
+        if (ret != ResultCode::SUCCEEDED) {
+            return ret;
+        }
+    }
+
+    return ResultCode::SUCCEEDED;
+}
+
 }  // namespace kvstore
 }  // namespace nebula
 

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -1105,7 +1105,7 @@ ResultCode NebulaStore::restoreFromFiles(GraphSpaceID spaceId,
     return ResultCode::SUCCEEDED;
 }
 
-ResultCode NebulaStore::multiPutWitoutReplicator(GraphSpaceID spaceId, std::vector<KV> keyValues) {
+ResultCode NebulaStore::multiPutWithoutReplicator(GraphSpaceID spaceId, std::vector<KV> keyValues) {
     auto spaceRet = space(spaceId);
     if (!ok(spaceRet)) {
         LOG(ERROR) << "Get Space " << spaceId << " Failed";

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -274,6 +274,9 @@ public:
                               PartitionID partId,
                               const std::vector<HostAddr>& remoteListeners) override;
 
+    ResultCode multiPutWitoutReplicator(GraphSpaceID spaceId,
+                                        std::vector<KV> keyValues) override;
+
 private:
     void loadPartFromDataPath();
 

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -274,7 +274,7 @@ public:
                               PartitionID partId,
                               const std::vector<HostAddr>& remoteListeners) override;
 
-    ResultCode multiPutWitoutReplicator(GraphSpaceID spaceId,
+    ResultCode multiPutWithoutReplicator(GraphSpaceID spaceId,
                                         std::vector<KV> keyValues) override;
 
 private:

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -1211,18 +1211,12 @@ bool MetaServiceUtils::replaceHostInZone(kvstore::KVStore* kvstore,
         iter->next();
     }
 
-    bool updateSucceed{false};
-    folly::Baton<true, std::atomic> baton;
-    kvstore->asyncMultiPut(
-        kDefaultSpaceId, kDefaultPartId, std::move(data), [&](kvstore::ResultCode code) {
-            updateSucceed = (code == kvstore::ResultCode::SUCCEEDED);
-            if (!updateSucceed) {
-                LOG(ERROR) << folly::stringPrintf("write to kvstore failed");
-            }
-            baton.post();
-        });
-    baton.wait();
-    return updateSucceed;
+    kvRet = kvstore->multiPutWitoutReplicator(kDefaultSpaceId, std::move(data));
+    if (kvRet != kvstore::ResultCode::SUCCEEDED) {
+        LOG(ERROR) << "multiPutWitoutReplicator failed kvRet=" << kvRet;
+        return false;
+    }
+    return true;
 }
 
 std::string MetaServiceUtils::balanceTaskKey(BalanceID balanceId,

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -1171,9 +1171,9 @@ bool MetaServiceUtils::replaceHostInPartition(kvstore::KVStore* kvstore,
         }
     }
 
-    kvRet = kvstore->multiPutWitoutReplicator(kDefaultSpaceId, std::move(data));
+    kvRet = kvstore->multiPutWithoutReplicator(kDefaultSpaceId, std::move(data));
     if (kvRet != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "multiPutWitoutReplicator failed kvRet=" << kvRet;
+        LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << kvRet;
         return false;
     }
 
@@ -1211,9 +1211,9 @@ bool MetaServiceUtils::replaceHostInZone(kvstore::KVStore* kvstore,
         iter->next();
     }
 
-    kvRet = kvstore->multiPutWitoutReplicator(kDefaultSpaceId, std::move(data));
+    kvRet = kvstore->multiPutWithoutReplicator(kDefaultSpaceId, std::move(data));
     if (kvRet != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "multiPutWitoutReplicator failed kvRet=" << kvRet;
+        LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << kvRet;
         return false;
     }
     return true;

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -1171,18 +1171,13 @@ bool MetaServiceUtils::replaceHostInPartition(kvstore::KVStore* kvstore,
         }
     }
 
-    bool updateSucceed{false};
-    folly::Baton<true, std::atomic> baton;
-    kvstore->asyncMultiPut(
-        kDefaultSpaceId, kDefaultPartId, std::move(data), [&](kvstore::ResultCode code) {
-            updateSucceed = (code == kvstore::ResultCode::SUCCEEDED);
-            if (!updateSucceed) {
-                LOG(ERROR) << folly::stringPrintf("write to kvstore failed");
-            }
-            baton.post();
-        });
-    baton.wait();
-    return updateSucceed;
+    kvRet = kvstore->multiPutWitoutReplicator(kDefaultSpaceId, std::move(data));
+    if (kvRet != kvstore::ResultCode::SUCCEEDED) {
+        LOG(ERROR) << "multiPutWitoutReplicator failed kvRet=" << kvRet;
+        return false;
+    }
+
+    return true;
 }
 
 bool MetaServiceUtils::replaceHostInZone(kvstore::KVStore* kvstore,

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -1127,7 +1127,8 @@ folly::Optional<std::vector<std::string>> MetaServiceUtils::backup(
 
 bool MetaServiceUtils::replaceHostInPartition(kvstore::KVStore* kvstore,
                                               const HostAddr& ipv4From,
-                                              const HostAddr& ipv4To) {
+                                              const HostAddr& ipv4To,
+                                              bool direct) {
     folly::SharedMutex::WriteHolder wHolder(LockUtils::spaceLock());
     const auto& spacePrefix = MetaServiceUtils::spacePrefix();
     std::unique_ptr<kvstore::KVIterator> iter;
@@ -1171,18 +1172,31 @@ bool MetaServiceUtils::replaceHostInPartition(kvstore::KVStore* kvstore,
         }
     }
 
-    kvRet = kvstore->multiPutWithoutReplicator(kDefaultSpaceId, std::move(data));
-    if (kvRet != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << kvRet;
-        return false;
+    if (direct) {
+        kvRet = kvstore->multiPutWithoutReplicator(kDefaultSpaceId, std::move(data));
+        if (kvRet != kvstore::ResultCode::SUCCEEDED) {
+            LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << kvRet;
+            return false;
+        }
+        return true;
     }
+    bool updateSucceed{false};
+    folly::Baton<true, std::atomic> baton;
+    kvstore->asyncMultiPut(
+        kDefaultSpaceId, kDefaultPartId, std::move(data), [&](kvstore::ResultCode code) {
+            updateSucceed = (code == kvstore::ResultCode::SUCCEEDED);
+            LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << code;
+            baton.post();
+        });
+    baton.wait();
 
-    return true;
+    return updateSucceed;
 }
 
 bool MetaServiceUtils::replaceHostInZone(kvstore::KVStore* kvstore,
                                          const HostAddr& ipv4From,
-                                         const HostAddr& ipv4To) {
+                                         const HostAddr& ipv4To,
+                                         bool direct) {
     folly::SharedMutex::WriteHolder wHolder(LockUtils::spaceLock());
     const auto& zonePrefix = MetaServiceUtils::zonePrefix();
     std::unique_ptr<kvstore::KVIterator> iter;
@@ -1211,12 +1225,25 @@ bool MetaServiceUtils::replaceHostInZone(kvstore::KVStore* kvstore,
         iter->next();
     }
 
-    kvRet = kvstore->multiPutWithoutReplicator(kDefaultSpaceId, std::move(data));
-    if (kvRet != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << kvRet;
-        return false;
+    if (direct) {
+        kvRet = kvstore->multiPutWithoutReplicator(kDefaultSpaceId, std::move(data));
+        if (kvRet != kvstore::ResultCode::SUCCEEDED) {
+            LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << kvRet;
+            return false;
+        }
+        return true;
     }
-    return true;
+    bool updateSucceed{false};
+    folly::Baton<true, std::atomic> baton;
+    kvstore->asyncMultiPut(
+        kDefaultSpaceId, kDefaultPartId, std::move(data), [&](kvstore::ResultCode code) {
+            updateSucceed = (code == kvstore::ResultCode::SUCCEEDED);
+            LOG(ERROR) << "multiPutWithoutReplicator failed kvRet=" << code;
+            baton.post();
+        });
+    baton.wait();
+
+    return updateSucceed;
 }
 
 std::string MetaServiceUtils::balanceTaskKey(BalanceID balanceId,

--- a/src/meta/MetaServiceUtils.h
+++ b/src/meta/MetaServiceUtils.h
@@ -318,12 +318,16 @@ public:
     static GraphSpaceID parseIndexKeySpaceID(folly::StringPiece key);
     static GraphSpaceID parseDefaultKeySpaceID(folly::StringPiece key);
 
+    // A direct value of true means that data will not be written to follow via the raft protocol,
+    // but will be written directly to local disk
     static bool replaceHostInPartition(kvstore::KVStore* kvstore,
                                        const HostAddr& ipv4From,
-                                       const HostAddr& ipv4To);
+                                       const HostAddr& ipv4To,
+                                       bool direct = false);
     static bool replaceHostInZone(kvstore::KVStore* kvstore,
                                   const HostAddr& ipv4From,
-                                  const HostAddr& ipv4To);
+                                  const HostAddr& ipv4To,
+                                  bool direct = false);
     // backup
     static ErrorOr<kvstore::ResultCode, std::vector<std::string>> backupIndexTable(
         kvstore::KVStore* kvstore,

--- a/src/meta/processors/admin/RestoreProcessor.cpp
+++ b/src/meta/processors/admin/RestoreProcessor.cpp
@@ -31,7 +31,7 @@ void RestoreProcessor::process(const cpp2::RestoreMetaReq& req) {
     if (!replaceHosts.empty()) {
         for (auto h : replaceHosts) {
             auto result = MetaServiceUtils::replaceHostInPartition(
-                kvstore_, h.get_from_host(), h.get_to_host());
+                kvstore_, h.get_from_host(), h.get_to_host(), true);
             if (!result) {
                 LOG(ERROR) << "replaceHost in partition fails when recovered";
                 handleErrorCode(cpp2::ErrorCode::E_RESTORE_FAILURE);
@@ -39,8 +39,8 @@ void RestoreProcessor::process(const cpp2::RestoreMetaReq& req) {
                 return;
             }
 
-            result =
-                MetaServiceUtils::replaceHostInZone(kvstore_, h.get_from_host(), h.get_to_host());
+            result = MetaServiceUtils::replaceHostInZone(
+                kvstore_, h.get_from_host(), h.get_to_host(), true);
             if (!result) {
                 LOG(ERROR) << "replacehost in zone fails when recovered";
                 handleErrorCode(cpp2::ErrorCode::E_RESTORE_FAILURE);


### PR DESCRIPTION
1. Fix the bug of incorrectly calling storage's interface when restore meta (no need to copy to follower node).

2. add the interface to write storage directly to Nebulastore.