### PR TITLE
separate vertex and edge

### DIFF
--- a/src/kvstore/RocksEngineConfig.cpp
+++ b/src/kvstore/RocksEngineConfig.cpp
@@ -99,8 +99,8 @@ public:
     }
 
     bool InDomain(const rocksdb::Slice& src) const override {
-        return src.size() >= prefixLen_ && NebulaKeyUtils::isDataKey(
-                folly::StringPiece(src.data(), 1));
+        // todo(doodle): only need to consider tag and edge
+        return src.size() >= prefixLen_;
     }
 };
 

--- a/src/kvstore/SnapshotManagerImpl.h
+++ b/src/kvstore/SnapshotManagerImpl.h
@@ -23,6 +23,14 @@ public:
                                  raftex::SnapshotCallback cb) override;
 
 private:
+    void accessTable(GraphSpaceID spaceId,
+                     PartitionID partId,
+                     const std::string& prefix,
+                     raftex::SnapshotCallback& cb,
+                     std::vector<std::string>& data,
+                     int64_t& totalCount,
+                     int64_t& totalSize);
+
     KVStore* store_;
 };
 

--- a/src/kvstore/plugins/elasticsearch/ESListener.cpp
+++ b/src/kvstore/plugins/elasticsearch/ESListener.cpp
@@ -44,7 +44,8 @@ void ESListener::init() {
 bool ESListener::apply(const std::vector<KV>& data) {
     std::vector<nebula::plugin::DocItem> docItems;
     for (const auto& kv : data) {
-        if (!nebula::NebulaKeyUtils::isDataKey(kv.first)) {
+        if (!nebula::NebulaKeyUtils::isVertex(vIdLen_, kv.first) &&
+            !nebula::NebulaKeyUtils::isEdge(vIdLen_, kv.first)) {
             continue;
         }
         if (!appendDocItem(docItems, kv)) {

--- a/src/storage/CompactionFilter.h
+++ b/src/storage/CompactionFilter.h
@@ -40,7 +40,23 @@ public:
             return false;
         }
 
-        if (NebulaKeyUtils::isDataKey(key)) {
+        // todo(doodle):
+        // 1. remove redundant code in schemaValid/ttlValid
+        // 2. only filter multi version when mvcc enabled
+        // 3. only check isLock once
+        if (NebulaKeyUtils::isVertex(vIdLen_, key)) {
+            if (!schemaValid(spaceId, key)) {
+                return true;
+            }
+            if (!ttlValid(spaceId, key, val)) {
+                VLOG(3) << "TTL invalid for key " << key;
+                return true;
+            }
+            if (filterVersions(key)) {
+                VLOG(3) << "Extra versions has been filtered!";
+                return true;
+            }
+        } else if (NebulaKeyUtils::isEdge(vIdLen_, key)) {
             if (!schemaValid(spaceId, key)) {
                 return true;
             }

--- a/src/storage/admin/RebuildEdgeIndexTask.cpp
+++ b/src/storage/admin/RebuildEdgeIndexTask.cpp
@@ -43,7 +43,7 @@ kvstore::ResultCode RebuildEdgeIndexTask::buildIndexGlobal(GraphSpaceID space,
 
     auto vidSize = vidSizeRet.value();
     std::unique_ptr<kvstore::KVIterator> iter;
-    auto prefix = NebulaKeyUtils::partPrefix(part);
+    auto prefix = NebulaKeyUtils::edgePrefix(part);
     auto ret = env_->kvstore_->prefix(space, part, prefix, &iter);
     if (ret != kvstore::ResultCode::SUCCEEDED) {
         LOG(ERROR) << "Processing Part " << part << " Failed";

--- a/src/storage/admin/RebuildTagIndexTask.cpp
+++ b/src/storage/admin/RebuildTagIndexTask.cpp
@@ -43,7 +43,7 @@ kvstore::ResultCode RebuildTagIndexTask::buildIndexGlobal(GraphSpaceID space,
 
     auto vidSize = vidSizeRet.value();
     std::unique_ptr<kvstore::KVIterator> iter;
-    auto prefix = NebulaKeyUtils::partPrefix(part);
+    auto prefix = NebulaKeyUtils::vertexPrefix(part);
     auto ret = env_->kvstore_->prefix(space, part, prefix, &iter);
     if (ret != kvstore::ResultCode::SUCCEEDED) {
         LOG(ERROR) << "Processing Part " << part << " Failed";

--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -41,7 +41,7 @@ void ScanEdgeProcessor::doProcess(const cpp2::ScanEdgeRequest& req) {
     }
 
     std::string start;
-    std::string prefix = NebulaKeyUtils::partPrefix(partId_);
+    std::string prefix = NebulaKeyUtils::edgePrefix(partId_);
     if (req.get_cursor() == nullptr || req.get_cursor()->empty()) {
         start = prefix;
     } else {

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -41,7 +41,7 @@ void ScanVertexProcessor::doProcess(const cpp2::ScanVertexRequest& req) {
     }
 
     std::string start;
-    std::string prefix = NebulaKeyUtils::partPrefix(partId_);
+    std::string prefix = NebulaKeyUtils::vertexPrefix(partId_);
     if (req.get_cursor() == nullptr || req.get_cursor()->empty()) {
         start = prefix;
     } else {

--- a/src/storage/test/CompactionTest.cpp
+++ b/src/storage/test/CompactionTest.cpp
@@ -36,7 +36,7 @@ void checkTagVertexData(int32_t spaceVidLen,
     VertexID lastVertexId = "";
 
     for (int part = 1; part <= parts; part++) {
-        auto prefix = NebulaKeyUtils::partPrefix(part);
+        auto prefix = NebulaKeyUtils::vertexPrefix(part);
         auto ret = env->kvstore_->prefix(spaceId, part, prefix, &iter);
         ASSERT_EQ(ret, kvstore::ResultCode::SUCCEEDED);
 
@@ -81,7 +81,7 @@ void checkEdgeData(int32_t spaceVidLen,
     EdgeRanking lastRank = 0;
 
     for (int part = 1; part <= parts; part++) {
-        auto prefix = NebulaKeyUtils::partPrefix(part);
+        auto prefix = NebulaKeyUtils::edgePrefix(part);
         auto ret = env->kvstore_->prefix(spaceId, part, prefix, &iter);
         ASSERT_EQ(ret, kvstore::ResultCode::SUCCEEDED);
 

--- a/src/storage/test/IndexWriteTest.cpp
+++ b/src/storage/test/IndexWriteTest.cpp
@@ -179,7 +179,7 @@ TEST(IndexTest, SimpleEdgesTest) {
 
         LOG(INFO) << "Check insert data...";
         for (auto partId = 1; partId <= 6; partId++) {
-            auto prefix = NebulaKeyUtils::partPrefix(partId);
+            auto prefix = NebulaKeyUtils::edgePrefix(partId);
             auto retNum = verifyResultNum(1, partId, prefix, env->kvstore_);
             EXPECT_EQ(2, retNum);
         }
@@ -213,7 +213,7 @@ TEST(IndexTest, SimpleEdgesTest) {
 
         LOG(INFO) << "Check delete data...";
         for (auto partId = 1; partId <= 6; partId++) {
-            auto prefix = NebulaKeyUtils::partPrefix(partId);
+            auto prefix = NebulaKeyUtils::edgePrefix(partId);
             auto retNum = verifyResultNum(1, partId, prefix, env->kvstore_);
             EXPECT_EQ(0, retNum);
         }

--- a/src/storage/test/RebuildIndexTest.cpp
+++ b/src/storage/test/RebuildIndexTest.cpp
@@ -102,7 +102,7 @@ TEST_F(RebuildIndexTest, RebuildTagIndexCheckALLData) {
     EXPECT_LT(0, vidSize);
     int dataNum = 0;
     for (auto part : parts) {
-        auto prefix = NebulaKeyUtils::partPrefix(part);
+        auto prefix = NebulaKeyUtils::vertexPrefix(part);
         std::unique_ptr<kvstore::KVIterator> iter;
         auto ret = RebuildIndexTest::env_->kvstore_->prefix(1, part, prefix, &iter);
         EXPECT_EQ(kvstore::ResultCode::SUCCEEDED, ret);
@@ -191,7 +191,7 @@ TEST_F(RebuildIndexTest, RebuildEdgeIndexCheckALLData) {
     EXPECT_LT(0, vidSize);
     int dataNum = 0;
     for (auto part : parts) {
-        auto prefix = NebulaKeyUtils::partPrefix(part);
+        auto prefix = NebulaKeyUtils::edgePrefix(part);
         std::unique_ptr<kvstore::KVIterator> iter;
         auto ret = RebuildIndexTest::env_->kvstore_->prefix(1, part, prefix, &iter);
         EXPECT_EQ(kvstore::ResultCode::SUCCEEDED, ret);

--- a/src/storage/test/StatisTaskTest.cpp
+++ b/src/storage/test/StatisTaskTest.cpp
@@ -296,7 +296,7 @@ TEST_F(StatisTaskTest, StatisTagAndEdgeData) {
             VertexID                              lastDstVertexId = "";
             EdgeRanking                           lastRank = 0;
 
-            auto prefix = NebulaKeyUtils::partPrefix(part);
+            auto prefix = NebulaKeyUtils::vertexPrefix(part);
             std::unique_ptr<kvstore::KVIterator> iter;
             auto ret = env_->kvstore_->prefix(spaceId, part, prefix, &iter);
             if (ret != kvstore::ResultCode::SUCCEEDED) {
@@ -305,53 +305,63 @@ TEST_F(StatisTaskTest, StatisTagAndEdgeData) {
 
             while (iter && iter->valid()) {
                 auto key = iter->key();
-                if (NebulaKeyUtils::isVertex(spaceVidLen, key)) {
-                    auto vId = NebulaKeyUtils::getVertexId(spaceVidLen, key).str();
-                    auto tagId = NebulaKeyUtils::getTagId(spaceVidLen, key);
-                    auto it = tagsVertices.find(tagId);
-                    if (it == tagsVertices.end()) {
-                        // Invalid data
-                        iter->next();
-                        continue;
-                    }
+                CHECK(NebulaKeyUtils::isVertex(spaceVidLen, key));
+                auto vId = NebulaKeyUtils::getVertexId(spaceVidLen, key).str();
+                auto tagId = NebulaKeyUtils::getTagId(spaceVidLen, key);
+                auto it = tagsVertices.find(tagId);
+                if (it == tagsVertices.end()) {
+                    // Invalid data
+                    iter->next();
+                    continue;
+                }
 
-                    if (vId == lastVertexId) {
-                        if (tagId == lastTagId) {
-                            // Multi version
-                        } else {
-                            tagsVertices[tagId] += 1;
-                            lastTagId = tagId;
-                        }
-                    } else {
-                        tagsVertices[tagId] += 1;
-                        spaceVertices++;
-                        lastTagId = tagId;
-                        lastVertexId  = vId;
-                    }
-                } else if (NebulaKeyUtils::isEdge(spaceVidLen, key)) {
-                    auto edgeType = NebulaKeyUtils::getEdgeType(spaceVidLen, key);
-                    if (edgeType < 0 || edgetypeEdges.find(edgeType) == edgetypeEdges.end()) {
-                        iter->next();
-                        continue;
-                    }
-
-                    auto source = NebulaKeyUtils::getSrcId(spaceVidLen, key).str();
-                    auto ranking = NebulaKeyUtils::getRank(spaceVidLen, key);
-                    auto destination = NebulaKeyUtils::getDstId(spaceVidLen, key).str();
-
-                    if (source == lastSrcVertexId &&
-                        edgeType == lastEdgeType &&
-                        ranking == lastRank &&
-                        destination == lastDstVertexId) {
+                if (vId == lastVertexId) {
+                    if (tagId == lastTagId) {
                         // Multi version
                     } else {
-                        spaceEdges++;
-                        edgetypeEdges[edgeType] += 1;
-                        lastSrcVertexId = source;
-                        lastEdgeType  = edgeType;
-                        lastRank = ranking;
-                        lastDstVertexId = destination;
+                        tagsVertices[tagId] += 1;
+                        lastTagId = tagId;
                     }
+                } else {
+                    tagsVertices[tagId] += 1;
+                    spaceVertices++;
+                    lastTagId = tagId;
+                    lastVertexId  = vId;
+                }
+                iter->next();
+            }
+
+            prefix = NebulaKeyUtils::edgePrefix(part);
+            ret = env_->kvstore_->prefix(spaceId, part, prefix, &iter);
+            if (ret != kvstore::ResultCode::SUCCEEDED) {
+                continue;
+            }
+
+            while (iter && iter->valid()) {
+                auto key = iter->key();
+                CHECK(NebulaKeyUtils::isEdge(spaceVidLen, key));
+                auto edgeType = NebulaKeyUtils::getEdgeType(spaceVidLen, key);
+                if (edgeType < 0 || edgetypeEdges.find(edgeType) == edgetypeEdges.end()) {
+                    iter->next();
+                    continue;
+                }
+
+                auto source = NebulaKeyUtils::getSrcId(spaceVidLen, key).str();
+                auto ranking = NebulaKeyUtils::getRank(spaceVidLen, key);
+                auto destination = NebulaKeyUtils::getDstId(spaceVidLen, key).str();
+
+                if (source == lastSrcVertexId &&
+                    edgeType == lastEdgeType &&
+                    ranking == lastRank &&
+                    destination == lastDstVertexId) {
+                    // Multi version
+                } else {
+                    spaceEdges++;
+                    edgetypeEdges[edgeType] += 1;
+                    lastSrcVertexId = source;
+                    lastEdgeType  = edgeType;
+                    lastRank = ranking;
+                    lastDstVertexId = destination;
                 }
                 iter->next();
             }

--- a/src/storage/test/StatisTaskTest.cpp
+++ b/src/storage/test/StatisTaskTest.cpp
@@ -305,7 +305,6 @@ TEST_F(StatisTaskTest, StatisTagAndEdgeData) {
 
             while (iter && iter->valid()) {
                 auto key = iter->key();
-                CHECK(NebulaKeyUtils::isVertex(spaceVidLen, key));
                 auto vId = NebulaKeyUtils::getVertexId(spaceVidLen, key).str();
                 auto tagId = NebulaKeyUtils::getTagId(spaceVidLen, key);
                 auto it = tagsVertices.find(tagId);
@@ -339,7 +338,6 @@ TEST_F(StatisTaskTest, StatisTagAndEdgeData) {
 
             while (iter && iter->valid()) {
                 auto key = iter->key();
-                CHECK(NebulaKeyUtils::isEdge(spaceVidLen, key));
                 auto edgeType = NebulaKeyUtils::getEdgeType(spaceVidLen, key);
                 if (edgeType < 0 || edgetypeEdges.find(edgeType) == edgetypeEdges.end()) {
                     iter->next();

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -2,4 +2,4 @@ nebula_add_subdirectory(storage-perf)
 #nebula_add_subdirectory(simple-kv-verify)
 nebula_add_subdirectory(edges-dump)
 nebula_add_subdirectory(db-dump)
-
+nebula_add_subdirectory(db-upgrade)

--- a/src/tools/db-dump/CMakeLists.txt
+++ b/src/tools/db-dump/CMakeLists.txt
@@ -40,26 +40,26 @@ set(tools_test_deps
     $<TARGET_OBJECTS:common_ft_es_storage_adapter_obj>
 )
 
-#nebula_add_executable(
-#    NAME
-#        db_dump
-#    SOURCES
-#        DbDumpTool.cpp
-#        DbDumper.cpp
-#    OBJECTS
-#        ${tools_test_deps}
-#    LIBRARIES
-#        ${ROCKSDB_LIBRARIES}
-#        ${THRIFT_LIBRARIES}
-#        proxygenlib
-#        wangle
-#)
-#
-#install(
-#    TARGETS
-#        db_dump
-#    DESTINATION
-#        bin
-#    COMPONENT
-#        tool
-#)
+nebula_add_executable(
+    NAME
+        db_dump
+    SOURCES
+        DbDumpTool.cpp
+        DbDumper.cpp
+    OBJECTS
+        ${tools_test_deps}
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        proxygenlib
+        wangle
+)
+
+install(
+    TARGETS
+        db_dump
+    DESTINATION
+        bin
+    COMPONENT
+        tool
+)

--- a/src/tools/db-dump/CMakeLists.txt
+++ b/src/tools/db-dump/CMakeLists.txt
@@ -40,26 +40,26 @@ set(tools_test_deps
     $<TARGET_OBJECTS:common_ft_es_storage_adapter_obj>
 )
 
-nebula_add_executable(
-    NAME
-        db_dump
-    SOURCES
-        DbDumpTool.cpp
-        DbDumper.cpp
-    OBJECTS
-        ${tools_test_deps}
-    LIBRARIES
-        ${ROCKSDB_LIBRARIES}
-        ${THRIFT_LIBRARIES}
-        proxygenlib
-        wangle
-)
-
-install(
-    TARGETS
-        db_dump
-    DESTINATION
-        bin
-    COMPONENT
-        tool
-)
+#nebula_add_executable(
+#    NAME
+#        db_dump
+#    SOURCES
+#        DbDumpTool.cpp
+#        DbDumper.cpp
+#    OBJECTS
+#        ${tools_test_deps}
+#    LIBRARIES
+#        ${ROCKSDB_LIBRARIES}
+#        ${THRIFT_LIBRARIES}
+#        proxygenlib
+#        wangle
+#)
+#
+#install(
+#    TARGETS
+#        db_dump
+#    DESTINATION
+#        bin
+#    COMPONENT
+#        tool
+#)

--- a/src/tools/db-dump/DbDumper.cpp
+++ b/src/tools/db-dump/DbDumper.cpp
@@ -271,8 +271,10 @@ void DbDumper::run() {
         case 0b1000: {
             // specified part, seek with prefix and print them all
             for (auto partId : parts_) {
-                auto prefix = NebulaKeyUtils::partPrefix(partId);
-                seek(prefix);
+                auto vertexPrefix = NebulaKeyUtils::vertexPrefix(partId);
+                seek(vertexPrefix);
+                auto edgePrefix = NebulaKeyUtils::edgePrefix(partId);
+                seek(edgePrefix);
             }
             break;
         }
@@ -281,7 +283,7 @@ void DbDumper::run() {
             beforePrintVertex_.emplace_back(noPrint);
             beforePrintEdge_.emplace_back(printIfEdgeFound);
             for (auto partId : parts_) {
-                auto prefix = NebulaKeyUtils::partPrefix(partId);
+                auto prefix = NebulaKeyUtils::edgePrefix(partId);
                 seek(prefix);
             }
             break;
@@ -291,7 +293,7 @@ void DbDumper::run() {
             beforePrintVertex_.emplace_back(printIfTagFound);
             beforePrintEdge_.emplace_back(noPrint);
             for (auto partId : parts_) {
-                auto prefix = NebulaKeyUtils::partPrefix(partId);
+                auto prefix = NebulaKeyUtils::vertexPrefix(partId);
                 seek(prefix);
             }
             break;
@@ -301,7 +303,7 @@ void DbDumper::run() {
             beforePrintVertex_.emplace_back(noPrint);
             beforePrintEdge_.emplace_back(printIfEdgeFound);
             for (auto partId : parts_) {
-                auto prefix = NebulaKeyUtils::partPrefix(partId);
+                auto prefix = NebulaKeyUtils::edgePrefix(partId);
                 seek(prefix);
             }
 
@@ -310,7 +312,7 @@ void DbDumper::run() {
             beforePrintVertex_.emplace_back(printIfTagFound);
             beforePrintEdge_.emplace_back(noPrint);
             for (auto partId : parts_) {
-                auto prefix = NebulaKeyUtils::partPrefix(partId);
+                auto prefix = NebulaKeyUtils::vertexPrefix(partId);
                 seek(prefix);
             }
             break;

--- a/src/tools/db-upgrade/CMakeLists.txt
+++ b/src/tools/db-upgrade/CMakeLists.txt
@@ -1,0 +1,61 @@
+nebula_add_executable(
+    NAME
+        db_upgrader
+    SOURCES
+        DbUpgraderTool.cpp
+        NebulaKeyUtilsV1.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:version_obj>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:storage_admin_service_handler>
+        $<TARGET_OBJECTS:graph_storage_service_handler>
+        $<TARGET_OBJECTS:storage_transaction_executor>
+        $<TARGET_OBJECTS:common_internal_storage_client_obj>
+        $<TARGET_OBJECTS:common_storage_client_base_obj>
+        $<TARGET_OBJECTS:storage_common_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:codec_obj>
+        $<TARGET_OBJECTS:keyutils_obj>
+        $<TARGET_OBJECTS:common_ws_common_obj>
+        $<TARGET_OBJECTS:common_http_client_obj>
+        $<TARGET_OBJECTS:common_storage_thrift_obj>
+        $<TARGET_OBJECTS:common_meta_client_obj>
+        $<TARGET_OBJECTS:common_file_based_cluster_id_man_obj>
+        $<TARGET_OBJECTS:common_time_obj>
+        $<TARGET_OBJECTS:common_meta_thrift_obj>
+        $<TARGET_OBJECTS:common_common_thrift_obj>
+        $<TARGET_OBJECTS:common_raftex_thrift_obj>
+        $<TARGET_OBJECTS:common_meta_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:common_thread_obj>
+        $<TARGET_OBJECTS:common_time_obj>
+        $<TARGET_OBJECTS:common_fs_obj>
+        $<TARGET_OBJECTS:common_network_obj>
+        $<TARGET_OBJECTS:common_charset_obj>
+        $<TARGET_OBJECTS:common_stats_obj>
+        $<TARGET_OBJECTS:common_process_obj>
+        $<TARGET_OBJECTS:common_conf_obj>
+        $<TARGET_OBJECTS:common_datatypes_obj>
+        $<TARGET_OBJECTS:common_base_obj>
+        $<TARGET_OBJECTS:common_expression_obj>
+        $<TARGET_OBJECTS:common_function_manager_obj>
+        $<TARGET_OBJECTS:common_time_utils_obj>
+        $<TARGET_OBJECTS:common_encryption_obj>
+        $<TARGET_OBJECTS:common_ft_es_storage_adapter_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        proxygenlib
+        wangle
+)
+
+#install(
+#    TARGETS
+#        db_upgrader
+#    DESTINATION
+#        bin
+#    COMPONENT
+#        tool
+#)

--- a/src/tools/db-upgrade/DbUpgraderTool.cpp
+++ b/src/tools/db-upgrade/DbUpgraderTool.cpp
@@ -1,0 +1,15 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/base/Base.h"
+#include "utils/NebulaKeyUtils.h"
+#include "tools/db-upgrade/NebulaKeyUtilsV1.h"
+
+int main(int argc, char *argv[]) {
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+    return 0;
+}

--- a/src/tools/db-upgrade/NebulaKeyUtilsV1.cpp
+++ b/src/tools/db-upgrade/NebulaKeyUtilsV1.cpp
@@ -1,0 +1,114 @@
+/* Copyright (c) 2018 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "tools/db-upgrade/NebulaKeyUtilsV1.h"
+
+namespace nebula {
+
+// static
+std::string NebulaKeyUtilsV1::indexPrefix(PartitionID partId, IndexID indexId) {
+    PartitionID item =
+        (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kIndex);
+    std::string key;
+    key.reserve(sizeof(PartitionID) + sizeof(IndexID));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
+       .append(reinterpret_cast<const char*>(&indexId), sizeof(IndexID));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::vertexPrefix(PartitionID partId, VertexID vId, TagID tagId) {
+    tagId &= kTagMaskSet;
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kData);
+
+    std::string key;
+    key.reserve(kVertexLen);
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
+       .append(reinterpret_cast<const char*>(&vId), sizeof(VertexID))
+       .append(reinterpret_cast<const char*>(&tagId), sizeof(TagID));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::edgePrefix(PartitionID partId, VertexID srcId, EdgeType type) {
+    type |= kEdgeMaskSet;
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kData);
+
+    std::string key;
+    key.reserve(sizeof(PartitionID) + sizeof(VertexID) + sizeof(EdgeType));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
+       .append(reinterpret_cast<const char*>(&srcId), sizeof(VertexID))
+       .append(reinterpret_cast<const char*>(&type), sizeof(EdgeType));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::edgePrefix(PartitionID partId,
+                                         VertexID srcId,
+                                         EdgeType type,
+                                         EdgeRanking rank,
+                                         VertexID dstId) {
+    type |= kEdgeMaskSet;
+    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kData);
+    std::string key;
+    key.reserve(sizeof(PartitionID) + sizeof(VertexID) + sizeof(EdgeType) + sizeof(VertexID) +
+                sizeof(EdgeRanking));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
+        .append(reinterpret_cast<const char*>(&srcId), sizeof(VertexID))
+        .append(reinterpret_cast<const char*>(&type), sizeof(EdgeType))
+        .append(reinterpret_cast<const char*>(&rank), sizeof(EdgeRanking))
+        .append(reinterpret_cast<const char*>(&dstId), sizeof(VertexID));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::prefix(PartitionID partId) {
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kData);
+    std::string key;
+    key.reserve(sizeof(PartitionID));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::snapshotPrefix(PartitionID partId) {
+    // snapshot of meta would be all key-value pairs
+    if (partId == 0) {
+        return "";
+    }
+    return prefix(partId);
+}
+
+// static
+std::string NebulaKeyUtilsV1::vertexPrefix(PartitionID partId, VertexID vId) {
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kData);
+    std::string key;
+    key.reserve(sizeof(PartitionID) + sizeof(VertexID));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
+       .append(reinterpret_cast<const char*>(&vId), sizeof(VertexID));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::edgePrefix(PartitionID partId, VertexID vId) {
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyTypeV1::kData);
+    std::string key;
+    key.reserve(sizeof(PartitionID) + sizeof(VertexID));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
+       .append(reinterpret_cast<const char*>(&vId), sizeof(VertexID));
+    return key;
+}
+
+// static
+std::string NebulaKeyUtilsV1::systemPrefix() {
+    int8_t type = static_cast<uint32_t>(NebulaKeyTypeV1::kSystem);
+    std::string key;
+    key.reserve(sizeof(int8_t));
+    key.append(reinterpret_cast<const char*>(&type), sizeof(int8_t));
+    return key;
+}
+
+}  // namespace nebula

--- a/src/tools/db-upgrade/NebulaKeyUtilsV1.h
+++ b/src/tools/db-upgrade/NebulaKeyUtilsV1.h
@@ -1,0 +1,263 @@
+/* Copyright (c) 2018 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef TOOLS_DBUPGRADE_NEBULAKEYUTILSV1_H_
+#define TOOLS_DBUPGRADE_NEBULAKEYUTILSV1_H_
+
+#include "utils/Types.h"
+
+namespace nebula {
+
+enum class NebulaKeyTypeV1 : uint32_t {
+    kData              = 0x00000001,
+    kIndex             = 0x00000002,
+    kUUID              = 0x00000003,
+    kSystem            = 0x00000004,
+    kOperation         = 0x00000005,
+};
+
+/**
+ * This class supply some utils for transition between Vertex/Edge and key in kvstore.
+ * */
+class NebulaKeyUtilsV1 final {
+public:
+    ~NebulaKeyUtilsV1() = default;
+
+    using VertexID = int64_t;
+
+    static std::string indexPrefix(PartitionID partId, IndexID indexId);
+
+    static std::string vertexPrefix(PartitionID partId, VertexID vId, TagID tagId);
+
+    static std::string edgePrefix(PartitionID partId, VertexID srcId, EdgeType type);
+
+    static std::string vertexPrefix(PartitionID partId, VertexID vId);
+
+    static std::string edgePrefix(PartitionID partId, VertexID vId);
+
+    static std::string edgePrefix(PartitionID partId,
+                                  VertexID srcId,
+                                  EdgeType type,
+                                  EdgeRanking rank,
+                                  VertexID dstId);
+
+    static std::string systemPrefix();
+
+    static std::string prefix(PartitionID partId);
+
+    static std::string snapshotPrefix(PartitionID partId);
+
+    static PartitionID getPart(const folly::StringPiece& rawKey) {
+        return readInt<PartitionID>(rawKey.data(), sizeof(PartitionID)) >> 8;
+    }
+
+    static bool isVertex(const folly::StringPiece& rawKey) {
+        if (rawKey.size() != kVertexLen) {
+            return false;
+        }
+        constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyTypeV1));
+        auto type = readInt<uint32_t>(rawKey.data(), len) & kTypeMask;
+        if (static_cast<uint32_t>(NebulaKeyTypeV1::kData) != type) {
+            return false;
+        }
+        auto offset = sizeof(PartitionID) + sizeof(VertexID);
+        TagID tagId =  readInt<TagID>(rawKey.data() + offset, sizeof(TagID));
+        return !(tagId & kTagEdgeMask);
+    }
+
+    static VertexID getVertexId(const folly::StringPiece& rawKey) {
+        CHECK_EQ(rawKey.size(), kVertexLen);
+        auto offset = sizeof(PartitionID);
+        return readInt<VertexID>(rawKey.data() + offset, sizeof(VertexID));
+    }
+
+    static TagID getTagId(const folly::StringPiece& rawKey) {
+        // CHECK_EQ(rawKey.size(), kVertexLen);
+        if (rawKey.size() != kVertexLen) {
+            std::stringstream msg;
+            msg << " rawKey.size() != kVertexLen."
+                << "\nrawKey.size()=" << rawKey.size()
+                << "\nkVertexLen=" << kVertexLen
+                << "\nhexDump:\n"
+                << folly::hexDump(rawKey.data(), rawKey.size());
+            LOG(FATAL) << msg.str();
+        }
+        auto offset = sizeof(PartitionID) + sizeof(VertexID);
+        return readInt<TagID>(rawKey.data() + offset, sizeof(TagID));
+    }
+
+    static bool isEdge(const folly::StringPiece& rawKey) {
+        if (rawKey.size() != kEdgeLen) {
+            return false;
+        }
+        constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyTypeV1));
+        auto type = readInt<uint32_t>(rawKey.data(), len) & kTypeMask;
+        if (static_cast<uint32_t>(NebulaKeyTypeV1::kData) != type) {
+            return false;
+        }
+        auto offset = sizeof(PartitionID) + sizeof(VertexID);
+        EdgeType etype = readInt<EdgeType>(rawKey.data() + offset, sizeof(EdgeType));
+        return etype & kTagEdgeMask;
+    }
+
+    static bool isSystemCommit(const folly::StringPiece& rawKey) {
+        if (rawKey.size() != kSystemLen) {
+            return false;
+        }
+        auto position = rawKey.data() + sizeof(PartitionID);
+        auto len = sizeof(NebulaSystemKeyType);
+        auto type = readInt<uint32_t>(position, len);
+        return static_cast<uint32_t>(NebulaSystemKeyType::kSystemCommit) == type;
+    }
+
+    static bool isSystemPart(const folly::StringPiece& rawKey) {
+        if (rawKey.size() != kSystemLen) {
+            return false;
+        }
+        auto position = rawKey.data() + sizeof(PartitionID);
+        auto len = sizeof(NebulaSystemKeyType);
+        auto type = readInt<uint32_t>(position, len);
+        return static_cast<uint32_t>(NebulaSystemKeyType::kSystemPart) == type;
+    }
+
+    static VertexID getSrcId(const folly::StringPiece& rawKey) {
+        CHECK_EQ(rawKey.size(), kEdgeLen);
+        return readInt<VertexID>(rawKey.data() + sizeof(PartitionID), sizeof(VertexID));
+    }
+
+    static VertexID getDstId(const folly::StringPiece& rawKey) {
+        CHECK_EQ(rawKey.size(), kEdgeLen);
+        auto offset = sizeof(PartitionID) + sizeof(VertexID) +
+                      sizeof(EdgeType) + sizeof(EdgeRanking);
+        return readInt<VertexID>(rawKey.data() + offset, sizeof(VertexID));
+    }
+
+    static EdgeType getEdgeType(const folly::StringPiece& rawKey) {
+        CHECK_EQ(rawKey.size(), kEdgeLen);
+        auto offset = sizeof(PartitionID) + sizeof(VertexID);
+        EdgeType type = readInt<EdgeType>(rawKey.data() + offset, sizeof(EdgeType));
+        return type > 0 ? type & kTagEdgeValueMask : type;
+    }
+
+    static EdgeRanking getRank(const folly::StringPiece& rawKey) {
+        CHECK_EQ(rawKey.size(), kEdgeLen);
+        auto offset = sizeof(PartitionID) + sizeof(VertexID) + sizeof(EdgeType);
+        return readInt<EdgeRanking>(rawKey.data() + offset, sizeof(EdgeRanking));
+    }
+
+    static int64_t getVersion(const folly::StringPiece& rawKey) {
+        CHECK(isVertex(rawKey) || isEdge(rawKey));
+        auto offset = rawKey.size() - sizeof(int64_t);
+        return readInt<int64_t>(rawKey.data() + offset, sizeof(int64_t));
+    }
+
+    static IndexID getIndexId(const folly::StringPiece& rawKey) {
+        CHECK_GT(rawKey.size(), kIndexLen);
+        auto offset = sizeof(PartitionID);
+        return readInt<IndexID>(rawKey.data() + offset, sizeof(IndexID));
+    }
+
+    template<typename T>
+    static typename std::enable_if<std::is_integral<T>::value, T>::type
+    readInt(const char* data, int32_t len) {
+        CHECK_GE(len, sizeof(T));
+        return *reinterpret_cast<const T*>(data);
+    }
+
+    static bool isDataKey(const folly::StringPiece& key) {
+        constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyTypeV1));
+        auto type = readInt<int32_t>(key.data(), len) & kTypeMask;
+        return static_cast<uint32_t>(NebulaKeyTypeV1::kData) == type;
+    }
+
+    static bool isIndexKey(const folly::StringPiece& key) {
+        if (key.size() < kIndexLen) {
+            return false;
+        }
+        constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyTypeV1));
+        auto type = readInt<int32_t>(key.data(), len) & kTypeMask;
+        return static_cast<uint32_t>(NebulaKeyTypeV1::kIndex) == type;
+    }
+
+    static bool isUUIDKey(const folly::StringPiece& key) {
+        auto type = readInt<int32_t>(key.data(), sizeof(int32_t)) & kTypeMask;
+        return static_cast<uint32_t>(NebulaKeyTypeV1::kUUID) == type;
+    }
+
+    static folly::StringPiece keyWithNoVersion(const folly::StringPiece& rawKey) {
+        // TODO(heng) We should change the method if varint data version supportted.
+        return rawKey.subpiece(0, rawKey.size() - sizeof(int64_t));
+    }
+
+    static VertexID getIndexVertexID(const folly::StringPiece& rawKey) {
+        CHECK_GE(rawKey.size(), kVertexIndexLen);
+        auto offset = rawKey.size() - sizeof(VertexID);
+        return *reinterpret_cast<const VertexID*>(rawKey.data() + offset);
+     }
+
+    static VertexID getIndexSrcId(const folly::StringPiece& rawKey) {
+        CHECK_GE(rawKey.size(), kEdgeIndexLen);
+        auto offset = rawKey.size() -
+                      sizeof(VertexID) * 2 - sizeof(EdgeRanking);
+        return readInt<VertexID>(rawKey.data() + offset, sizeof(VertexID));
+    }
+
+    static VertexID getIndexDstId(const folly::StringPiece& rawKey) {
+        CHECK_GE(rawKey.size(), kEdgeIndexLen);
+        auto offset = rawKey.size() - sizeof(VertexID);
+        return readInt<VertexID>(rawKey.data() + offset, sizeof(VertexID));
+    }
+
+    static EdgeRanking getIndexRank(const folly::StringPiece& rawKey) {
+        CHECK_GE(rawKey.size(), kEdgeIndexLen);
+        auto offset = rawKey.size() - sizeof(VertexID) - sizeof(EdgeRanking);
+        return readInt<EdgeRanking>(rawKey.data() + offset, sizeof(EdgeRanking));
+    }
+
+private:
+    NebulaKeyUtilsV1() = delete;
+
+private:
+    static constexpr int32_t kVertexLen = sizeof(PartitionID) + sizeof(VertexID)
+                                        + sizeof(TagID) + sizeof(TagVersion);
+
+    static constexpr int32_t kEdgeLen = sizeof(PartitionID) + sizeof(VertexID)
+                                      + sizeof(EdgeType) + sizeof(VertexID)
+                                      + sizeof(EdgeRanking) + sizeof(EdgeVersion);
+
+    static constexpr int32_t kVertexIndexLen = sizeof(PartitionID) + sizeof(IndexID)
+                                               + sizeof(VertexID);
+
+    static constexpr int32_t kEdgeIndexLen = sizeof(PartitionID) + sizeof(IndexID)
+                                             + sizeof(VertexID) * 2 + sizeof(EdgeRanking);
+
+    static constexpr int32_t kIndexLen = std::min(kVertexIndexLen, kEdgeIndexLen);
+
+    static constexpr int32_t kSystemLen = sizeof(PartitionID) + sizeof(NebulaSystemKeyType);
+
+    // The partition id offset in 4 Bytes
+    static constexpr uint8_t kPartitionOffset = 8;
+
+    // The key type bits Mask
+    // See KeyType enum
+    static constexpr uint32_t kTypeMask     = 0x000000FF;
+
+    // The most significant bit is sign bit, tag is always 0
+    // The second most significant bit is tag/edge type bit Mask
+    // 0 for Tag, 1 for Edge
+    static constexpr uint32_t kTagEdgeMask      = 0x40000000;
+    // For extract Tag/Edge value
+    static constexpr uint32_t kTagEdgeValueMask = ~kTagEdgeMask;
+    // Write edge by |= 0x40000000
+    static constexpr uint32_t kEdgeMaskSet      = kTagEdgeMask;
+    // Write Tag by &= 0xbfffffff
+    static constexpr uint32_t kTagMaskSet       = ~kTagEdgeMask;
+};
+
+
+}  // namespace nebula
+#endif  // TOOLS_DBUPGRADE_NEBULAKEYUTILSV1_H_
+

--- a/src/utils/NebulaKeyUtils.cpp
+++ b/src/utils/NebulaKeyUtils.cpp
@@ -23,8 +23,7 @@ std::string NebulaKeyUtils::vertexKey(size_t vIdLen,
                                       TagID tagId,
                                       TagVersion tv) {
     CHECK_GE(vIdLen, vId.size());
-    tagId &= kTagMaskSet;
-    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kVertex);
 
     std::string key;
     key.reserve(kVertexLen + vIdLen);
@@ -46,8 +45,7 @@ std::string NebulaKeyUtils::edgeKey(size_t vIdLen,
                                     EdgeVersion ev) {
     CHECK_GE(vIdLen, srcId.size());
     CHECK_GE(vIdLen, dstId.size());
-    type |= kEdgeMaskSet;
-    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
 
     std::string key;
     key.reserve(kEdgeLen + (vIdLen << 1));
@@ -98,7 +96,7 @@ std::string NebulaKeyUtils::uuidKey(PartitionID partId, const folly::StringPiece
 std::string NebulaKeyUtils::kvKey(PartitionID partId, const folly::StringPiece& name) {
     std::string key;
     key.reserve(sizeof(PartitionID) + name.size());
-    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kKeyValue);
     key.append(reinterpret_cast<const char*>(&item), sizeof(int32_t))
        .append(name.data(), name.size());
     return key;
@@ -108,8 +106,7 @@ std::string NebulaKeyUtils::kvKey(PartitionID partId, const folly::StringPiece& 
 std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId,
                                          VertexID vId, TagID tagId) {
     CHECK_GE(vIdLen, vId.size());
-    tagId &= kTagMaskSet;
-    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kVertex);
 
     std::string key;
     key.reserve(sizeof(PartitionID) + vIdLen + sizeof(TagID));
@@ -123,7 +120,7 @@ std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId,
 // static
 std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId, VertexID vId) {
     CHECK_GE(vIdLen, vId.size());
-    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kVertex);
     std::string key;
     key.reserve(sizeof(PartitionID) + vIdLen);
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
@@ -133,11 +130,19 @@ std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId, Vert
 }
 
 // static
+std::string NebulaKeyUtils::vertexPrefix(PartitionID partId) {
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kVertex);
+    std::string key;
+    key.reserve(sizeof(PartitionID));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID));
+    return key;
+}
+
+// static
 std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId,
                                        VertexID srcId, EdgeType type) {
     CHECK_GE(vIdLen, srcId.size());
-    type |= kEdgeMaskSet;
-    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
 
     std::string key;
     key.reserve(sizeof(PartitionID) + vIdLen + sizeof(EdgeType));
@@ -151,12 +156,21 @@ std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId,
 // static
 std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId, VertexID srcId) {
     CHECK_GE(vIdLen, srcId.size());
-    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
     std::string key;
     key.reserve(sizeof(PartitionID) + vIdLen);
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
        .append(srcId.data(), srcId.size())
        .append(vIdLen - srcId.size(), '\0');
+    return key;
+}
+
+// static
+std::string NebulaKeyUtils::edgePrefix(PartitionID partId) {
+    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
+    std::string key;
+    key.reserve(sizeof(PartitionID));
+    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID));
     return key;
 }
 
@@ -169,8 +183,7 @@ std::string NebulaKeyUtils::edgePrefix(size_t vIdLen,
                                        VertexID dstId) {
     CHECK_GE(vIdLen, srcId.size());
     CHECK_GE(vIdLen, dstId.size());
-    type |= kEdgeMaskSet;
-    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
+    int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
     std::string key;
     key.reserve(sizeof(PartitionID) + (vIdLen << 1) + sizeof(EdgeType) + sizeof(EdgeRanking));
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
@@ -184,21 +197,16 @@ std::string NebulaKeyUtils::edgePrefix(size_t vIdLen,
 }
 
 // static
-std::string NebulaKeyUtils::partPrefix(PartitionID partId) {
-    PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
-    std::string key;
-    key.reserve(sizeof(PartitionID));
-    key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID));
-    return key;
-}
-
-// static
-std::string NebulaKeyUtils::snapshotPrefix(PartitionID partId) {
+std::vector<std::string> NebulaKeyUtils::snapshotPrefix(PartitionID partId) {
+    std::vector<std::string> result;
     // snapshot of meta would be all key-value pairs
     if (partId == 0) {
-        return "";
+        result.emplace_back("");
+    } else {
+        result.emplace_back(vertexPrefix(partId));
+        result.emplace_back(edgePrefix(partId));
     }
-    return partPrefix(partId);
+    return result;
 }
 
 std::string NebulaKeyUtils::systemPrefix() {

--- a/src/utils/Types.h
+++ b/src/utils/Types.h
@@ -13,11 +13,13 @@
 namespace nebula {
 
 enum class NebulaKeyType : uint32_t {
-    kData              = 0x00000001,
-    kIndex             = 0x00000002,
-    kUUID              = 0x00000003,
-    kSystem            = 0x00000004,
-    kOperation         = 0x00000005,
+    kVertex            = 0x00000001,
+    kEdge              = 0x00000002,
+    kIndex             = 0x00000003,
+    kUUID              = 0x00000004,
+    kSystem            = 0x00000005,
+    kOperation         = 0x00000006,
+    kKeyValue          = 0x00000007,
 };
 
 enum class NebulaSystemKeyType : uint32_t {
@@ -31,7 +33,6 @@ enum class NebulaOperationType : uint32_t {
 };
 
 using VertexIDSlice = folly::StringPiece;
-using VertexIntID = int64_t;
 using IndexID = int32_t;
 
 template<typename T>
@@ -56,16 +57,6 @@ static constexpr uint8_t kPartitionOffset = 8;
 // The key type bits Mask
 // See KeyType enum
 static constexpr uint32_t kTypeMask     = 0x000000FF;
-
-// The Tag/Edge type bit Mask, the most significant bit is to indicate sign,
-// the next bit is to indicate it is tag or edge, 0 for Tag, 1 for Edge
-static constexpr uint32_t kTagEdgeMask      = 0x40000000;
-// For extract Tag/Edge value
-static constexpr uint32_t kTagEdgeValueMask = ~kTagEdgeMask;
-// Write edge by &=
-static constexpr uint32_t kEdgeMaskSet      = kTagEdgeMask;
-// Write Tag by |=
-static constexpr uint32_t kTagMaskSet       = ~kTagEdgeMask;
 
 static constexpr int32_t kVertexIndexLen = sizeof(PartitionID) + sizeof(IndexID);
 

--- a/src/utils/test/NebulaKeyUtilsTest.cpp
+++ b/src/utils/test/NebulaKeyUtilsTest.cpp
@@ -34,7 +34,6 @@ public:
         ASSERT_EQ(tagId, NebulaKeyUtils::getTagId(vIdLen_, vertexKey));
         ASSERT_EQ(vId, NebulaKeyUtils::getVertexId(vIdLen_, vertexKey).subpiece(0, actualSize));
         ASSERT_EQ(tagVersion, NebulaKeyUtils::getVersion(vIdLen_, vertexKey));
-        ASSERT_TRUE(NebulaKeyUtils::isDataKey(vertexKey));
     }
 
     void verifyEdge(PartitionID partId,
@@ -62,7 +61,6 @@ public:
         ASSERT_EQ(type, NebulaKeyUtils::getEdgeType(vIdLen_, edgeKey));
         ASSERT_EQ(rank, NebulaKeyUtils::getRank(vIdLen_, edgeKey));
         ASSERT_EQ(edgeVersion, NebulaKeyUtils::getVersion(vIdLen_, edgeKey));
-        ASSERT_TRUE(NebulaKeyUtils::isDataKey(edgeKey));
     }
 
 protected:


### PR DESCRIPTION
1. Separate vertex and edge by different prefix
2. Add an upgrade tool skeleton which can use both NebulaKeyUtils of 1.0 and 2.0. (NebulaKeyUtilsV1 should only use in upgrader, and support only basic method)

No business logic is changed in this PR. Some code need to refine later, e.g., CompactionFilter and PrefixBloomFilter. 