### PR TITLE
Support multiple versions of schemas for index scan

### DIFF
--- a/src/storage/exec/IndexEdgeNode.h
+++ b/src/storage/exec/IndexEdgeNode.h
@@ -19,11 +19,11 @@ public:
 
     IndexEdgeNode(PlanContext* planCtx,
                   IndexScanNode<T>* indexScanNode,
-                  std::shared_ptr<const meta::NebulaSchemaProvider> schema,
+                  const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas,
                   const std::string& schemaName)
         : planContext_(planCtx)
         , indexScanNode_(indexScanNode)
-        , schema_(schema)
+        , schemas_(schemas)
         , schemaName_(schemaName) {}
 
     kvstore::ResultCode execute(PartitionID partId) override {
@@ -66,8 +66,8 @@ public:
         return std::move(data_);
     }
 
-    const meta::NebulaSchemaProvider* getSchema() {
-        return schema_.get();
+    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& getSchemas() {
+        return schemas_;
     }
 
     const std::string& getSchemaName() {
@@ -75,11 +75,11 @@ public:
     }
 
 private:
-    PlanContext*                                      planContext_;
-    IndexScanNode<T>*                                 indexScanNode_;
-    std::vector<kvstore::KV>                          data_;
-    std::shared_ptr<const meta::NebulaSchemaProvider> schema_{nullptr};
-    const std::string&                                schemaName_;
+    PlanContext*                                                          planContext_;
+    IndexScanNode<T>*                                                     indexScanNode_;
+    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas_;
+    const std::string&                                                    schemaName_;
+    std::vector<kvstore::KV>                                              data_;
 };
 
 }  // namespace storage

--- a/src/storage/exec/IndexFilterNode.h
+++ b/src/storage/exec/IndexFilterNode.h
@@ -73,9 +73,9 @@ public:
                     data_.emplace_back(k.first, k.second);
                 }
             } else {
-                const auto* schema = isEdge_ ? indexEdgeNode_->getSchema()
-                                             : indexVertexNode_->getSchema();
-                auto reader = RowReaderWrapper::getRowReader(schema, k.second);
+                const auto& schemas = isEdge_ ? indexEdgeNode_->getSchemas()
+                                              : indexVertexNode_->getSchemas();
+                auto reader = RowReaderWrapper::getRowReader(schemas, k.second);
                 if (!reader) {
                     continue;
                 }
@@ -91,12 +91,9 @@ public:
         return std::move(data_);
     }
 
