### PR TITLE
PlainTable support

### DIFF
--- a/conf/nebula-storaged.conf.default
+++ b/conf/nebula-storaged.conf.default
@@ -91,9 +91,6 @@
 --enable_rocksdb_prefix_filtering=false
 # Whether or not to enable the whole key filtering.
 --enable_rocksdb_whole_key_filtering=true
-# The prefix length for each key to use as the filter value.
-# can be 12 bytes(PartitionId + VertexID), or 16 bytes(PartitionId + VertexID + TagID/EdgeType).
---rocksdb_filtering_prefix_length=12
 
 ############## rocksdb Options ##############
 # rocksdb DBOptions in json, each name and value of option is a string, given as "option_name":"option_value" separated by comma

--- a/conf/nebula-storaged.conf.production
+++ b/conf/nebula-storaged.conf.production
@@ -97,9 +97,6 @@
 --enable_rocksdb_prefix_filtering=false
 # Whether or not to enable the whole key filtering.
 --enable_rocksdb_whole_key_filtering=true
-# The prefix length for each key to use as the filter value.
-# can be 12 bytes(PartitionId + VertexID), or 16 bytes(PartitionId + VertexID + TagID/EdgeType).
---rocksdb_filtering_prefix_length=12
 
 ############### misc ####################
 --max_handlers_per_req=1

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -17,6 +17,8 @@
 DEFINE_string(local_ip, "", "IP address which is used to identify this server");
 DEFINE_string(data_path, "", "Root data path, multi paths should be split by comma."
                              "For rocksdb engine, one path one instance.");
+DEFINE_string(wal_path, "",
+              "Nebula wal path. By default, wal will be stored as a sibling of rocksdb data.");
 DEFINE_string(listener_path, "", "Path for listener, only wal will be saved."
                                  "if it is not empty, data_path will not take effect.");
 DEFINE_bool(daemonize, true, "Whether to run the process as a daemon");
@@ -124,6 +126,7 @@ int main(int argc, char *argv[]) {
     gStorageServer = std::make_unique<nebula::storage::StorageServer>(host,
                                                                       metaAddrsRet.value(),
                                                                       paths,
+                                                                      FLAGS_wal_path,
                                                                       FLAGS_listener_path);
     if (!gStorageServer->start()) {
         LOG(ERROR) << "Storage server start failed";

--- a/src/kvstore/KVEngine.h
+++ b/src/kvstore/KVEngine.h
@@ -45,6 +45,8 @@ public:
     // Otherwise, nullptr will be returned
     virtual const char* getDataRoot() const = 0;
 
+    virtual const char* getWalRoot() const = 0;
+
     virtual std::unique_ptr<WriteBatch> startBatchWrite() = 0;
 
     virtual nebula::cpp2::ErrorCode

--- a/src/kvstore/KVEngine.h
+++ b/src/kvstore/KVEngine.h
@@ -129,6 +129,9 @@ public:
                 const std::string& tablePrefix,
                 std::function<bool(const folly::StringPiece& key)> filter) = 0;
 
+    virtual nebula::cpp2::ErrorCode backup() = 0;
+
+
 protected:
     GraphSpaceID spaceId_;
 };

--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -34,6 +34,8 @@ struct KVOptions {
     // otherwise it would mix up the data on disk.
     std::vector<std::string> dataPaths_;
 
+    std::string walPath_;
+
     // Path for listener, only wal is stored, the structure would be spaceId/partId/wal
     std::string listenerPath_;
 

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -244,6 +244,8 @@ public:
         GraphSpaceID spaceId,
         const std::string& name) override;
 
+    nebula::cpp2::ErrorCode backup();
+
     nebula::cpp2::ErrorCode
     dropCheckpoint(GraphSpaceID spaceId, const std::string& name) override;
 

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -312,7 +312,9 @@ private:
                            const std::unordered_map<std::string, std::string>& options,
                            bool isDbOption) override;
 
