### PR TITLE
 change toBool

### DIFF
--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -68,7 +68,7 @@ private:
             auto result = filterExp_->eval(*expCtx_);
             // NULL is always false
             auto ret = result.toBool();
-            if (ret.second && ret.first) {
+            if (ret.isBool() && ret.getBool()) {
                 return true;
             }
             return false;


### PR DESCRIPTION
The interface `Value::toBool` in nebula-common has been modified, so it needs to be modified accordingly. 
But I don’t understand why `toBool` is needed here.

Depends on [https://github.com/vesoft-inc/nebula-common/pull/412](https://github.com/vesoft-inc/nebula-common/pull/412)