### PR TITLE
remove shuffle when balance data

### DIFF
--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -429,9 +429,6 @@ bool Balancer::balanceParts(BalanceID balanceId,
         maxPartsHost = sortedHosts.back();
         minPartsHost = sortedHosts.front();
     }
-    std::random_device rd;
-    std::mt19937 g(rd());
-    std::shuffle(tasks.begin(), tasks.end(), g);
     LOG(INFO) << "Balance tasks num: " << tasks.size();
     for (auto& task : tasks) {
         LOG(INFO) << task.taskIdStr();


### PR DESCRIPTION
For example is in hosts [a, b, c], want move from c to d, then b to c. However, b to c is invoked at first.
Expected: [abc] -> [abd] -> [acd]
Actual: [abc] -> [ac] -> [ad]

Just remove the shuffle, the relative order of given part can't be changed during balance.

![image](https://user-images.githubusercontent.com/13706157/109909328-e1569b00-7ce0-11eb-88e4-c64d87a91868.png)
![image](https://user-images.githubusercontent.com/13706157/109909345-e61b4f00-7ce0-11eb-91ff-cacec14c32ea.png)