-    std::unique_ptr<KVEngine> newEngine(GraphSpaceID spaceId, const std::string& path);
+    std::unique_ptr<KVEngine> newEngine(GraphSpaceID spaceId,
+                                        const std::string& dataPath,
+                                        const std::string& walPath);
 
     std::shared_ptr<Part> newPart(GraphSpaceID spaceId,
                                   PartitionID partId,

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -110,6 +110,7 @@ class MemPartManager final : public PartManager {
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
     FRIEND_TEST(NebulaStoreTest, AtomicOpBatchTest);
     FRIEND_TEST(NebulaStoreTest, RemoveInvalidSpaceTest);
+    FRIEND_TEST(NebulaStoreTest, BackupRestoreTest);
     friend class ListenerBasicTest;
 
 public:

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -80,11 +80,12 @@ public:
 RocksEngine::RocksEngine(GraphSpaceID spaceId,
                          int32_t vIdLen,
                          const std::string& dataPath,
+                         const std::string& walPath,
                          std::shared_ptr<rocksdb::MergeOperator> mergeOp,
                          std::shared_ptr<rocksdb::CompactionFilterFactory> cfFactory,
                          bool readonly)
     : KVEngine(spaceId)
-    , spaceId_(spaceId),
+    , spaceId_(spaceId)
     , dataPath_(folly::stringPrintf("%s/nebula/%d", dataPath.c_str(), spaceId)) {
     // set wal path as dataPath by default
     if (walPath.empty()) {

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -84,7 +84,14 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
                          std::shared_ptr<rocksdb::CompactionFilterFactory> cfFactory,
                          bool readonly)
     : KVEngine(spaceId)
+    , spaceId_(spaceId),
     , dataPath_(folly::stringPrintf("%s/nebula/%d", dataPath.c_str(), spaceId)) {
+    // set wal path as dataPath by default
+    if (walPath.empty()) {
+        walPath_ = folly::stringPrintf("%s/nebula/%d", dataPath.c_str(), spaceId);
+    } else {
+        walPath_ = folly::stringPrintf("%s/nebula/%d", walPath.c_str(), spaceId);
+    }
     auto path = folly::stringPrintf("%s/data", dataPath_.c_str());
     if (FileUtils::fileType(path.c_str()) == FileType::NOTEXIST) {
         if (readonly) {
@@ -100,10 +107,12 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
         LOG(FATAL) << path << " is not directory";
     }
 
+    openBackupEngine(spaceId);
+
     rocksdb::Options options;
     rocksdb::DB* db = nullptr;
-    rocksdb::Status status = initRocksdbOptions(options, vIdLen);
-    CHECK(status.ok());
+    rocksdb::Status status = initRocksdbOptions(options, spaceId, vIdLen);
+    CHECK(status.ok()) << status.ToString();
     if (mergeOp != nullptr) {
         options.merge_operator = mergeOp;
     }
@@ -120,6 +129,8 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
     db_.reset(db);
     partsNum_ = allParts().size();
     LOG(INFO) << "open rocksdb on " << path;
+
+    backup();
 }
 
 void RocksEngine::stop() {
@@ -418,6 +429,66 @@ nebula::cpp2::ErrorCode RocksEngine::flush() {
     } else {
         LOG(ERROR) << "Flush Failed: " << status.ToString();
         return nebula::cpp2::ErrorCode::E_UNKNOWN;
+    }
+}
+
+nebula::cpp2::ErrorCode RocksEngine::backup() {
+    if (!backupDb_) {
+        return nebula::cpp2::ErrorCode::SUCCEEDED;
+    }
+    LOG(INFO) << "begin to backup space " << spaceId_ << " on path " << backupPath_;
+    bool flushBeforeBackup = true;
+    auto status = backupDb_->CreateNewBackup(db_.get(), flushBeforeBackup);
+    if (status.ok()) {
+        return nebula::cpp2::ErrorCode::SUCCEEDED;
+    } else {
+        LOG(ERROR) << "backup failed: " << status.ToString();
+        return nebula::cpp2::ErrorCode::E_BACKUP_FAILED;
+    }
+}
+
+void RocksEngine::openBackupEngine(GraphSpaceID spaceId) {
+    // If backup dir is not empty, set backup related options
+    if (FLAGS_rocksdb_table_format == "PlainTable" && !FLAGS_rocksdb_backup_dir.empty()) {
+        backupPath_ =
+            folly::stringPrintf("%s/rocksdb_backup/%d", FLAGS_rocksdb_backup_dir.c_str(), spaceId);
+        if (FileUtils::fileType(backupPath_.c_str()) == FileType::NOTEXIST) {
+            if (!FileUtils::makeDir(backupPath_)) {
+                LOG(FATAL) << "makeDir " << backupPath_ << " failed";
+            }
+        }
+        rocksdb::BackupEngine* backupDb;
+        rocksdb::BackupableDBOptions backupOptions(backupPath_);
+        backupOptions.backup_log_files = false;
+        auto status =
+            rocksdb::BackupEngine::Open(rocksdb::Env::Default(), backupOptions, &backupDb);
+        CHECK(status.ok()) << status.ToString();
+        backupDb_.reset(backupDb);
+        LOG(INFO) << "open plain table backup engine on " << backupPath_;
+
+        std::string dataPath = folly::stringPrintf("%s/data", dataPath_.c_str());
+        auto walDir = dataPath;
+        if (!FLAGS_rocksdb_wal_dir.empty()) {
+            walDir =
+                folly::stringPrintf("%s/rocksdb_wal/%d", FLAGS_rocksdb_wal_dir.c_str(), spaceId);
+        } else {
+            LOG(WARNING) << "rocksdb wal is stored with data";
+        }
+
+        rocksdb::RestoreOptions restoreOptions;
+        restoreOptions.keep_log_files = true;
+        status = backupDb_->RestoreDBFromLatestBackup(dataPath, walDir, restoreOptions);
+        LOG(INFO) << "try to restore from backup path " << backupPath_;
+        if (status.IsNotFound()) {
+            LOG(WARNING) << "no valid backup found";
+            return;
+        } else if (!status.ok()) {
+            LOG(FATAL) << status.ToString();
+        }
+        LOG(INFO) << "restore from latest backup succesfully"
+                  << ", backup path " << backupPath_
+                  << ", wal path " << walDir
+                  << ", data path " << dataPath;
     }
 }
 

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -95,6 +95,7 @@ public:
     RocksEngine(GraphSpaceID spaceId,
                 int32_t vIdLen,
                 const std::string& dataPath,
+                const std::string& walPath = "",
                 std::shared_ptr<rocksdb::MergeOperator> mergeOp = nullptr,
                 std::shared_ptr<rocksdb::CompactionFilterFactory> cfFactory = nullptr,
                 bool readonly = false);
@@ -109,6 +110,10 @@ public:
     // two subdir: data and wal.
     const char* getDataRoot() const override {
         return dataPath_.c_str();
+    }
+
+    const char* getWalRoot() const override {
+        return walPath_.c_str();
     }
 
     std::unique_ptr<WriteBatch> startBatchWrite() override;
@@ -197,6 +202,7 @@ private:
 private:
     GraphSpaceID spaceId_;
     std::string dataPath_;
+    std::string walPath_;
     std::unique_ptr<rocksdb::DB> db_{nullptr};
     std::string backupPath_;
     std::unique_ptr<rocksdb::BackupEngine> backupDb_{nullptr};

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -10,6 +10,7 @@
 #include <gtest/gtest_prod.h>
 #include <rocksdb/db.h>
 #include <rocksdb/utilities/checkpoint.h>
+#include <rocksdb/utilities/backupable_db.h>
 #include "common/base/Base.h"
 #include "kvstore/KVEngine.h"
 #include "kvstore/KVIterator.h"
@@ -176,6 +177,8 @@ public:
 
     nebula::cpp2::ErrorCode flush() override;
 
+    nebula::cpp2::ErrorCode backup() override;
+
     /*********************
      * Checkpoint operation
      ********************/
@@ -189,9 +192,14 @@ public:
 private:
     std::string partKey(PartitionID partId);
 
+    void openBackupEngine(GraphSpaceID spaceId);
+
 private:
+    GraphSpaceID spaceId_;
     std::string dataPath_;
     std::unique_ptr<rocksdb::DB> db_{nullptr};
+    std::string backupPath_;
+    std::unique_ptr<rocksdb::BackupEngine> backupDb_{nullptr};
     int32_t partsNum_ = -1;
 };
 

--- a/src/kvstore/RocksEngineConfig.cpp
+++ b/src/kvstore/RocksEngineConfig.cpp
@@ -6,6 +6,7 @@
 
 #include "common/base/Base.h"
 #include "common/conf/Configuration.h"
+#include "common/fs/FileUtils.h"
 #include "kvstore/RocksEngineConfig.h"
 #include "kvstore/EventListener.h"
 #include <rocksdb/db.h>
@@ -45,6 +46,7 @@ DEFINE_string(rocksdb_block_based_table_options,
 DEFINE_int32(rocksdb_batch_size,
              4 * 1024,
              "default reserved bytes for one batch operation");
+
 /*
  * For these un-supported string options as below, will need to specify them with gflag.
  */
@@ -74,10 +76,11 @@ DEFINE_int32(rate_limit, 0,
 
 DEFINE_bool(enable_rocksdb_prefix_filtering, false,
             "Whether or not to enable rocksdb's prefix bloom filter.");
+DEFINE_bool(rocksdb_prefix_bloom_filter_length_flag, false,
+            "If true, prefix bloom filter will be sizeof(PartitionID) + vidLen + sizeof(EdgeType). "
+            "If false, prefix bloom filter will be sizeof(PartitionID) + vidLen. ");
 DEFINE_bool(enable_rocksdb_whole_key_filtering, true,
             "Whether or not to enable the whole key filtering.");
-DEFINE_int32(rocksdb_filtering_prefix_length, 12,
-            "The prefix length, default value is 12 bytes(PartitionID+VertexID).");
 
 DEFINE_bool(rocksdb_compact_change_level, true,
             "If true, compacted files will be moved to the minimum level capable "
@@ -87,6 +90,17 @@ DEFINE_int32(rocksdb_compact_target_level, -1,
              "If change_level is true and target_level have non-negative value, compacted files "
              "will be moved to target_level. If change_level is true and target_level is -1, "
              "compacted files will be moved to the minimum level capable of holding the data.");
+
+DEFINE_string(rocksdb_table_format,
+              "BlockBasedTable",
+              "SST file format of rocksdb, only support BlockBasedTable and PlainTable");
+
+DEFINE_string(rocksdb_wal_dir, "", "Rocksdb wal directory");
+
+DEFINE_string(rocksdb_backup_dir, "", "Rocksdb backup directory, only used in PlainTable format");
+
+DEFINE_int32(rocksdb_backup_interval_secs, 300,
+             "Rocksdb backup directory, only used in PlainTable format");
 
 namespace nebula {
 namespace kvstore {
@@ -98,8 +112,7 @@ private:
 
 public:
     explicit GraphPrefixTransform(size_t prefixLen)
-        : prefixLen_(prefixLen),
-        name_("nebula.GraphPrefix." + std::to_string(prefixLen_)) {}
+        : prefixLen_(prefixLen), name_("nebula.GraphPrefix." + std::to_string(prefixLen_)) {}
 
     const char* Name() const override { return name_.c_str(); }
 
@@ -107,9 +120,15 @@ public:
         return rocksdb::Slice(src.data(), prefixLen_);
     }
 
-    bool InDomain(const rocksdb::Slice& src) const override {
-        // todo(doodle): only need to consider tag and edge
-        return src.size() >= prefixLen_;
+    bool InDomain(const rocksdb::Slice& key) const override {
+        if (key.size() < prefixLen_) {
+            return false;
+        }
+        // And we should not use NebulaKeyUtils::isVertex or isEdge here, because it will regard the
+        // prefix itself not in domain since its length does not satisfy
+        constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyType));
+        auto type = static_cast<NebulaKeyType>(readInt<uint32_t>(key.data(), len) & kTypeMask);
+        return type == NebulaKeyType::kEdge || type == NebulaKeyType::kVertex;
     }
 };
 
@@ -159,12 +178,15 @@ static rocksdb::Status initRocksdbCompression(rocksdb::Options &baseOpts) {
     return rocksdb::Status::OK();
 }
 
-rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts, int32_t vidLen) {
+rocksdb::Status initRocksdbOptions(rocksdb::Options& baseOpts,
+                                   GraphSpaceID spaceId,
+                                   int32_t vidLen) {
     rocksdb::Status s;
     rocksdb::DBOptions dbOpts;
     rocksdb::ColumnFamilyOptions cfOpts;
     rocksdb::BlockBasedTableOptions bbtOpts;
 
+    // DBOptions
     std::unordered_map<std::string, std::string> dbOptsMap;
     if (!loadOptionsMap(dbOptsMap, FLAGS_rocksdb_db_options)) {
         return rocksdb::Status::InvalidArgument();
@@ -180,6 +202,20 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts, int32_t vidLen) {
     }
     dbOpts.listeners.emplace_back(new EventListener());
 
+    // if rocksdb_wal_dir is set, specify it to rocksdb
+    if (!FLAGS_rocksdb_wal_dir.empty()) {
+        auto walDir =
+            folly::stringPrintf("%s/rocksdb_wal/%d", FLAGS_rocksdb_wal_dir.c_str(), spaceId);
+        if (fs::FileUtils::fileType(walDir.c_str()) == fs::FileType::NOTEXIST) {
+            if (!fs::FileUtils::makeDir(walDir)) {
+                LOG(FATAL) << "makeDir " << walDir << " failed";
+            }
+        }
+        LOG(INFO) << "set rocksdb wal of space " << spaceId << " to " << walDir;
+        dbOpts.wal_dir = walDir;
+    }
+
+    // ColumnFamilyOptions
     std::unordered_map<std::string, std::string> cfOptsMap;
     if (!loadOptionsMap(cfOptsMap, FLAGS_rocksdb_column_family_options)) {
         return rocksdb::Status::InvalidArgument();
@@ -196,23 +232,6 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts, int32_t vidLen) {
         return s;
     }
 
-    std::unordered_map<std::string, std::string> bbtOptsMap;
-    if (!loadOptionsMap(bbtOptsMap, FLAGS_rocksdb_block_based_table_options)) {
-        return rocksdb::Status::InvalidArgument();
-    }
-    s = GetBlockBasedTableOptionsFromMap(rocksdb::BlockBasedTableOptions(), bbtOptsMap,
-                                         &bbtOpts, true);
-    if (!s.ok()) {
-        return s;
-    }
-
-    if (FLAGS_rocksdb_block_cache <= 0) {
-        bbtOpts.no_block_cache = true;
-    } else {
-        static std::shared_ptr<rocksdb::Cache> blockCache
-            = rocksdb::NewLRUCache(FLAGS_rocksdb_block_cache * 1024 * 1024, 8/*shard bits*/);
-        bbtOpts.block_cache = blockCache;
-    }
     if (FLAGS_num_compaction_threads > 0) {
         static std::shared_ptr<rocksdb::ConcurrentTaskLimiter> compaction_thread_limiter{
             rocksdb::NewConcurrentTaskLimiter("compaction", FLAGS_num_compaction_threads)};
@@ -224,23 +243,59 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts, int32_t vidLen) {
         baseOpts.rate_limiter = rate_limiter;
     }
 
-    bbtOpts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
-    if (FLAGS_enable_partitioned_index_filter) {
-        bbtOpts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
-        bbtOpts.partition_filters = true;
-        bbtOpts.cache_index_and_filter_blocks = true;
-        bbtOpts.cache_index_and_filter_blocks_with_high_priority = true;
-        bbtOpts.pin_l0_filter_and_index_blocks_in_cache =
-            baseOpts.compaction_style == rocksdb::CompactionStyle::kCompactionStyleLevel;
+    size_t prefixLength = FLAGS_rocksdb_prefix_bloom_filter_length_flag
+                              ? sizeof(PartitionID) + vidLen + sizeof(EdgeType)
+                              : sizeof(PartitionID) + vidLen;
+    if (FLAGS_rocksdb_table_format == "BlockBasedTable") {
+        // BlockBasedTableOptions
+        std::unordered_map<std::string, std::string> bbtOptsMap;
+        if (!loadOptionsMap(bbtOptsMap, FLAGS_rocksdb_block_based_table_options)) {
+            return rocksdb::Status::InvalidArgument();
+        }
+        s = GetBlockBasedTableOptionsFromMap(rocksdb::BlockBasedTableOptions(), bbtOptsMap,
+                                            &bbtOpts, true);
+        if (!s.ok()) {
+            return s;
+        }
+
+        if (FLAGS_rocksdb_block_cache <= 0) {
+            bbtOpts.no_block_cache = true;
+        } else {
+            static std::shared_ptr<rocksdb::Cache> blockCache
+                = rocksdb::NewLRUCache(FLAGS_rocksdb_block_cache * 1024 * 1024, 8/*shard bits*/);
+            bbtOpts.block_cache = blockCache;
+        }
+
+        bbtOpts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(10, false));
+        if (FLAGS_enable_partitioned_index_filter) {
+            bbtOpts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
+            bbtOpts.partition_filters = true;
+            bbtOpts.cache_index_and_filter_blocks = true;
+            bbtOpts.cache_index_and_filter_blocks_with_high_priority = true;
+            bbtOpts.pin_top_level_index_and_filter = true;
+            bbtOpts.pin_l0_filter_and_index_blocks_in_cache =
+                baseOpts.compaction_style == rocksdb::CompactionStyle::kCompactionStyleLevel;
+        }
+        if (FLAGS_enable_rocksdb_prefix_filtering) {
+            baseOpts.prefix_extractor.reset(new GraphPrefixTransform(prefixLength));
+        }
+        bbtOpts.whole_key_filtering = FLAGS_enable_rocksdb_whole_key_filtering;
+        baseOpts.table_factory.reset(NewBlockBasedTableFactory(bbtOpts));
+        baseOpts.create_if_missing = true;
+    } else if (FLAGS_rocksdb_table_format == "PlainTable") {
+        // wal_dir need to be specified by rocksdb_wal_dir.
+        //
+        // WAL_ttl_seconds is 0 by default in rocksdb, which will check every 10 mins,
+        // so rocksdb_backup_interval_secs is set to half of WAL_ttl_seconds by default.
+        // WAL_ttl_seconds and rocksdb_backup_interval_secs need to be modify together if necessary
+        FLAGS_rocksdb_disable_wal = false;
+        baseOpts.prefix_extractor.reset(rocksdb::NewCappedPrefixTransform(prefixLength));
+        baseOpts.table_factory.reset(rocksdb::NewPlainTableFactory());
+        baseOpts.create_if_missing = true;
+    } else {
+        return rocksdb::Status::NotSupported("Illegal table format");
     }
-    if (FLAGS_enable_rocksdb_prefix_filtering) {
-        int lengthBeforeVid = 4;
-        baseOpts.prefix_extractor.reset(
-                new GraphPrefixTransform(lengthBeforeVid + vidLen));
-    }
-    bbtOpts.whole_key_filtering = FLAGS_enable_rocksdb_whole_key_filtering;
-    baseOpts.table_factory.reset(NewBlockBasedTableFactory(bbtOpts));
-    baseOpts.create_if_missing = true;
+
     return s;
 }
 

--- a/src/kvstore/RocksEngineConfig.h
+++ b/src/kvstore/RocksEngineConfig.h
@@ -59,6 +59,9 @@ DECLARE_string(rocksdb_wal_dir);
 DECLARE_string(rocksdb_backup_dir);
 DECLARE_int32(rocksdb_backup_interval_secs);
 
+DECLARE_string(rocksdb_memtable_type);
+DECLARE_int32(rocksdb_memtable_hash_bucket_count);
+
 namespace nebula {
 namespace kvstore {
 

--- a/src/kvstore/RocksEngineConfig.h
+++ b/src/kvstore/RocksEngineConfig.h
@@ -8,6 +8,7 @@
 #define KVSTORE_ROCKSENGINECONFIG_H_
 
 #include "common/base/Base.h"
+#include "common/thrift/ThriftTypes.h"
 #include <rocksdb/db.h>
 
 // [Version]
@@ -35,6 +36,9 @@ DECLARE_int64(rocksdb_block_cache);
 
 DECLARE_int32(rocksdb_batch_size);
 
+// rocksdb table format
+DECLARE_string(rocksdb_table_format);
+
 DECLARE_string(part_man_type);
 
 DECLARE_string(rocksdb_compression_per_level);
@@ -44,17 +48,23 @@ DECLARE_bool(enable_rocksdb_statistics);
 DECLARE_string(rocksdb_stats_level);
 
 DECLARE_bool(enable_rocksdb_prefix_filtering);
+DECLARE_bool(rocksdb_prefix_bloom_filter_length_flag);
 DECLARE_bool(enable_rocksdb_whole_key_filtering);
-DECLARE_int32(rocksdb_filtering_prefix_length);
 
 // rocksdb compact RangeOptions
 DECLARE_bool(rocksdb_compact_change_level);
 DECLARE_int32(rocksdb_compact_target_level);
 
+DECLARE_string(rocksdb_wal_dir);
+DECLARE_string(rocksdb_backup_dir);
+DECLARE_int32(rocksdb_backup_interval_secs);
+
 namespace nebula {
 namespace kvstore {
 
-rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts, int32_t vidLen = 8);
+rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts,
+                                   GraphSpaceID spaceId,
+                                   int32_t vidLen = 8);
 
 bool loadOptionsMap(std::unordered_map<std::string, std::string> &map, const std::string& gflags);
 

--- a/src/kvstore/test/RocksEngineConfigTest.cpp
+++ b/src/kvstore/test/RocksEngineConfigTest.cpp
@@ -80,7 +80,7 @@ TEST(RocksEngineConfigTest, createOptionsTest) {
     rocksdb::Options options;
     FLAGS_rocksdb_db_options = R"({"stats_dump_period_sec":"aaaaaa"})";
 
-    rocksdb::Status s = initRocksdbOptions(options);
+    rocksdb::Status s = initRocksdbOptions(options, 1);
     ASSERT_EQ(rocksdb::Status::kInvalidArgument , s.code());
     EXPECT_EQ("Invalid argument: Error parsing stats_dump_period_sec:stoull",
               s.ToString());
@@ -93,7 +93,7 @@ TEST(RocksEngineConfigTest, StatisticsConfigTest) {
     {
         FLAGS_enable_rocksdb_statistics = false;
         rocksdb::Options options;
-        auto status = initRocksdbOptions(options);
+        auto status = initRocksdbOptions(options, 1);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_EQ(nullptr, getDBStatistics());
     }
@@ -102,7 +102,7 @@ TEST(RocksEngineConfigTest, StatisticsConfigTest) {
         FLAGS_enable_rocksdb_statistics = true;
         FLAGS_rocksdb_stats_level = "kExceptTimers";
         rocksdb::Options options;
-        auto status = initRocksdbOptions(options);
+        auto status = initRocksdbOptions(options, 1);
         ASSERT_TRUE(status.ok()) << status.ToString();
         std::shared_ptr<rocksdb::Statistics> stats = getDBStatistics();
         ASSERT_EQ(rocksdb::StatsLevel::kExceptTimers, stats->get_stats_level());
@@ -114,7 +114,7 @@ TEST(RocksEngineConfigTest, CompressionConfigTest) {
         FLAGS_rocksdb_compression = "lz4";
         FLAGS_rocksdb_compression_per_level = "no:no::mp3::zstd";
         rocksdb::Options options;
-        auto status = initRocksdbOptions(options);
+        auto status = initRocksdbOptions(options, 1);
         ASSERT_EQ(rocksdb::Status::kInvalidArgument, status.code());
     }
 
@@ -122,7 +122,7 @@ TEST(RocksEngineConfigTest, CompressionConfigTest) {
         FLAGS_rocksdb_compression = "lz4";
         FLAGS_rocksdb_compression_per_level = "no:no::snappy::zstd";
         rocksdb::Options options;
-        auto status = initRocksdbOptions(options);
+        auto status = initRocksdbOptions(options, 1);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_EQ(rocksdb::kLZ4Compression, options.compression);
         ASSERT_EQ(rocksdb::kNoCompression, options.compression_per_level[0]);
@@ -145,7 +145,7 @@ TEST(RocksEngineConfigTest, CompressionConfigTest) {
         FLAGS_rocksdb_compression = "snappy";
         FLAGS_rocksdb_compression_per_level = "no:snappy:lz4:lz4hc:zstd:zlib:bzip2";
         rocksdb::Options options;
-        auto status = initRocksdbOptions(options);
+        auto status = initRocksdbOptions(options, 1);
         ASSERT_TRUE(status.ok()) << status.ToString();
         ASSERT_EQ(rocksdb::kSnappyCompression, options.compression);
         ASSERT_EQ(rocksdb::kNoCompression, options.compression_per_level[0]);

--- a/src/mock/MockCluster.cpp
+++ b/src/mock/MockCluster.cpp
@@ -196,9 +196,10 @@ void MockCluster::initStorageKV(const char* dataPath,
         indexMan_ = meta::ServerBasedIndexManager::create(metaClient_.get());
     } else {
         LOG(INFO) << "Use meta in memory!";
-        options.partMan_ = memPartMan(1, parts);;
         schemaMan_ = memSchemaMan(schemaVerCount, 1, hasProp);
         indexMan_ = memIndexMan(1, hasProp);
+        options.partMan_ = memPartMan(1, parts);;
+        options.schemaMan_ = schemaMan_.get();
     }
     std::vector<std::string> paths;
     paths.emplace_back(folly::stringPrintf("%s/disk1", dataPath));

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -41,10 +41,12 @@ namespace storage {
 StorageServer::StorageServer(HostAddr localHost,
                              std::vector<HostAddr> metaAddrs,
                              std::vector<std::string> dataPaths,
+                             std::string walPath,
                              std::string listenerPath)
     : localHost_(localHost)
     , metaAddrs_(std::move(metaAddrs))
     , dataPaths_(std::move(dataPaths))
+    , walPath_(std::move(walPath))
     , listenerPath_(std::move(listenerPath)) {}
 
 StorageServer::~StorageServer() {
@@ -54,6 +56,7 @@ StorageServer::~StorageServer() {
 std::unique_ptr<kvstore::KVStore> StorageServer::getStoreInstance() {
     kvstore::KVOptions options;
     options.dataPaths_ = dataPaths_;
+    options.walPath_ = walPath_;
     options.listenerPath_ = listenerPath_;
     options.partMan_ = std::make_unique<kvstore::MetaServerBasedPartManager>(
                                                 localHost_,

--- a/src/storage/StorageServer.h
+++ b/src/storage/StorageServer.h
@@ -28,6 +28,7 @@ public:
     StorageServer(HostAddr localHost,
                   std::vector<HostAddr> metaAddrs,
                   std::vector<std::string> dataPaths,
+                  std::string walPath = "",
                   std::string listenerPath = "");
 
     ~StorageServer();
@@ -79,6 +80,7 @@ private:
     HostAddr localHost_;
     std::vector<HostAddr> metaAddrs_;
     std::vector<std::string> dataPaths_;
+    std::string walPath_;
     std::string listenerPath_;
 
     AdminTaskManager* taskMgr_{nullptr};

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -590,7 +590,7 @@ TEST(QueryVertexPropsTest, PrefixBloomFilterTest) {
         std::unique_ptr<kvstore::KVIterator> iter;
         auto prefix = NebulaKeyUtils::vertexPrefix(vIdLen, partId, vId, player);
         auto code = env->kvstore_->prefix(spaceId, partId, prefix, &iter);
-        CHECK_EQ(code, nebula::kvstore::ResultCode::SUCCEEDED);
+        ASSERT_EQ(code, nebula::cpp2::ErrorCode::SUCCEEDED);
     }
 
     {

--- a/src/storage/test/GetPropTest.cpp
+++ b/src/storage/test/GetPropTest.cpp
@@ -576,8 +576,11 @@ TEST(QueryVertexPropsTest, PrefixBloomFilterTest) {
     auto* env = cluster.storageEnv_.get();
     auto totalParts = cluster.getTotalParts();
     ASSERT_EQ(true, QueryTestUtils::mockVertexData(env, totalParts));
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env, totalParts));
 
     GraphSpaceID spaceId = 1;
+    TagID player = 1;
+    EdgeType serve = 101;
     auto status = env->schemaMan_->getSpaceVidLen(spaceId);
     auto vIdLen = status.value();
     std::vector<VertexID> vertices = {"Tim Duncan", "Not Existed"};
@@ -585,14 +588,37 @@ TEST(QueryVertexPropsTest, PrefixBloomFilterTest) {
     for (const auto& vId : vertices) {
         PartitionID partId = (hash(vId) % totalParts) + 1;
         std::unique_ptr<kvstore::KVIterator> iter;
-        auto prefix = NebulaKeyUtils::vertexPrefix(vIdLen, partId, vId);
+        auto prefix = NebulaKeyUtils::vertexPrefix(vIdLen, partId, vId, player);
+        auto code = env->kvstore_->prefix(spaceId, partId, prefix, &iter);
+        CHECK_EQ(code, nebula::kvstore::ResultCode::SUCCEEDED);
+    }
+
+    {
+        std::shared_ptr<rocksdb::Statistics> statistics = kvstore::getDBStatistics();
+        ASSERT_GT(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_CHECKED), 0);
+        ASSERT_GT(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_USEFUL), 0);
+        ASSERT_EQ(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_USEFUL), 0);
+        statistics->Reset();
+        ASSERT_EQ(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_CHECKED), 0);
+        ASSERT_EQ(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_USEFUL), 0);
+        ASSERT_EQ(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_USEFUL), 0);
+    }
+
+    for (const auto& vId : vertices) {
+        PartitionID partId = (hash(vId) % totalParts) + 1;
+        std::unique_ptr<kvstore::KVIterator> iter;
+        auto prefix = NebulaKeyUtils::edgePrefix(vIdLen, partId, vId, serve);
         auto code = env->kvstore_->prefix(spaceId, partId, prefix, &iter);
         ASSERT_EQ(code, nebula::cpp2::ErrorCode::SUCCEEDED);
     }
 
-    std::shared_ptr<rocksdb::Statistics> statistics = kvstore::getDBStatistics();
-    ASSERT_GT(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_CHECKED), 0);
-    ASSERT_GT(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_USEFUL), 0);
+    {
+        std::shared_ptr<rocksdb::Statistics> statistics = kvstore::getDBStatistics();
+        ASSERT_GT(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_CHECKED), 0);
+        ASSERT_GT(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_PREFIX_USEFUL), 0);
+        ASSERT_EQ(statistics->getTickerCount(rocksdb::Tickers::BLOOM_FILTER_USEFUL), 0);
+    }
+
     FLAGS_enable_rocksdb_statistics = false;
     FLAGS_enable_rocksdb_prefix_filtering = false;
 }

--- a/src/tools/db-upgrade/DbUpgrader.cpp
+++ b/src/tools/db-upgrade/DbUpgrader.cpp
@@ -72,7 +72,7 @@ Status UpgraderSpace::initSpace(const std::string& sId) {
     spaceVidLen_ = spaceVidLen.value();
 
     // Use readonly rocksdb
-    readEngine_.reset(new nebula::kvstore::RocksEngine(spaceId_, spaceVidLen_, srcPath_,
+    readEngine_.reset(new nebula::kvstore::RocksEngine(spaceId_, spaceVidLen_, srcPath_, "",
                                                        nullptr, nullptr, true));
     writeEngine_.reset(new nebula::kvstore::RocksEngine(spaceId_, spaceVidLen_, dstPath_));
 


### PR DESCRIPTION
To support rocksdb PlainTable and nebula work in memory
1. Dir of rocksdb wal and nebula wal should be configurable
2. Backup rocksdb periodically, and try to recover from latest backup
3. Fix the 2.0 prefix bloom filter