### PR TITLE
Task report finish to job manager

### DIFF
--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -59,6 +59,7 @@ nebula_add_library(
     processors/jobMan/TaskDescription.cpp
     processors/jobMan/JobStatus.cpp
     processors/jobMan/AdminJobProcessor.cpp
+    processors/jobMan/ReportTaskProcessor.cpp
     processors/jobMan/JobUtils.cpp
     processors/jobMan/MetaJobExecutor.cpp
     processors/jobMan/SimpleConcurrentJobExecutor.cpp

--- a/src/meta/MetaServiceHandler.cpp
+++ b/src/meta/MetaServiceHandler.cpp
@@ -50,6 +50,7 @@
 #include "meta/processors/configMan/SetConfigProcessor.h"
 #include "meta/processors/configMan/ListConfigsProcessor.h"
 #include "meta/processors/jobMan/AdminJobProcessor.h"
+#include "meta/processors/jobMan/ReportTaskProcessor.h"
 #include "meta/processors/admin/CreateBackupProcessor.h"
 #include "meta/processors/jobMan/GetStatisProcessor.h"
 #include "meta/processors/jobMan/ListTagIndexStatusProcessor.h"
@@ -96,6 +97,12 @@ MetaServiceHandler::future_listSpaces(const cpp2::ListSpacesReq& req) {
 folly::Future<cpp2::AdminJobResp>
 MetaServiceHandler::future_runAdminJob(const cpp2::AdminJobReq& req) {
     auto* processor = AdminJobProcessor::instance(kvstore_, adminClient_.get());
+    RETURN_FUTURE(processor);
+}
+
+folly::Future<cpp2::ExecResp>
+MetaServiceHandler::future_reportTaskFinish(const cpp2::ReportTaskReq& req) {
+    auto* processor = ReportTaskProcessor::instance(kvstore_);
     RETURN_FUTURE(processor);
 }
 

--- a/src/meta/MetaServiceHandler.h
+++ b/src/meta/MetaServiceHandler.h
@@ -266,6 +266,9 @@ public:
     folly::Future<cpp2::GetStatisResp>
     future_getStatis(const cpp2::GetStatisReq& req) override;
 
+    folly::Future<cpp2::ExecResp>
+    future_reportTaskFinish(const cpp2::ReportTaskReq& req) override;
+
 private:
     kvstore::KVStore* kvstore_ = nullptr;
     ClusterID clusterId_{0};

--- a/src/meta/processors/jobMan/AdminJobProcessor.cpp
+++ b/src/meta/processors/jobMan/AdminJobProcessor.cpp
@@ -16,11 +16,11 @@ void AdminJobProcessor::process(const cpp2::AdminJobReq& req) {
     cpp2::AdminJobResult result;
     cpp2::ErrorCode errorCode = cpp2::ErrorCode::SUCCEEDED;
     std::stringstream oss;
-    oss << " op = " << static_cast<int>(req.get_op());
+    oss << "op = " << cpp2::_AdminJobOp_VALUES_TO_NAMES.at(req.get_op());
     if (req.get_op() == nebula::meta::cpp2::AdminJobOp::ADD) {
-        oss << ", cmd = " << static_cast<int>(req.get_cmd());
+        oss << ", cmd = " << cpp2::_AdminCmd_VALUES_TO_NAMES.at(req.get_cmd());
     }
-    oss << ", paras =";
+    oss << ", paras.size()=" << req.get_paras().size();
     for (auto& p : req.get_paras()) {
         oss << " " << p;
     }

--- a/src/meta/processors/jobMan/JobManager.cpp
+++ b/src/meta/processors/jobMan/JobManager.cpp
@@ -255,7 +255,6 @@ cpp2::ErrorCode JobManager::jobFinished(JobID jobId, bool suc) {
     cleanJob(jobId);
 }
 
-// cpp2::ErrorCode JobManager::reportTaskFinish(JobID jobId, int32_t taskId, cpp2::ErrorCode code) {
 cpp2::ErrorCode JobManager::reportTaskFinish(const cpp2::ReportTaskReq& req) {
     auto jobId = req.get_job_id();
     auto taskId = req.get_task_id();
@@ -284,6 +283,7 @@ cpp2::ErrorCode JobManager::reportTaskFinish(const cpp2::ReportTaskReq& req) {
     auto taskStatus =
         code == cpp2::ErrorCode::SUCCEEDED ? cpp2::JobStatus::FINISHED : cpp2::JobStatus::FAILED;
     task->setStatus(taskStatus);
+    save(task->taskKey(), task->taskVal());
 
     auto allTaskFinished = std::none_of(tasks.begin(), tasks.end(), [](auto& task){
         return task.status_ == cpp2::JobStatus::RUNNING;

--- a/src/meta/processors/jobMan/JobManager.cpp
+++ b/src/meta/processors/jobMan/JobManager.cpp
@@ -263,13 +263,13 @@ cpp2::ErrorCode JobManager::reportTaskFinish(const cpp2::ReportTaskReq& req) {
         return rc;
     }
 
-    auto allTaskFinished = std::none_of(tasks.begin(), tasks.end(), [](auto& task){
-        return task.status_ == cpp2::JobStatus::RUNNING;
+    auto allTaskFinished = std::none_of(tasks.begin(), tasks.end(), [](auto& tsk){
+        return tsk.status_ == cpp2::JobStatus::RUNNING;
     });
 
     if (allTaskFinished) {
-        auto jobSucceeded = std::all_of(tasks.begin(), tasks.end(), [](auto& task) {
-            return task.status_ == cpp2::JobStatus::FINISHED;
+        auto jobSucceeded = std::all_of(tasks.begin(), tasks.end(), [](auto& tsk) {
+            return tsk.status_ == cpp2::JobStatus::FINISHED;
         });
         return jobFinished(jobId, jobSucceeded);
     }

--- a/src/meta/processors/jobMan/JobManager.h
+++ b/src/meta/processors/jobMan/JobManager.h
@@ -122,6 +122,8 @@ private:
 
     void cleanJob(JobID jobId);
 
+    cpp2::ErrorCode saveTaskStatus(TaskDescription& td, const cpp2::ReportTaskReq& req);
+
 private:
     // Todo(pandasheep)
     // When folly is upgraded, PriorityUMPSCQueueSet can be used

--- a/src/meta/processors/jobMan/JobManager.h
+++ b/src/meta/processors/jobMan/JobManager.h
@@ -134,7 +134,7 @@ private:
     // The job in running or queue
     folly::ConcurrentHashMap<JobID, JobDescription>    inFlightJobs_;
 
-    std::unique_ptr<thread::GenericWorker>             bgThread_;
+    std::thread                                        bgThread_;
     std::mutex                                         statusGuard_;
     JbmgrStatus                                        status_{JbmgrStatus::NOT_START};
     nebula::kvstore::KVStore*                          kvStore_{nullptr};

--- a/src/meta/processors/jobMan/JobManager.h
+++ b/src/meta/processors/jobMan/JobManager.h
@@ -50,7 +50,7 @@ public:
     enum class JbmgrStatus {
         NOT_START,
         IDLE,       // Job manager started, no running any job
-        RUNNING,    // Job manager is running job
+        BUSY,       // Job manager is running job
         STOPPED,
     };
 

--- a/src/meta/processors/jobMan/JobManager.h
+++ b/src/meta/processors/jobMan/JobManager.h
@@ -138,9 +138,7 @@ private:
     std::mutex                                         statusGuard_;
     JbmgrStatus                                        status_{JbmgrStatus::NOT_START};
     nebula::kvstore::KVStore*                          kvStore_{nullptr};
-    std::unique_ptr<nebula::thread::GenericThreadPool> pool_{nullptr};
     AdminClient*                                       adminClient_{nullptr};
-    std::unique_ptr<meta::MetaJobExecutor>             currJob_{nullptr};
 
     std::mutex                                         muReportFinish_;
 };

--- a/src/meta/processors/jobMan/JobManager.h
+++ b/src/meta/processors/jobMan/JobManager.h
@@ -17,6 +17,7 @@
 #include "kvstore/NebulaStore.h"
 #include "meta/processors/jobMan/JobStatus.h"
 #include "meta/processors/jobMan/JobDescription.h"
+#include "meta/processors/jobMan/TaskDescription.h"
 #include "meta/processors/jobMan/MetaJobExecutor.h"
 
 namespace nebula {
@@ -46,9 +47,10 @@ public:
     ~JobManager();
     static JobManager* getInstance();
 
-    enum class Status {
+    enum class JbmgrStatus {
         NOT_START,
-        RUNNING,
+        IDLE,       // Job manager started, no running any job
+        RUNNING,    // Job manager is running job
         STOPPED,
     };
 
@@ -77,6 +79,16 @@ public:
 
     ErrorOr<cpp2::ErrorCode, JobID> recoverJob();
 
+    /**
+     * @brief persist job executed result, and do the cleanup
+     * @return cpp2::ErrorCode if error when write to kv store
+     */
+    cpp2::ErrorCode jobFinished(JobID jobId, bool suc);
+
+    // report task finished.
+    // cpp2::ErrorCode reportTaskFinish(JobID jobId, int32_t taskId, cpp2::ErrorCode code);
+    cpp2::ErrorCode reportTaskFinish(const cpp2::ReportTaskReq& req);
+
     // Only used for Test
     // The number of jobs in lowPriorityQueue_ a and highPriorityQueue_
     size_t jobSize() const;
@@ -91,9 +103,12 @@ public:
 
 private:
     JobManager() = default;
+
     void scheduleThread();
+    void scheduleThreadOld();
 
     bool runJobInternal(const JobDescription& jobDesc);
+    bool runJobInternalOld(const JobDescription& jobDesc);
 
     GraphSpaceID getSpaceId(const std::string& name);
 
@@ -102,6 +117,10 @@ private:
     static bool isExpiredJob(const cpp2::JobDesc& jobDesc);
 
     void removeExpiredJobs(const std::vector<std::string>& jobKeys);
+
+    std::list<TaskDescription> getAllTasks(JobID jobId);
+
+    void cleanJob(JobID jobId);
 
 private:
     // Todo(pandasheep)
@@ -115,11 +134,13 @@ private:
 
     std::unique_ptr<thread::GenericWorker>             bgThread_;
     std::mutex                                         statusGuard_;
-    Status                                             status_{Status::NOT_START};
+    JbmgrStatus                                        status_{JbmgrStatus::NOT_START};
     nebula::kvstore::KVStore*                          kvStore_{nullptr};
     std::unique_ptr<nebula::thread::GenericThreadPool> pool_{nullptr};
     AdminClient*                                       adminClient_{nullptr};
     std::unique_ptr<meta::MetaJobExecutor>             currJob_{nullptr};
+
+    std::mutex                                         muReportFinish_;
 };
 
 }  // namespace meta

--- a/src/meta/processors/jobMan/MetaJobExecutor.h
+++ b/src/meta/processors/jobMan/MetaJobExecutor.h
@@ -15,8 +15,6 @@
 namespace nebula {
 namespace meta {
 
-using ExecuteRet  = ErrorOr<cpp2::ErrorCode, std::unordered_map<HostAddr, Status>>;
-
 using ErrOrHosts  = ErrorOr<cpp2::ErrorCode,
                             std::vector<std::pair<HostAddr, std::vector<PartitionID>>>>;
 
@@ -41,7 +39,7 @@ public:
 
     // The skeleton to run the job.
     // You should rewrite the executeInternal to trigger the calling.
-    ExecuteRet execute();
+    cpp2::ErrorCode  execute();
 
     void interruptExecution(JobID jobId);
 

--- a/src/meta/processors/jobMan/MetaJobExecutor.h
+++ b/src/meta/processors/jobMan/MetaJobExecutor.h
@@ -50,6 +50,12 @@ public:
 
     virtual void finish(bool) {}
 
+    void setSpaceId(GraphSpaceID spaceId) { space_ = spaceId; }
+
+    virtual cpp2::ErrorCode saveSpecialTaskStatus(const cpp2::ReportTaskReq&) {
+        return cpp2::ErrorCode::SUCCEEDED;
+    }
+
 protected:
     ErrorOr<cpp2::ErrorCode, GraphSpaceID>
     getSpaceIdFromName(const std::string& spaceName);

--- a/src/meta/processors/jobMan/ReportTaskProcessor.cpp
+++ b/src/meta/processors/jobMan/ReportTaskProcessor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "meta/processors/jobMan/ReportTaskProcessor.h"
+#include "meta/processors/jobMan/JobManager.h"
 
 namespace nebula {
 namespace meta {
@@ -13,10 +14,6 @@ namespace meta {
 
 void ReportTaskProcessor::process(const cpp2::ReportTaskReq& req) {
     JobManager* jobMgr = JobManager::getInstance();
-    // auto rc = jobMgr->reportTaskFinish(req.get_job_id(),
-    //                                    req.get_task_id(),
-    //                                    req.get_code(),
-    //                                    req.);
     auto rc = jobMgr->reportTaskFinish(req);
     if (rc != cpp2::ErrorCode::SUCCEEDED) {
         handleErrorCode(rc);

--- a/src/meta/processors/jobMan/ReportTaskProcessor.cpp
+++ b/src/meta/processors/jobMan/ReportTaskProcessor.cpp
@@ -1,0 +1,28 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "meta/processors/jobMan/ReportTaskProcessor.h"
+
+namespace nebula {
+namespace meta {
+
+#include "meta/processors/jobMan/JobManager.h"
+
+void ReportTaskProcessor::process(const cpp2::ReportTaskReq& req) {
+    JobManager* jobMgr = JobManager::getInstance();
+    // auto rc = jobMgr->reportTaskFinish(req.get_job_id(),
+    //                                    req.get_task_id(),
+    //                                    req.get_code(),
+    //                                    req.);
+    auto rc = jobMgr->reportTaskFinish(req);
+    if (rc != cpp2::ErrorCode::SUCCEEDED) {
+        handleErrorCode(rc);
+    }
+    onFinished();
+}
+
+}   // namespace meta
+}   // namespace nebula

--- a/src/meta/processors/jobMan/ReportTaskProcessor.h
+++ b/src/meta/processors/jobMan/ReportTaskProcessor.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef META_REPORTTASKPROCESSOR_H_
+#define META_REPORTTASKPROCESSOR_H_
+
+#include "meta/processors/BaseProcessor.h"
+#include "meta/processors/admin/AdminClient.h"
+
+namespace nebula {
+namespace meta {
+
+class ReportTaskProcessor : public BaseProcessor<cpp2::ExecResp> {
+public:
+    static ReportTaskProcessor* instance(kvstore::KVStore* kvstore) {
+        return new ReportTaskProcessor(kvstore);
+    }
+
+    void process(const cpp2::ReportTaskReq& req);
+
+protected:
+    explicit ReportTaskProcessor(kvstore::KVStore* kvstore, AdminClient* adminClient)
+        : BaseProcessor<cpp2::ExecResp>(kvstore) {}
+};
+
+}  // namespace meta
+}  // namespace nebula
+
+#endif  // META_REPORTTASKPROCESSOR_H_

--- a/src/meta/processors/jobMan/ReportTaskProcessor.h
+++ b/src/meta/processors/jobMan/ReportTaskProcessor.h
@@ -8,11 +8,9 @@
 #define META_REPORTTASKPROCESSOR_H_
 
 #include "meta/processors/BaseProcessor.h"
-#include "meta/processors/admin/AdminClient.h"
 
 namespace nebula {
 namespace meta {
-
 class ReportTaskProcessor : public BaseProcessor<cpp2::ExecResp> {
 public:
     static ReportTaskProcessor* instance(kvstore::KVStore* kvstore) {
@@ -22,7 +20,7 @@ public:
     void process(const cpp2::ReportTaskReq& req);
 
 protected:
-    explicit ReportTaskProcessor(kvstore::KVStore* kvstore, AdminClient* adminClient)
+    explicit ReportTaskProcessor(kvstore::KVStore* kvstore)
         : BaseProcessor<cpp2::ExecResp>(kvstore) {}
 };
 

--- a/src/meta/processors/jobMan/StatisJobExecutor.cpp
+++ b/src/meta/processors/jobMan/StatisJobExecutor.cpp
@@ -118,6 +118,14 @@ cpp2::ErrorCode StatisJobExecutor::saveSpecialTaskStatus(const cpp2::ReportTaskR
     return cpp2::ErrorCode::SUCCEEDED;
 }
 
+/**
+ * @brief
+ *      if two stats job run at the same time.
+ *      (this may happens if leader changed)
+ *      they will write to the same kv data
+ *      so separate the partial result by job
+ * @return std::string
+ */
 std::string StatisJobExecutor::toTempKey(int32_t jobId) {
     std::string key = MetaServiceUtils::statisKey(space_);;
     return key.append(reinterpret_cast<const char*>(&jobId), sizeof(int32_t));

--- a/src/meta/processors/jobMan/StatisJobExecutor.cpp
+++ b/src/meta/processors/jobMan/StatisJobExecutor.cpp
@@ -57,6 +57,56 @@ StatisJobExecutor::executeInternal(HostAddr&& address, std::vector<PartitionID>&
                                  std::move(parts), concurrency_, &(statisItem_[address]));
 }
 
+void showStatisItem(const cpp2::StatisItem& item, const std::string& msg) {
+    std::stringstream oss;
+    oss << msg << ": ";
+    oss << "tag_vertices: ";
+    for (auto& it : item.tag_vertices) {
+        oss << folly::sformat("[{}, {}] ", it.first, it.second);
+    }
+    oss << ", edges: ";
+    for (auto& it : item.edges) {
+        oss << folly::sformat("[{}, {}] ", it.first, it.second);
+    }
+    oss << folly::sformat(", space_vertices={}", item.space_vertices);
+    oss << folly::sformat(", space_edges={}", item.space_edges);
+    LOG(INFO) << oss.str();
+}
+
+void StatisJobExecutor::addStatis(cpp2::StatisItem& lhs, const cpp2::StatisItem& rhs) {
+    for (auto& it : rhs.tag_vertices) {
+        lhs.tag_vertices[it.first] += it.second;
+    }
+
+    for (auto& it : rhs.edges) {
+        lhs.edges[it.first] += it.second;
+    }
+
+    lhs.space_vertices += rhs.space_vertices;
+    lhs.space_edges += rhs.space_edges;
+    // ignore part_corelativity, they shoule be same
+}
+
+/**
+ * @brief caller will guarantee there won't be any conflict read / write.
+ */
+cpp2::ErrorCode StatisJobExecutor::saveSpecialTaskStatus(const cpp2::ReportTaskReq& req) {
+    if (!req.__isset.statis) {
+        return cpp2::ErrorCode::SUCCEEDED;
+    }
+    cpp2::StatisItem statisItem;
+    auto statisKey = MetaServiceUtils::statisKey(space_);
+    std::string val;
+    auto ret = kvstore_->get(kDefaultSpaceId, kDefaultPartId, statisKey, &val);
+    if (ret == kvstore::ResultCode::SUCCEEDED) {
+        statisItem = MetaServiceUtils::parseStatisVal(val);
+    }
+    addStatis(statisItem, *req.get_statis());
+    auto statisVal = MetaServiceUtils::statisVal(statisItem);
+    save(statisKey, statisVal);
+    return cpp2::ErrorCode::SUCCEEDED;
+}
+
 void StatisJobExecutor::finish(bool ExeSuccessed) {
     auto statisKey = MetaServiceUtils::statisKey(space_);
     std::string val;
@@ -68,35 +118,6 @@ void StatisJobExecutor::finish(bool ExeSuccessed) {
     auto statisItem = MetaServiceUtils::parseStatisVal(val);
     if (ExeSuccessed) {
         statisItem.status = cpp2::JobStatus::FINISHED;
-        statisItem.space_vertices = 0;
-        statisItem.space_edges = 0;
-        decltype(statisItem.tag_vertices) tagVertices;
-        decltype(statisItem.edges) edges;
-
-        for (auto& e : statisItem_) {
-            auto item = e.second;
-            statisItem.space_vertices += item.space_vertices;
-            statisItem.space_edges += item.space_edges;
-
-            for (auto& tag : item.tag_vertices) {
-                auto tagName = tag.first;
-                if (tagVertices.find(tagName) == tagVertices.end()) {
-                    tagVertices[tagName] = tag.second;
-                } else {
-                    tagVertices[tagName] += tag.second;
-                }
-            }
-            for (auto& edge : item.edges) {
-                auto edgeName = edge.first;
-                if (edges.find(edgeName) == edges.end()) {
-                    edges[edgeName] = edge.second;
-                } else {
-                    edges[edgeName] += edge.second;
-                }
-            }
-        }
-        statisItem.set_tag_vertices(std::move(tagVertices));
-        statisItem.set_edges(std::move(edges));
     } else {
         statisItem.status = cpp2::JobStatus::FAILED;
     }

--- a/src/meta/processors/jobMan/StatisJobExecutor.h
+++ b/src/meta/processors/jobMan/StatisJobExecutor.h
@@ -36,11 +36,15 @@ public:
     // Summarize the results of statisItem_
     void finish(bool ExeSuccessed) override;
 
+    cpp2::ErrorCode saveSpecialTaskStatus(const cpp2::ReportTaskReq& req) override;
+
 private:
     // Statis job writes an additional data.
     // The additional data is written when the statis job passes the check function.
     // Update this additional data when job finishes.
     kvstore::ResultCode save(const std::string& key, const std::string& val);
+
+    void addStatis(cpp2::StatisItem& lhs, const cpp2::StatisItem& rhs);
 
 private:
     // Statis results

--- a/src/meta/processors/jobMan/StatisJobExecutor.h
+++ b/src/meta/processors/jobMan/StatisJobExecutor.h
@@ -46,6 +46,10 @@ private:
 
     void addStatis(cpp2::StatisItem& lhs, const cpp2::StatisItem& rhs);
 
+    std::string toTempKey(int32_t jobId);
+
+    void doRemove(const std::string& key);
+
 private:
     // Statis results
     std::unordered_map<HostAddr, cpp2::StatisItem>  statisItem_;

--- a/src/meta/processors/jobMan/TaskDescription.h
+++ b/src/meta/processors/jobMan/TaskDescription.h
@@ -35,7 +35,7 @@ class TaskDescription {
     FRIEND_TEST(TaskDescriptionTest, dump);
     FRIEND_TEST(TaskDescriptionTest, ctor2);
     FRIEND_TEST(JobManagerTest, showJob);
-
+    friend class JobManager;
 public:
     TaskDescription(JobID iJob, TaskID iTask, const HostAddr& dst);
     TaskDescription(JobID iJob, TaskID iTask, std::string addr, int32_t port);
@@ -94,6 +94,8 @@ public:
     bool setStatus(cpp2::JobStatus newStatus);
 
     JobID getJobId() { return iJob_; }
+
+    TaskID getTaskId() { return iTask_; }
 
 private:
     JobID                           iJob_;

--- a/src/meta/test/GetStatisTest.cpp
+++ b/src/meta/test/GetStatisTest.cpp
@@ -39,7 +39,7 @@ protected:
         });
 
         jobMgr = JobManager::getInstance();
-        jobMgr->status_ = JobManager::Status::NOT_START;
+        jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
         jobMgr->init(kv_.get());
     }
 

--- a/src/meta/test/GetStatisTest.cpp
+++ b/src/meta/test/GetStatisTest.cpp
@@ -27,6 +27,57 @@ using ::testing::DefaultValue;
 using ::testing::NiceMock;
 using ::testing::SetArgPointee;
 
+std::string toTempKey(int32_t space, int32_t jobId) {
+    std::string key = MetaServiceUtils::statisKey(space);
+    return key.append(reinterpret_cast<const char*>(&jobId), sizeof(int32_t));
+}
+
+void copyData(kvstore::KVStore* kv,
+              int32_t space,
+              int32_t part,
+              const std::string& keySrc,
+              const std::string& keyDst) {
+    std::string val;
+    kv->get(space, part, keySrc, &val);
+
+    std::vector<kvstore::KV> data{std::make_pair(keyDst, val)};
+    folly::Baton<true, std::atomic> b;
+    kv->asyncMultiPut(space, part, std::move(data), [&](auto) { b.post(); });
+    b.wait();
+}
+
+void genTempData(int32_t spaceId, int jobId, kvstore::KVStore* kv) {
+    auto statisKey = MetaServiceUtils::statisKey(spaceId);
+    auto tempKey = toTempKey(spaceId, jobId);
+    copyData(kv, 0, 0, statisKey, tempKey);
+}
+
+struct JobCallBack {
+    JobCallBack(JobManager* jobMgr, int job, int task, int n)
+        : jobMgr_(jobMgr), jobId_(job), taskId_(task), n_(n) {}
+
+    folly::Future<nebula::Status> operator()() {
+        cpp2::ReportTaskReq req;
+        req.set_code(cpp2::ErrorCode::SUCCEEDED);
+        req.set_job_id(jobId_);
+        req.set_task_id(taskId_);
+
+        cpp2::StatisItem item;
+        item.tag_vertices = {{"t1", n_}, {"t2", n_}};
+        item.edges = {{"e1", n_}, {"e2", n_}};
+        item.space_vertices = 2 * n_;
+        item.space_edges = 2 * n_;
+        req.set_statis(item);
+        jobMgr_->reportTaskFinish(req);
+        return folly::Future<Status>(Status::OK());
+    }
+
+    JobManager* jobMgr_{nullptr};
+    int32_t jobId_{-1};
+    int32_t taskId_{-1};
+    int32_t n_{-1};
+};
+
 class GetStatisTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -103,7 +154,12 @@ TEST_F(GetStatisTest, StatisJob) {
     // But set statis data.
     statisJob.setStatus(cpp2::JobStatus::FINISHED);
     jobMgr->save(statisJob.jobKey(), statisJob.jobVal());
+    auto jobId = statisJob.getJobId();
+    auto statisKey = MetaServiceUtils::statisKey(spaceId);
+    auto tempKey = toTempKey(spaceId, jobId);
 
+    copyData(kv_.get(), 0, 0, statisKey, tempKey);
+    jobMgr->jobFinished(jobId, true);
     {
         auto job2 = JobDescription::loadJobDescription(statisJob.id_, kv_.get());
         ASSERT_TRUE(job2);
@@ -116,6 +172,9 @@ TEST_F(GetStatisTest, StatisJob) {
         auto f = processor->getFuture();
         processor->process(req);
         auto resp = std::move(f).get();
+        if (resp.code != cpp2::ErrorCode::SUCCEEDED) {
+            LOG(INFO) << "resp.code=" << static_cast<int>(resp.code);
+        }
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
 
         auto statisItem = resp.statis;
@@ -218,6 +277,14 @@ TEST_F(GetStatisTest, StatisJob) {
     // Insert running status statis data in prepare function of runJobInternal.
     // Update statis data to finished or failed status in finish function of runJobInternal.
     auto result2 = jobMgr->runJobInternal(statisJob2);
+
+    auto jobId2 = statisJob2.getJobId();
+    auto statisKey2 = MetaServiceUtils::statisKey(spaceId);
+    auto tempKey2 = toTempKey(spaceId, jobId2);
+
+    copyData(kv_.get(), 0, 0, statisKey2, tempKey2);
+    jobMgr->jobFinished(jobId2, true);
+
     ASSERT_TRUE(result2);
     // JobManager does not set the job finished status in RunJobInternal function.
     // But set statis data.
@@ -285,21 +352,13 @@ TEST_F(GetStatisTest, MockSingleMachineTest) {
     JobDescription job1(jobId1, cpp2::AdminCmd::STATS, paras);
     jobMgr->addJob(job1, &adminClient);
 
-    auto genItem = [] (int64_t count) -> cpp2::StatisItem {
-        cpp2::StatisItem item;
-        item.tag_vertices = {{"t1", count}, {"t2", count}};
-        item.edges = {{"e1", count}, {"e2", count}};
-        item.space_vertices = 2 * count;
-        item.space_edges = 2 * count;
-        return item;
-    };
+    JobCallBack cb1(jobMgr, jobId1, 0, 100);
+    JobCallBack cb2(jobMgr, 2, 0, 200);
 
     EXPECT_CALL(adminClient, addTask(_, _, _, _, _, _, _, _, _))
         .Times(2)
-        .WillOnce(DoAll(SetArgPointee<8>(genItem(100)),
-                        Return(ByMove(folly::Future<Status>(Status::OK())))))
-        .WillOnce(DoAll(SetArgPointee<8>(genItem(200)),
-                        Return(ByMove(folly::Future<Status>(Status::OK())))));
+        .WillOnce(testing::InvokeWithoutArgs(cb1))
+        .WillOnce(testing::InvokeWithoutArgs(cb2));
 
     // check job result
     {
@@ -404,23 +463,15 @@ TEST_F(GetStatisTest, MockMultiMachineTest) {
     JobDescription job(jobId, cpp2::AdminCmd::STATS, paras);
     jobMgr->addJob(job, &adminClient);
 
-    auto genItem = [] (int64_t count) -> cpp2::StatisItem {
-        cpp2::StatisItem item;
-        item.tag_vertices = {{"t1", count}, {"t2", count}};
-        item.edges = {{"e1", count}, {"e2", count}};
-        item.space_vertices = 2 * count;
-        item.space_edges = 2 * count;
-        return item;
-    };
+    JobCallBack cb1(jobMgr, jobId, 0, 100);
+    JobCallBack cb2(jobMgr, jobId, 1, 200);
+    JobCallBack cb3(jobMgr, jobId, 2, 300);
 
     EXPECT_CALL(adminClient, addTask(_, _, _, _, _, _, _, _, _))
         .Times(3)
-        .WillOnce(DoAll(SetArgPointee<8>(genItem(100)),
-                        Return(ByMove(folly::Future<Status>(Status::OK())))))
-        .WillOnce(DoAll(SetArgPointee<8>(genItem(200)),
-                        Return(ByMove(folly::Future<Status>(Status::OK())))))
-        .WillOnce(DoAll(SetArgPointee<8>(genItem(300)),
-                        Return(ByMove(folly::Future<Status>(Status::OK())))));
+        .WillOnce(testing::InvokeWithoutArgs(cb1))
+        .WillOnce(testing::InvokeWithoutArgs(cb2))
+        .WillOnce(testing::InvokeWithoutArgs(cb3));
 
     // check job result
     {

--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -31,28 +31,26 @@ bool gInitialized = false;
 class JobManagerTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        rootPath_ = std::make_unique<fs::TempDir>("/tmp/JobManager.XXXXXX");
-        mock::MockCluster cluster;
-        kv_ = cluster.initMetaKV(rootPath_->path());
-
-        ASSERT_TRUE(TestUtils::createSomeHosts(kv_.get()));
-        TestUtils::assembleSpace(kv_.get(), 1, 1);
-
-        // Make sure the rebuild job could find the index name.
-        std::vector<cpp2::ColumnDef> columns;
-        TestUtils::mockTagIndex(kv_.get(), 1, "tag_name", 11,
-                                "tag_index_name", columns);
-        TestUtils::mockEdgeIndex(kv_.get(), 1, "edge_name", 21,
-                                 "edge_index_name", columns);
-
-        adminClient_ = std::make_unique<NiceMock<MockAdminClient>>();
-        DefaultValue<folly::Future<Status>>::SetFactory([] {
-            return folly::Future<Status>(Status::OK());
-        });
-
-        jobMgr = JobManager::getInstance();
-        jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
         if (!gInitialized) {
+            rootPath_ = std::make_unique<fs::TempDir>("/tmp/JobManager.XXXXXX");
+            mock::MockCluster cluster;
+            kv_ = cluster.initMetaKV(rootPath_->path());
+
+            ASSERT_TRUE(TestUtils::createSomeHosts(kv_.get()));
+            TestUtils::assembleSpace(kv_.get(), 1, 1);
+
+            // Make sure the rebuild job could find the index name.
+            std::vector<cpp2::ColumnDef> columns;
+            TestUtils::mockTagIndex(kv_.get(), 1, "tag_name", 11, "tag_index_name", columns);
+            TestUtils::mockEdgeIndex(kv_.get(), 1, "edge_name", 21, "edge_index_name", columns);
+
+            adminClient_ = std::make_unique<NiceMock<MockAdminClient>>();
+            DefaultValue<folly::Future<Status>>::SetFactory(
+                [] { return folly::Future<Status>(Status::OK()); });
+
+            jobMgr = JobManager::getInstance();
+            jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
+
             jobMgr->init(kv_.get());
             gInitialized = true;
         }

--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -49,6 +49,7 @@ protected:
 
         jobMgr = JobManager::getInstance();
         jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
+        jobMgr->kvStore_ = kv_.get();
         if (!gInitialized) {
             jobMgr->init(kv_.get());
             gInitialized = true;
@@ -70,7 +71,6 @@ protected:
 
     std::unique_ptr<fs::TempDir> rootPath_{nullptr};
     std::unique_ptr<kvstore::KVStore> kv_{nullptr};
-    std::unique_ptr<nebula::thread::GenericThreadPool> pool_{nullptr};
     std::unique_ptr<AdminClient> adminClient_{nullptr};
     JobManager* jobMgr{nullptr};
 };

--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -31,26 +31,25 @@ bool gInitialized = false;
 class JobManagerTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        rootPath_ = std::make_unique<fs::TempDir>("/tmp/JobManager.XXXXXX");
+        mock::MockCluster cluster;
+        kv_ = cluster.initMetaKV(rootPath_->path());
+
+        ASSERT_TRUE(TestUtils::createSomeHosts(kv_.get()));
+        TestUtils::assembleSpace(kv_.get(), 1, 1);
+
+        // Make sure the rebuild job could find the index name.
+        std::vector<cpp2::ColumnDef> columns;
+        TestUtils::mockTagIndex(kv_.get(), 1, "tag_name", 11, "tag_index_name", columns);
+        TestUtils::mockEdgeIndex(kv_.get(), 1, "edge_name", 21, "edge_index_name", columns);
+
+        adminClient_ = std::make_unique<NiceMock<MockAdminClient>>();
+        DefaultValue<folly::Future<Status>>::SetFactory(
+            [] { return folly::Future<Status>(Status::OK()); });
+
+        jobMgr = JobManager::getInstance();
+        jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
         if (!gInitialized) {
-            rootPath_ = std::make_unique<fs::TempDir>("/tmp/JobManager.XXXXXX");
-            mock::MockCluster cluster;
-            kv_ = cluster.initMetaKV(rootPath_->path());
-
-            ASSERT_TRUE(TestUtils::createSomeHosts(kv_.get()));
-            TestUtils::assembleSpace(kv_.get(), 1, 1);
-
-            // Make sure the rebuild job could find the index name.
-            std::vector<cpp2::ColumnDef> columns;
-            TestUtils::mockTagIndex(kv_.get(), 1, "tag_name", 11, "tag_index_name", columns);
-            TestUtils::mockEdgeIndex(kv_.get(), 1, "edge_name", 21, "edge_index_name", columns);
-
-            adminClient_ = std::make_unique<NiceMock<MockAdminClient>>();
-            DefaultValue<folly::Future<Status>>::SetFactory(
-                [] { return folly::Future<Status>(Status::OK()); });
-
-            jobMgr = JobManager::getInstance();
-            jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
-
             jobMgr->init(kv_.get());
             gInitialized = true;
         }

--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -151,7 +151,7 @@ TEST_F(JobManagerTest, JobPriority) {
     result = jobMgr->try_dequeue(jobId);
     ASSERT_FALSE(result);
 
-    jobMgr->status_ = JobManager::JbmgrStatus::RUNNING;
+    jobMgr->status_ = JobManager::JbmgrStatus::IDLE;
 }
 
 TEST_F(JobManagerTest, JobDeduplication) {
@@ -202,7 +202,7 @@ TEST_F(JobManagerTest, JobDeduplication) {
 
     result = jobMgr->try_dequeue(jobId);
     ASSERT_FALSE(result);
-    jobMgr->status_ = JobManager::JbmgrStatus::RUNNING;
+    jobMgr->status_ = JobManager::JbmgrStatus::IDLE;
 }
 
 TEST_F(JobManagerTest, loadJobDescription) {

--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -49,7 +49,7 @@ protected:
         });
 
         jobMgr = JobManager::getInstance();
-        jobMgr->status_ = JobManager::Status::NOT_START;
+        jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
         jobMgr->init(kv_.get());
     }
 
@@ -76,7 +76,7 @@ TEST_F(JobManagerTest, addJob) {
 
 TEST_F(JobManagerTest, AddRebuildTagIndexJob) {
     // For preventting job schedule in JobManager
-    jobMgr->status_ = JobManager::Status::STOPPED;
+    jobMgr->status_ = JobManager::JbmgrStatus::STOPPED;
 
     std::vector<std::string> paras{"tag_index_name", "test_space"};
     JobDescription job(11, cpp2::AdminCmd::REBUILD_TAG_INDEX, paras);
@@ -89,7 +89,7 @@ TEST_F(JobManagerTest, AddRebuildTagIndexJob) {
 
 TEST_F(JobManagerTest, AddRebuildEdgeIndexJob) {
     // For preventting job schedule in JobManager
-    jobMgr->status_ = JobManager::Status::STOPPED;
+    jobMgr->status_ = JobManager::JbmgrStatus::STOPPED;
 
     std::vector<std::string> paras{"edge_index_name", "test_space"};
     JobDescription job(11, cpp2::AdminCmd::REBUILD_EDGE_INDEX, paras);
@@ -101,7 +101,7 @@ TEST_F(JobManagerTest, AddRebuildEdgeIndexJob) {
 
 TEST_F(JobManagerTest, StatisJob) {
     // For preventting job schedule in JobManager
-    jobMgr->status_ = JobManager::Status::STOPPED;
+    jobMgr->status_ = JobManager::JbmgrStatus::STOPPED;
 
     std::vector<std::string> paras{"test_space"};
     JobDescription job(12, cpp2::AdminCmd::STATS, paras);
@@ -121,7 +121,7 @@ TEST_F(JobManagerTest, StatisJob) {
 
 TEST_F(JobManagerTest, JobPriority) {
     // For preventting job schedule in JobManager
-    jobMgr->status_ = JobManager::Status::STOPPED;
+    jobMgr->status_ = JobManager::JbmgrStatus::STOPPED;
 
     ASSERT_EQ(0, jobMgr->jobSize());
 
@@ -151,12 +151,12 @@ TEST_F(JobManagerTest, JobPriority) {
     result = jobMgr->try_dequeue(jobId);
     ASSERT_FALSE(result);
 
-    jobMgr->status_ = JobManager::Status::RUNNING;
+    jobMgr->status_ = JobManager::JbmgrStatus::RUNNING;
 }
 
 TEST_F(JobManagerTest, JobDeduplication) {
     // For preventting job schedule in JobManager
-    jobMgr->status_ = JobManager::Status::STOPPED;
+    jobMgr->status_ = JobManager::JbmgrStatus::STOPPED;
 
     ASSERT_EQ(0, jobMgr->jobSize());
 
@@ -202,7 +202,7 @@ TEST_F(JobManagerTest, JobDeduplication) {
 
     result = jobMgr->try_dequeue(jobId);
     ASSERT_FALSE(result);
-    jobMgr->status_ = JobManager::Status::RUNNING;
+    jobMgr->status_ = JobManager::JbmgrStatus::RUNNING;
 }
 
 TEST_F(JobManagerTest, loadJobDescription) {
@@ -324,7 +324,7 @@ TEST_F(JobManagerTest, showJob) {
 
 TEST_F(JobManagerTest, recoverJob) {
     // set status to prevent running the job since AdminClient is a injector
-    jobMgr->status_ = JobManager::Status::NOT_START;
+    jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
     int32_t nJob = 3;
     for (auto i = 0; i != nJob; ++i) {
         JobDescription jd(i, cpp2::AdminCmd::FLUSH, {"test_space"});

--- a/src/storage/admin/AdminTaskProcessor.cpp
+++ b/src/storage/admin/AdminTaskProcessor.cpp
@@ -21,8 +21,9 @@ void AdminTaskProcessor::process(const cpp2::AddAdminTaskRequest& req) {
             case storage::cpp2::ErrorCode::E_UNKNOWN:
                 return meta::cpp2::ErrorCode::E_UNKNOWN;
             default:
-                LOG(FATAL) << "unsupported conversion of code "
+                LOG(ERROR) << "unsupported conversion of code "
                            << cpp2::_ErrorCode_VALUES_TO_NAMES.at(storageCode);
+                return meta::cpp2::ErrorCode::SUCCEEDED;
         }
     };
 
@@ -46,9 +47,9 @@ void AdminTaskProcessor::process(const cpp2::AddAdminTaskRequest& req) {
             if (!fut.hasValue()) {
                 continue;
             }
-            rc = fut.value();
-            if (rc.value() == meta::cpp2::ErrorCode::E_LEADER_CHANGED ||
-                rc.value() == meta::cpp2::ErrorCode::E_STORE_FAILURE) {
+            rc = fut.value().value();
+            if (rc == meta::cpp2::ErrorCode::E_LEADER_CHANGED ||
+                rc == meta::cpp2::ErrorCode::E_STORE_FAILURE) {
                 continue;
             } else {
                 break;

--- a/src/storage/admin/AdminTaskProcessor.cpp
+++ b/src/storage/admin/AdminTaskProcessor.cpp
@@ -40,12 +40,13 @@ void AdminTaskProcessor::process(const cpp2::AddAdminTaskRequest& req) {
         auto maxRetry = 5;
         auto retry = 0;
         while (retry++ < maxRetry) {
+            auto rc = meta::cpp2::ErrorCode::SUCCEEDED;
             auto fut = env_->metaClient_->reportTaskFinish(jobId, taskId, metaCode, pStatis);
             fut.wait();
             if (!fut.hasValue()) {
                 continue;
             }
-            auto rc = fut.value();
+            rc = fut.value();
             if (rc.value() == meta::cpp2::ErrorCode::E_LEADER_CHANGED ||
                 rc.value() == meta::cpp2::ErrorCode::E_STORE_FAILURE) {
                 continue;

--- a/src/storage/admin/AdminTaskProcessor.cpp
+++ b/src/storage/admin/AdminTaskProcessor.cpp
@@ -46,8 +46,8 @@ void AdminTaskProcessor::process(const cpp2::AddAdminTaskRequest& req) {
                 continue;
             }
             auto rc = fut.value();
-            if (rc == meta::cpp2::ErrorCode::E_LEADER_CHANGED ||
-                rc == meta::cpp2::ErrorCode::E_STORE_FAILURE) {
+            if (rc.value() == meta::cpp2::ErrorCode::E_LEADER_CHANGED ||
+                rc.value() == meta::cpp2::ErrorCode::E_STORE_FAILURE) {
                 continue;
             } else {
                 break;

--- a/src/storage/admin/AdminTaskProcessor.h
+++ b/src/storage/admin/AdminTaskProcessor.h
@@ -24,8 +24,6 @@ public:
     }
 
     void process(const cpp2::AddAdminTaskRequest& req);
-    void process1(const cpp2::AddAdminTaskRequest& req);
-    void process2(const cpp2::AddAdminTaskRequest& req);
 
 private:
     explicit AdminTaskProcessor(StorageEnv* env)

--- a/src/storage/admin/AdminTaskProcessor.h
+++ b/src/storage/admin/AdminTaskProcessor.h
@@ -24,6 +24,8 @@ public:
     }
 
     void process(const cpp2::AddAdminTaskRequest& req);
+    void process1(const cpp2::AddAdminTaskRequest& req);
+    void process2(const cpp2::AddAdminTaskRequest& req);
 
 private:
     explicit AdminTaskProcessor(StorageEnv* env)


### PR DESCRIPTION
What problem this pr want to address: 

when JobManager(meta) dispatch tasks to storage, 
it will call "collectAll" to wait all task finished.
if meta leader change during this collectAll, 
meta will fail to write job status to kvstore, forever.

So, don't let meta wait for those tasks. Instead of when a single task finished, 
task manager(storage) will call reportTaskFinish to the leader of meta. 