### PR TITLE
Improve delete edges, remove extra prefix in fetch

### DIFF
--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -2145,14 +2145,6 @@ TEST(MetaClientTest, RocksdbOptionsTest) {
             module, name,
             mode, Value(map)));
         client->regConfig(configItems);
-
-        // get from meta server
-        auto getRet = client->getConfig(module, name).get();
-        ASSERT_TRUE(getRet.ok());
-        auto item = getRet.value().front();
-
-        sleep(FLAGS_heartbeat_interval_secs + 1);
-        ASSERT_EQ(FLAGS_rocksdb_db_options, GflagsManager::ValueToGflagString(item.get_value()));
     }
     {
         std::vector<HostAddr> hosts = {{"0", 0}};
@@ -2180,9 +2172,8 @@ TEST(MetaClientTest, RocksdbOptionsTest) {
         auto item = getRet.value().front();
 
         sleep(FLAGS_heartbeat_interval_secs + 1);
-        ASSERT_EQ(FLAGS_rocksdb_db_options, GflagsManager::ValueToGflagString(item.get_value()));
-        ASSERT_EQ(listener->options["disable_auto_compactions"], "true");
-        ASSERT_EQ(listener->options["level0_file_num_compaction_trigger"], "4");
+        ASSERT_EQ(listener->options["disable_auto_compactions"], "\"true\"");
+        ASSERT_EQ(listener->options["level0_file_num_compaction_trigger"], "\"4\"");
     }
 }
 

--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -83,6 +83,11 @@ protected:
                   PartitionID partId,
                   std::vector<std::string>&& keys);
 
+    void doRemoveRange(GraphSpaceID spaceId,
+                       PartitionID partId,
+                       const std::string& start,
+                       const std::string& end);
+
     cpp2::ErrorCode to(kvstore::ResultCode code);
 
     cpp2::ErrorCode writeResultTo(WriteResult code, bool isEdge);

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -180,6 +180,17 @@ void BaseProcessor<RESP>::doRemove(GraphSpaceID spaceId,
 }
 
 template <typename RESP>
+void BaseProcessor<RESP>::doRemoveRange(GraphSpaceID spaceId,
+                                        PartitionID partId,
+                                        const std::string& start,
+                                        const std::string& end) {
+    this->env_->kvstore_->asyncRemoveRange(
+        spaceId, partId, start, end, [spaceId, partId, this](kvstore::ResultCode code) {
+            handleAsync(spaceId, partId, code);
+        });
+}
+
+template <typename RESP>
 StatusOr<std::string>
 BaseProcessor<RESP>::encodeRowVal(const meta::NebulaSchemaProvider* schema,
                                   const std::vector<std::string>& propNames,

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -28,23 +28,16 @@ public:
         , vertexCache_(vertexCache) {}
 
     kvstore::ResultCode execute(PartitionID partId, const VertexID& vId) override {
-        // todo(doodle): revert to previous behavior, here is an extra io, will be deleted asap
-        // check is vertex exists
-        std::unique_ptr<kvstore::KVIterator> iter;
-        auto prefix = NebulaKeyUtils::vertexPrefix(planContext_->vIdLen_, partId, vId);
-        auto ret = planContext_->env_->kvstore_->prefix(planContext_->spaceId_,
-                                                        partId, prefix, &iter);
+        auto ret = RelNode::execute(partId, vId);
         if (ret != kvstore::ResultCode::SUCCEEDED) {
             return ret;
-        }
-        if (iter == nullptr || !iter->valid()) {
-            // not emplace row when vertex not exists
-            return kvstore::ResultCode::SUCCEEDED;
         }
 
-        ret = RelNode::execute(partId, vId);
-        if (ret != kvstore::ResultCode::SUCCEEDED) {
-            return ret;
+        // if none of the tag node valid, do not emplace the row
+        if (!std::any_of(tagNodes_.begin(), tagNodes_.end(), [] (const auto& tagNode) {
+            return tagNode->valid();
+        })) {
+            return kvstore::ResultCode::SUCCEEDED;
         }
 
         List row;

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -61,33 +61,14 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
                     code = cpp2::ErrorCode::E_INVALID_VID;
                     break;
                 }
-                auto start = NebulaKeyUtils::edgeKey(spaceVidLen_,
-                                                     partId,
-                                                     edgeKey.src.getStr(),
-                                                     edgeKey.edge_type,
-                                                     edgeKey.ranking,
-                                                     edgeKey.dst.getStr(),
-                                                     0);
-                auto end = NebulaKeyUtils::edgeKey(spaceVidLen_,
-                                                   partId,
-                                                   edgeKey.src.getStr(),
-                                                   edgeKey.edge_type,
-                                                   edgeKey.ranking,
-                                                   edgeKey.dst.getStr(),
-                                                   std::numeric_limits<char>::max());
-                std::unique_ptr<kvstore::KVIterator> iter;
-                auto retRes = env_->kvstore_->range(spaceId_, partId, start, end, &iter);
-                if (retRes != kvstore::ResultCode::SUCCEEDED) {
-                    VLOG(3) << "Error! ret = " << static_cast<int32_t>(retRes)
-                            << ", spaceID " << spaceId_;
-                    code = to(retRes);
-                    break;
-                }
-                while (iter && iter->valid()) {
-                    auto key = iter->key();
-                    keys.emplace_back(key.data(), key.size());
-                    iter->next();
-                }
+                // todo(doodle): delete lock in toss
+                auto edge = NebulaKeyUtils::edgeKey(spaceVidLen_,
+                                                    partId,
+                                                    edgeKey.src.getStr(),
+                                                    edgeKey.edge_type,
+                                                    edgeKey.ranking,
+                                                    edgeKey.dst.getStr());
+                keys.emplace_back(edge.data(), edge.size());
             }
             if (code != cpp2::ErrorCode::SUCCEEDED) {
                 handleAsync(spaceId_, partId, code);

--- a/src/storage/test/VertexCacheTest.cpp
+++ b/src/storage/test/VertexCacheTest.cpp
@@ -502,7 +502,7 @@ TEST(VertexCacheTest, GetVertexPropWithTTLTest) {
 
         // TODO At present, when the ttl data expires, tag returns a vid,
         // other attributes are empty value, edge returns a row with an empty value fields.
-        getVertices(env, parts, &cache, tagId, vertices, 51);
+        getVertices(env, parts, &cache, tagId, vertices, 0);
         checkCache(&cache, 51, 51, 102);
     }
 


### PR DESCRIPTION
1. Remove extra io in fetch. For example, v1 don't have t1 and t2, but has t3. When fetch t1 and t2, it will be returned as one row as well. 

**This will break graph ci.**, please fix it. @yixinglu @CPWstatic @nevermore3 @Shylock-Hg
  
  This is the previous ci log https://github.com/vesoft-inc/nebula-graph/pull/507/checks?check_run_id=1600034306.

`go ... yield edge.xxx, $$.xxx` will reproduce this problem as well, because no more `$$.xxx` returned. (previously will return an empty value if vertex has another tag).

2. Improve delete edge

**Don't merge plz, wait graph ready.**