### PR TITLE
update iterate edges benchmark

### DIFF
--- a/src/codec/RowReaderV2.h
+++ b/src/codec/RowReaderV2.h
@@ -23,6 +23,7 @@ class RowReaderV2 : public RowReader {
     friend class RowReaderWrapper;
 
     FRIEND_TEST(RowReaderV2, encodedData);
+    FRIEND_TEST(ScanEdgePropBench, ProcessEdgeProps);
 
 public:
     virtual ~RowReaderV2() = default;

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -21,8 +21,6 @@ namespace storage {
 // result from HashJoinNode, and the stat info and edge iterator from AggregateNode. Then collect
 // some edge props, and put them into the target cell of a row.
 class GetNeighborsNode : public QueryNode<VertexID> {
-    FRIEND_TEST(ScanEdgePropBench, ProcessEdgeProps);
-
 public:
     using RelNode::execute;
 


### PR DESCRIPTION
Since we update storage data from 1.x to 2.x, actually we don't need `RowReaderWrapper` or `RowReaderV1` anymore. Based on the benchmark, performance impact is very small, so not in a rush, we could do it later.

When 10000 edges to iterate:
* RowReaderWrapper reset with vector schemas takes 10550us 
* RowReaderV2 reset with vector schemas takes 10182us

When 100 edges to iterate:
* RowReaderWrapper reset with vector schemas takes 87us 
* RowReaderV2 reset with vector schemas takes 86us

