### PR TITLE
const VertexID&

### DIFF
--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -414,7 +414,7 @@ public:
     }
 
     std::string indexKey(PartitionID partId,
-                         VertexID vId,
+                         const VertexID& vId,
                          RowReader* reader,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
         auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields());

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -236,7 +236,7 @@ AddVerticesProcessor::addVertices(PartitionID partId,
 }
 
 folly::Optional<std::string>
-AddVerticesProcessor::findOldValue(PartitionID partId, VertexID vId, TagID tagId) {
+AddVerticesProcessor::findOldValue(PartitionID partId, const VertexID& vId, TagID tagId) {
     auto prefix = NebulaKeyUtils::vertexPrefix(spaceVidLen_, partId, vId, tagId);
     std::unique_ptr<kvstore::KVIterator> iter;
     auto ret = env_->kvstore_->prefix(spaceId_, partId, prefix, &iter);
@@ -252,7 +252,7 @@ AddVerticesProcessor::findOldValue(PartitionID partId, VertexID vId, TagID tagId
 }
 
 std::string AddVerticesProcessor::indexKey(PartitionID partId,
-                                           VertexID vId,
+                                           const VertexID& vId,
                                            RowReader* reader,
                                            std::shared_ptr<nebula::meta::cpp2::IndexItem> index) {
     auto values = IndexKeyUtils::collectIndexValues(reader, index->get_fields());

--- a/src/storage/mutate/AddVerticesProcessor.h
+++ b/src/storage/mutate/AddVerticesProcessor.h
@@ -35,9 +35,9 @@ private:
     addVertices(PartitionID partId,
                 const std::vector<kvstore::KV>& vertices);
 
-    folly::Optional<std::string> findOldValue(PartitionID partId, VertexID vId, TagID tagId);
+    folly::Optional<std::string> findOldValue(PartitionID partId, const VertexID& vId, TagID tagId);
 
-    std::string indexKey(PartitionID partId, VertexID vId, RowReader* reader,
+    std::string indexKey(PartitionID partId, const VertexID& vId, RowReader* reader,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index);
 
 private:

--- a/src/utils/IndexKeyUtils.cpp
+++ b/src/utils/IndexKeyUtils.cpp
@@ -45,7 +45,7 @@ std::string IndexKeyUtils::encodeValues(std::vector<Value>&& values,
 
 // static
 std::string IndexKeyUtils::vertexIndexKey(size_t vIdLen, PartitionID partId,
-                                          IndexID indexId, VertexID vId,
+                                          IndexID indexId, const VertexID& vId,
                                           std::string&& values) {
     int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kIndex);
     std::string key;
@@ -60,8 +60,8 @@ std::string IndexKeyUtils::vertexIndexKey(size_t vIdLen, PartitionID partId,
 
 // static
 std::string IndexKeyUtils::edgeIndexKey(size_t vIdLen, PartitionID partId,
-                                        IndexID indexId, VertexID srcId,
-                                        EdgeRanking rank, VertexID dstId,
+                                        IndexID indexId, const VertexID& srcId,
+                                        EdgeRanking rank, const VertexID& dstId,
                                         std::string&& values) {
     int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kIndex);
     std::string key;

--- a/src/utils/IndexKeyUtils.h
+++ b/src/utils/IndexKeyUtils.h
@@ -458,7 +458,7 @@ public:
      *                     in the index, the parameter can be empty.
      **/
     static std::string vertexIndexKey(size_t vIdLen, PartitionID partId,
-                                      IndexID indexId, VertexID vId,
+                                      IndexID indexId, const VertexID& vId,
                                       std::string&& values);
 
     /**
@@ -466,8 +466,8 @@ public:
      *                     in the index, the parameter can be empty.
      **/
     static std::string edgeIndexKey(size_t vIdLen, PartitionID partId,
-                                    IndexID indexId, VertexID srcId,
-                                    EdgeRanking rank, VertexID dstId,
+                                    IndexID indexId, const VertexID& srcId,
+                                    EdgeRanking rank, const VertexID& dstId,
                                     std::string&& values);
 
     static std::string indexPrefix(PartitionID partId, IndexID indexId);

--- a/src/utils/NebulaKeyUtils.cpp
+++ b/src/utils/NebulaKeyUtils.cpp
@@ -9,7 +9,7 @@
 namespace nebula {
 
 // static
-bool NebulaKeyUtils::isValidVidLen(size_t vIdLen, VertexID srcVId, VertexID dstVId) {
+bool NebulaKeyUtils::isValidVidLen(size_t vIdLen, const VertexID& srcVId, const VertexID& dstVId) {
     if (srcVId.size() > vIdLen || dstVId.size() > vIdLen) {
         return false;
     }
@@ -19,7 +19,7 @@ bool NebulaKeyUtils::isValidVidLen(size_t vIdLen, VertexID srcVId, VertexID dstV
 // static
 std::string NebulaKeyUtils::vertexKey(size_t vIdLen,
                                       PartitionID partId,
-                                      VertexID vId,
+                                      const VertexID& vId,
                                       TagID tagId,
                                       TagVersion tv) {
     CHECK_GE(vIdLen, vId.size());
@@ -38,10 +38,10 @@ std::string NebulaKeyUtils::vertexKey(size_t vIdLen,
 // static
 std::string NebulaKeyUtils::edgeKey(size_t vIdLen,
                                     PartitionID partId,
-                                    VertexID srcId,
+                                    const VertexID& srcId,
                                     EdgeType type,
                                     EdgeRanking rank,
-                                    VertexID dstId,
+                                    const VertexID& dstId,
                                     EdgeVersion ev) {
     CHECK_GE(vIdLen, srcId.size());
     CHECK_GE(vIdLen, dstId.size());
@@ -104,7 +104,7 @@ std::string NebulaKeyUtils::kvKey(PartitionID partId, const folly::StringPiece& 
 
 // static
 std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId,
-                                         VertexID vId, TagID tagId) {
+                                         const VertexID& vId, TagID tagId) {
     CHECK_GE(vIdLen, vId.size());
     PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kVertex);
 
@@ -118,7 +118,7 @@ std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId,
 }
 
 // static
-std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId, VertexID vId) {
+std::string NebulaKeyUtils::vertexPrefix(size_t vIdLen, PartitionID partId, const VertexID& vId) {
     CHECK_GE(vIdLen, vId.size());
     PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kVertex);
     std::string key;
@@ -140,7 +140,7 @@ std::string NebulaKeyUtils::vertexPrefix(PartitionID partId) {
 
 // static
 std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId,
-                                       VertexID srcId, EdgeType type) {
+                                       const VertexID& srcId, EdgeType type) {
     CHECK_GE(vIdLen, srcId.size());
     PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
 
@@ -154,7 +154,7 @@ std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId,
 }
 
 // static
-std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId, VertexID srcId) {
+std::string NebulaKeyUtils::edgePrefix(size_t vIdLen, PartitionID partId, const VertexID& srcId) {
     CHECK_GE(vIdLen, srcId.size());
     PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);
     std::string key;
@@ -177,10 +177,10 @@ std::string NebulaKeyUtils::edgePrefix(PartitionID partId) {
 // static
 std::string NebulaKeyUtils::edgePrefix(size_t vIdLen,
                                        PartitionID partId,
-                                       VertexID srcId,
+                                       const VertexID& srcId,
                                        EdgeType type,
                                        EdgeRanking rank,
-                                       VertexID dstId) {
+                                       const VertexID& dstId) {
     CHECK_GE(vIdLen, srcId.size());
     CHECK_GE(vIdLen, dstId.size());
     int32_t item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kEdge);

--- a/src/utils/NebulaKeyUtils.h
+++ b/src/utils/NebulaKeyUtils.h
@@ -37,20 +37,27 @@ public:
     /*
      * Check the validity of vid length
      */
-    static bool isValidVidLen(size_t vIdLen, VertexID srcvId, VertexID dstvId = "");
+    static bool isValidVidLen(size_t vIdLen, const VertexID& srcvId, const VertexID& dstvId = "");
 
     /**
      * Generate vertex key for kv store
      * */
-    static std::string vertexKey(size_t vIdLen, PartitionID partId, VertexID vId,
-                                 TagID tagId, TagVersion tv);
+    static std::string vertexKey(size_t vIdLen,
+                                 PartitionID partId,
+                                 const VertexID& vId,
+                                 TagID tagId,
+                                 TagVersion tv);
 
     /**
      * Generate edge key for kv store
      * */
-    static std::string edgeKey(size_t vIdLen, PartitionID partId, VertexID srcId,
-                               EdgeType type, EdgeRanking rank,
-                               VertexID dstId, EdgeVersion ev);
+    static std::string edgeKey(size_t vIdLen,
+                               PartitionID partId,
+                               const VertexID& srcId,
+                               EdgeType type,
+                               EdgeRanking rank,
+                               const VertexID& dstId,
+                               EdgeVersion ev);
 
     static std::string systemCommitKey(PartitionID partId);
 
@@ -63,25 +70,31 @@ public:
     /**
      * Prefix for vertex
      * */
-    static std::string vertexPrefix(size_t vIdLen, PartitionID partId, VertexID vId, TagID tagId);
+    static std::string vertexPrefix(size_t vIdLen,
+                                    PartitionID partId,
+                                    const VertexID& vId,
+                                    TagID tagId);
 
-    static std::string vertexPrefix(size_t vIdLen, PartitionID partId, VertexID vId);
+    static std::string vertexPrefix(size_t vIdLen, PartitionID partId, const VertexID& vId);
 
     static std::string vertexPrefix(PartitionID partId);
 
     /**
      * Prefix for edge
      * */
-    static std::string edgePrefix(size_t vIdLen, PartitionID partId, VertexID srcId, EdgeType type);
+    static std::string edgePrefix(size_t vIdLen,
+                                  PartitionID partId,
+                                  const VertexID& srcId,
+                                  EdgeType type);
 
-    static std::string edgePrefix(size_t vIdLen, PartitionID partId, VertexID srcId);
+    static std::string edgePrefix(size_t vIdLen, PartitionID partId, const VertexID& srcId);
 
     static std::string edgePrefix(size_t vIdLen,
                                   PartitionID partId,
-                                  VertexID srcId,
+                                  const VertexID& srcId,
                                   EdgeType type,
                                   EdgeRanking rank,
-                                  VertexID dstId);
+                                  const VertexID& dstId);
 
     static std::string edgePrefix(PartitionID partId);
 

--- a/src/utils/OperationKeyUtils.cpp
+++ b/src/utils/OperationKeyUtils.cpp
@@ -10,7 +10,7 @@
 namespace nebula {
 
 // static
-std::string OperationKeyUtils::modifyOperationKey(PartitionID part, std::string key) {
+std::string OperationKeyUtils::modifyOperationKey(PartitionID part, const std::string& key) {
     uint32_t item = (part << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kOperation);
     int64_t ts = time::WallClock::fastNowInMicroSec();
     uint32_t type = static_cast<uint32_t>(NebulaOperationType::kModify);

--- a/src/utils/OperationKeyUtils.h
+++ b/src/utils/OperationKeyUtils.h
@@ -18,7 +18,7 @@ class OperationKeyUtils final {
 public:
     ~OperationKeyUtils() = default;
 
-    static std::string modifyOperationKey(PartitionID part, std::string key);
+    static std::string modifyOperationKey(PartitionID part, const std::string& key);
 
     static std::string deleteOperationKey(PartitionID part);
 


### PR DESCRIPTION
Modify all `VertexID` to `const VertexID&` in utils since we treat vid as string, avoid extra string copy.