-    const meta::NebulaSchemaProvider* getSchema() {
-        if (evalExprByIndex_) {
-            return nullptr;
-        }
-        return isEdge_ ? indexEdgeNode_->getSchema()
-                       : indexVertexNode_->getSchema();
+    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& getSchemas() {
+        return isEdge_ ? indexEdgeNode_->getSchemas()
+                       : indexVertexNode_->getSchemas();
     }
 
      bool hasNullableCol() const {

--- a/src/storage/exec/IndexOutputNode.h
+++ b/src/storage/exec/IndexOutputNode.h
@@ -153,21 +153,21 @@ private:
     }
 
     kvstore::ResultCode vertexRowsFromData(const std::vector<kvstore::KV>& data) {
-        const auto* schema = type_ == IndexResultType::kVertexFromDataScan
-                             ? indexVertexNode_->getSchema()
-                             : indexFilterNode_->getSchema();
-        if (schema == nullptr) {
+        const auto& schemas = type_ == IndexResultType::kVertexFromDataScan
+                              ? indexVertexNode_->getSchemas()
+                              : indexFilterNode_->getSchemas();
+        if (schemas.empty()) {
             return kvstore::ResultCode::ERR_TAG_NOT_FOUND;
         }
         for (const auto& val : data) {
             Row row;
-            auto reader = RowReaderWrapper::getRowReader(schema, val.second);
+            auto reader = RowReaderWrapper::getRowReader(schemas, val.second);
             if (!reader) {
                 VLOG(1) << "Can't get tag reader";
                 return kvstore::ResultCode::ERR_TAG_NOT_FOUND;
             }
             for (const auto& col : result_->colNames) {
-                auto ret = addIndexValue(row, reader.get(), val, col, schema);
+                auto ret = addIndexValue(row, reader.get(), val, col, schemas.back().get());
                 if (!ret.ok()) {
                     return kvstore::ResultCode::ERR_INVALID_DATA;
                 }
@@ -192,21 +192,21 @@ private:
     }
 
     kvstore::ResultCode edgeRowsFromData(const std::vector<kvstore::KV>& data) {
-        const auto* schema = type_ == IndexResultType::kEdgeFromDataScan
-                             ? indexEdgeNode_->getSchema()
-                             : indexFilterNode_->getSchema();
-        if (schema == nullptr) {
+        const auto& schemas = type_ == IndexResultType::kEdgeFromDataScan
+                              ? indexEdgeNode_->getSchemas()
+                              : indexFilterNode_->getSchemas();
+        if (schemas.empty()) {
             return kvstore::ResultCode::ERR_EDGE_NOT_FOUND;
         }
         for (const auto& val : data) {
             Row row;
-            auto reader = RowReaderWrapper::getRowReader(schema, val.second);
+            auto reader = RowReaderWrapper::getRowReader(schemas, val.second);
             if (!reader) {
                 VLOG(1) << "Can't get tag reader";
                 return kvstore::ResultCode::ERR_EDGE_NOT_FOUND;
             }
             for (const auto& col : result_->colNames) {
-                auto ret = addIndexValue(row, reader.get(), val, col, schema);
+                auto ret = addIndexValue(row, reader.get(), val, col, schemas.back().get());
                 if (!ret.ok()) {
                     return kvstore::ResultCode::ERR_INVALID_DATA;
                 }

--- a/src/storage/exec/IndexVertexNode.h
+++ b/src/storage/exec/IndexVertexNode.h
@@ -21,12 +21,12 @@ public:
     IndexVertexNode(PlanContext* planCtx,
                     VertexCache* vertexCache,
                     IndexScanNode<T>* indexScanNode,
-                    std::shared_ptr<const meta::NebulaSchemaProvider> schema,
+                    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas,
                     const std::string& schemaName)
         : planContext_(planCtx)
         , vertexCache_(vertexCache)
         , indexScanNode_(indexScanNode)
-        , schema_(schema)
+        , schemas_(schemas)
         , schemaName_(schemaName) {}
 
     kvstore::ResultCode execute(PartitionID partId) override {
@@ -76,8 +76,8 @@ public:
         return std::move(data_);
     }
 
-    const meta::NebulaSchemaProvider* getSchema() {
-        return schema_.get();
+    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& getSchemas() {
+        return schemas_;
     }
 
     const std::string& getSchemaName() {
@@ -85,12 +85,12 @@ public:
     }
 
 private:
-    PlanContext*                                      planContext_;
-    VertexCache*                                      vertexCache_;
-    IndexScanNode<T>*                                 indexScanNode_;
-    std::vector<kvstore::KV>                          data_;
-    std::shared_ptr<const meta::NebulaSchemaProvider> schema_{nullptr};
-    const std::string&                                schemaName_;
+    PlanContext*                                                          planContext_;
+    VertexCache*                                                          vertexCache_;
+    IndexScanNode<T>*                                                     indexScanNode_;
+    const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas_;
+    const std::string&                                                    schemaName_;
+    std::vector<kvstore::KV>                                              data_;
 };
 
 }  // namespace storage

--- a/src/storage/index/LookupBaseProcessor.h
+++ b/src/storage/index/LookupBaseProcessor.h
@@ -68,16 +68,16 @@ protected:
                                Expression* exp);
 
 protected:
-    GraphSpaceID                                spaceId_;
-    std::unique_ptr<PlanContext>                planContext_;
-    VertexCache*                                vertexCache_{nullptr};
-    nebula::DataSet                             resultDataSet_;
-    std::vector<cpp2::IndexQueryContext>        contexts_{};
-    std::vector<std::string>                    yieldCols_{};
-    IndexFilterItem                             filterItems_;
-    // Save schema when column is out of index, need to read from data
-    std::shared_ptr<const meta::NebulaSchemaProvider> schema_;
-    std::vector<size_t>                         deDupColPos_;
+    GraphSpaceID                                                   spaceId_;
+    std::unique_ptr<PlanContext>                                   planContext_;
+    VertexCache*                                                   vertexCache_{nullptr};
+    nebula::DataSet                                                resultDataSet_;
+    std::vector<cpp2::IndexQueryContext>                           contexts_{};
+    std::vector<std::string>                                       yieldCols_{};
+    IndexFilterItem                                                filterItems_;
+    // Save schemas when column is out of index, need to read from data
+    std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>> schemas_;
+    std::vector<size_t>                                            deDupColPos_;
 };
 }  // namespace storage
 }  // namespace nebula


### PR DESCRIPTION
Read prop value of `indexScan`, If the RowReader contains this field,  read from the `rowReader`, otherwise read the default value or null value from the latest schema

```
CREATE SPACE space1(partition_num=1, replica_factor=1)
use space1

create tag t1(c1 int)
create tag index i1 on t1(c1)
insert vertex t1(c1) values "1":(1)
alter tag t1 add (c2 int)
alter tag t1 add (c3 int default 666)
lookup on t1 where t1.c1 == 1 yield t1.c1, t1.c2, t1.c3
(root@nebula) [space1]> lookup on t1 where t1.c1 == 1 yield t1.c1, t1.c2, t1.c3
+----------+-------+-------+-------+
| VertexID | t1.c1 | t1.c2 | t1.c3 |
+----------+-------+-------+-------+
| "1"      | 1     | NULL  | 666   |
+----------+-------+-------+-------+
Got 1 rows (time spent 2352/2742 us)

create edge e1(c1 int)
create edge index i2 on e1(c1)
insert edge e1(c1) values "1"->"2":(1)
alter edge e1 add (c2 int)
alter edge e1 add (c3 int default 666)
lookup on e1 where e1.c1 == 1 yield e1.c1, e1.c2, e1.c3
(root@nebula) [space1]> lookup on e1 where e1.c1 == 1 yield e1.c1, e1.c2, e1.c3
+--------+--------+---------+-------+-------+-------+
| SrcVID | DstVID | Ranking | e1.c1 | e1.c2 | e1.c3 |
+--------+--------+---------+-------+-------+-------+
| "1"    | "2"    | 0       | 1     | NULL  | 666   |
+--------+--------+---------+-------+-------+-------+
Got 1 rows (time spent 2693/1442811 us)
```