### PR TITLE
fix early onFinished

### DIFF
--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -102,6 +102,10 @@ protected:
                      PartitionID partId,
                      kvstore::ResultCode code);
 
+    void handleAsync(GraphSpaceID spaceId,
+                     PartitionID partId,
+                     cpp2::ErrorCode code);
+
     StatusOr<std::string> encodeRowVal(const meta::NebulaSchemaProvider* schema,
                                        const std::vector<std::string>& propNames,
                                        const std::vector<Value>& props,

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -11,52 +11,7 @@ namespace storage {
 
 template<typename RESP>
 cpp2::ErrorCode BaseProcessor<RESP>::to(kvstore::ResultCode code) {
-    switch (code) {
-    case kvstore::ResultCode::SUCCEEDED:
-        return cpp2::ErrorCode::SUCCEEDED;
-    case kvstore::ResultCode::ERR_LEADER_CHANGED:
-        return cpp2::ErrorCode::E_LEADER_CHANGED;
-    case kvstore::ResultCode::ERR_SPACE_NOT_FOUND:
-        return cpp2::ErrorCode::E_SPACE_NOT_FOUND;
-    case kvstore::ResultCode::ERR_PART_NOT_FOUND:
-        return cpp2::ErrorCode::E_PART_NOT_FOUND;
-    case kvstore::ResultCode::ERR_KEY_NOT_FOUND:
-        return cpp2::ErrorCode::E_KEY_NOT_FOUND;
-    case kvstore::ResultCode::ERR_CONSENSUS_ERROR:
-        return cpp2::ErrorCode::E_CONSENSUS_ERROR;
-    case kvstore::ResultCode::ERR_CHECKPOINT_ERROR:
-        return cpp2::ErrorCode::E_FAILED_TO_CHECKPOINT;
-    case kvstore::ResultCode::ERR_WRITE_BLOCK_ERROR:
-        return cpp2::ErrorCode::E_CHECKPOINT_BLOCKED;
-    case kvstore::ResultCode::ERR_PARTIAL_RESULT:
-        return cpp2::ErrorCode::E_PARTIAL_RESULT;
-    case kvstore::ResultCode::ERR_INVALID_FIELD_VALUE:
-        return cpp2::ErrorCode::E_INVALID_FIELD_VALUE;
-    case kvstore::ResultCode::ERR_RESULT_FILTERED:
-        return cpp2::ErrorCode::E_FILTER_OUT;
-    case kvstore::ResultCode::ERR_EDGE_NOT_FOUND:
-        return cpp2::ErrorCode::E_EDGE_NOT_FOUND;
-    case kvstore::ResultCode::ERR_TAG_NOT_FOUND:
-        return cpp2::ErrorCode::E_TAG_NOT_FOUND;
-    case kvstore::ResultCode::ERR_ATOMIC_OP_FAILED:
-        return cpp2::ErrorCode::E_ATOMIC_OP_FAILED;
-    case kvstore::ResultCode::ERR_TAG_PROP_NOT_FOUND:
-        return cpp2::ErrorCode::E_TAG_PROP_NOT_FOUND;
-    case kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND:
-        return cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
-    case kvstore::ResultCode::ERR_RESULT_OVERFLOW:
-        return cpp2::ErrorCode::E_OUT_OF_RANGE;
-    case kvstore::ResultCode::ERR_INVALID_DATA:
-        return cpp2::ErrorCode::E_INVALID_DATA;
-    case kvstore::ResultCode::ERR_BUILD_INDEX_FAILED:
-        return cpp2::ErrorCode::E_REBUILD_INDEX_FAILED;
-    case kvstore::ResultCode::ERR_INVALID_OPERATION:
-        return cpp2::ErrorCode::E_INVALID_OPERATION;
-    case kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR:
-        return cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
-    default:
-        return cpp2::ErrorCode::E_UNKNOWN;
-    }
+    return CommonUtils::to(code);
 }
 
 template <typename RESP>
@@ -94,6 +49,27 @@ void BaseProcessor<RESP>::handleAsync(GraphSpaceID spaceId,
     {
         std::lock_guard<std::mutex> lg(this->lock_);
         handleErrorCode(code, spaceId, partId);
+        this->callingNum_--;
+        if (this->callingNum_ == 0) {
+            finished = true;
+        }
+    }
+
+    if (finished) {
+        this->onFinished();
+    }
+}
+
+template <typename RESP>
+void BaseProcessor<RESP>::handleAsync(GraphSpaceID,
+                                      PartitionID partId,
+                                      cpp2::ErrorCode code) {
+    VLOG(3) << "partId:" << partId << ", code:" << static_cast<int32_t>(code);
+
+    bool finished = false;
+    {
+        std::lock_guard<std::mutex> lg(this->lock_);
+        pushResultCode(code, partId);
         this->callingNum_--;
         if (this->callingNum_ == 0) {
             finished = true;

--- a/src/storage/CommonUtils.cpp
+++ b/src/storage/CommonUtils.cpp
@@ -26,10 +26,48 @@ cpp2::ErrorCode CommonUtils::to(const Status& status) {
 
 cpp2::ErrorCode CommonUtils::to(kvstore::ResultCode rc) {
     switch (rc) {
-        case kvstore::ResultCode::SUCCEEDED :
+        case kvstore::ResultCode::SUCCEEDED:
             return cpp2::ErrorCode::SUCCEEDED;
-        case kvstore::ResultCode::ERR_LEADER_CHANGED :
+        case kvstore::ResultCode::ERR_LEADER_CHANGED:
             return cpp2::ErrorCode::E_LEADER_CHANGED;
+        case kvstore::ResultCode::ERR_SPACE_NOT_FOUND:
+            return cpp2::ErrorCode::E_SPACE_NOT_FOUND;
+        case kvstore::ResultCode::ERR_PART_NOT_FOUND:
+            return cpp2::ErrorCode::E_PART_NOT_FOUND;
+        case kvstore::ResultCode::ERR_KEY_NOT_FOUND:
+            return cpp2::ErrorCode::E_KEY_NOT_FOUND;
+        case kvstore::ResultCode::ERR_CONSENSUS_ERROR:
+            return cpp2::ErrorCode::E_CONSENSUS_ERROR;
+        case kvstore::ResultCode::ERR_CHECKPOINT_ERROR:
+            return cpp2::ErrorCode::E_FAILED_TO_CHECKPOINT;
+        case kvstore::ResultCode::ERR_WRITE_BLOCK_ERROR:
+            return cpp2::ErrorCode::E_CHECKPOINT_BLOCKED;
+        case kvstore::ResultCode::ERR_PARTIAL_RESULT:
+            return cpp2::ErrorCode::E_PARTIAL_RESULT;
+        case kvstore::ResultCode::ERR_INVALID_FIELD_VALUE:
+            return cpp2::ErrorCode::E_INVALID_FIELD_VALUE;
+        case kvstore::ResultCode::ERR_RESULT_FILTERED:
+            return cpp2::ErrorCode::E_FILTER_OUT;
+        case kvstore::ResultCode::ERR_EDGE_NOT_FOUND:
+            return cpp2::ErrorCode::E_EDGE_NOT_FOUND;
+        case kvstore::ResultCode::ERR_TAG_NOT_FOUND:
+            return cpp2::ErrorCode::E_TAG_NOT_FOUND;
+        case kvstore::ResultCode::ERR_ATOMIC_OP_FAILED:
+            return cpp2::ErrorCode::E_ATOMIC_OP_FAILED;
+        case kvstore::ResultCode::ERR_TAG_PROP_NOT_FOUND:
+            return cpp2::ErrorCode::E_TAG_PROP_NOT_FOUND;
+        case kvstore::ResultCode::ERR_EDGE_PROP_NOT_FOUND:
+            return cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
+        case kvstore::ResultCode::ERR_RESULT_OVERFLOW:
+            return cpp2::ErrorCode::E_OUT_OF_RANGE;
+        case kvstore::ResultCode::ERR_INVALID_DATA:
+            return cpp2::ErrorCode::E_INVALID_DATA;
+        case kvstore::ResultCode::ERR_BUILD_INDEX_FAILED:
+            return cpp2::ErrorCode::E_REBUILD_INDEX_FAILED;
+        case kvstore::ResultCode::ERR_INVALID_OPERATION:
+            return cpp2::ErrorCode::E_INVALID_OPERATION;
+        case kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR:
+            return cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
         default:
             LOG(ERROR) << "unknown ResultCode: " << static_cast<int>(rc);
             return cpp2::ErrorCode::E_UNKNOWN;

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -262,9 +262,9 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
             continue;
         }
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
-            [l = std::move(lg), partId, this](kvstore::ResultCode code) {
+            [l = std::move(lg), partId, this](kvstore::ResultCode kvRet) {
                 UNUSED(l);
-                handleAsync(spaceId_, partId, code);
+                handleAsync(spaceId_, partId, kvRet);
             });
     }
 }

--- a/src/storage/mutate/AddEdgesProcessor.h
+++ b/src/storage/mutate/AddEdgesProcessor.h
@@ -37,11 +37,11 @@ private:
     AddEdgesProcessor(StorageEnv* env, const ProcessorCounters* counters)
         : BaseProcessor<cpp2::ExecResponse>(env, counters) {}
 
-    folly::Optional<std::string> addEdges(PartitionID partId,
-                                          const std::vector<kvstore::KV>& edges);
+    ErrorOr<kvstore::ResultCode, std::string> addEdges(PartitionID partId,
+                                                       const std::vector<kvstore::KV>& edges);
 
-    folly::Optional<std::string> findOldValue(PartitionID partId,
-                                              const folly::StringPiece& rawKey);
+    ErrorOr<kvstore::ResultCode, std::string> findOldValue(PartitionID partId,
+                                                           const folly::StringPiece& rawKey);
 
     std::string indexKey(PartitionID partId,
                          RowReader* reader,

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -273,9 +273,9 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
             continue;
         }
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
-            [l = std::move(lg), partId, this](kvstore::ResultCode code) {
+            [l = std::move(lg), partId, this](kvstore::ResultCode kvRet) {
                 UNUSED(l);
-                handleAsync(spaceId_, partId, code);
+                handleAsync(spaceId_, partId, kvRet);
             });
     }
 }

--- a/src/storage/mutate/AddVerticesProcessor.h
+++ b/src/storage/mutate/AddVerticesProcessor.h
@@ -40,7 +40,9 @@ private:
         : BaseProcessor<cpp2::ExecResponse>(env, counters)
         , vertexCache_(cache) {}
 
-    folly::Optional<std::string> findOldValue(PartitionID partId, const VertexID& vId, TagID tagId);
+    ErrorOr<kvstore::ResultCode, std::string> findOldValue(PartitionID partId,
+                                                           const VertexID& vId,
+                                                           TagID tagId);
 
     std::string indexKey(PartitionID partId, const VertexID& vId, RowReader* reader,
                          std::shared_ptr<nebula::meta::cpp2::IndexItem> index);

--- a/src/storage/mutate/DeleteEdgesProcessor.h
+++ b/src/storage/mutate/DeleteEdgesProcessor.h
@@ -30,8 +30,9 @@ private:
     explicit DeleteEdgesProcessor(StorageEnv* env, const ProcessorCounters* counters)
             : BaseProcessor<cpp2::ExecResponse>(env, counters) {}
 
-    folly::Optional<std::string> deleteEdges(PartitionID partId,
-                                             const std::vector<cpp2::EdgeKey>& edges);
+    ErrorOr<kvstore::ResultCode, std::string> deleteEdges(PartitionID partId,
+                                                          const std::vector<cpp2::EdgeKey>& edges);
+
 private:
     GraphSpaceID                                                spaceId_;
     std::vector<std::shared_ptr<nebula::meta::cpp2::IndexItem>> indexes_;

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -95,11 +95,11 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
             auto partId = pv.first;
             std::vector<VMLI> dummyLock;
             auto batch = deleteVertices(partId, std::move(pv).second, dummyLock);
-            if (batch == folly::none) {
-                handleAsync(spaceId_, partId, kvstore::ResultCode::ERR_INVALID_DATA);
+            if (!nebula::ok(batch)) {
+                handleAsync(spaceId_, partId, nebula::error(batch));
                 continue;
             }
-            DCHECK(!batch.value().empty());
+            DCHECK(!nebula::value(batch).empty());
             nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(), std::move(dummyLock), true);
             if (!lg) {
                 auto conflict = lg.conflictKey();
@@ -111,7 +111,7 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
                 handleAsync(spaceId_, partId, cpp2::ErrorCode::E_DATA_CONFLICT_ERROR);
                 continue;
             }
-            env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch).value(),
+            env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(nebula::value(batch)),
                 [l = std::move(lg), partId, this](kvstore::ResultCode code) {
                     UNUSED(l);
                     handleAsync(spaceId_, partId, code);
@@ -121,7 +121,7 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
 }
 
 
-folly::Optional<std::string>
+ErrorOr<kvstore::ResultCode, std::string>
 DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                                         const std::vector<Value>& vertices,
                                         std::vector<VMLI>& target) {
@@ -135,7 +135,7 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
         if (ret != kvstore::ResultCode::SUCCEEDED) {
             VLOG(3) << "Error! ret = " << static_cast<int32_t>(ret)
                     << ", spaceId " << spaceId_;
-            return folly::none;
+            return ret;
         }
 
         while (iter->valid()) {
@@ -153,7 +153,7 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                                                                     iter->val());
                         if (reader == nullptr) {
                             LOG(WARNING) << "Bad format row";
-                            return folly::none;
+                            return kvstore::ResultCode::ERR_INVALID_DATA;
                         }
                     }
                     const auto& cols = index->get_fields();
@@ -175,7 +175,7 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                         batchHolder->put(std::move(deleteOpKey), std::move(indexKey));
                     } else if (env_->checkIndexLocked(indexState)) {
                         LOG(ERROR) << "The index has been locked: " << index->get_index_name();
-                        return folly::none;
+                        return kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR;
                     } else {
                         batchHolder->remove(std::move(indexKey));
                     }

--- a/src/storage/mutate/DeleteVerticesProcessor.h
+++ b/src/storage/mutate/DeleteVerticesProcessor.h
@@ -35,10 +35,9 @@ private:
         : BaseProcessor<cpp2::ExecResponse>(env, counters)
         , vertexCache_(cache) {}
 
-    folly::Optional<std::string>
-    deleteVertices(PartitionID partId,
-                   const std::vector<Value>& vertices,
-                   std::vector<VMLI>& target);
+    ErrorOr<kvstore::ResultCode, std::string> deleteVertices(PartitionID partId,
+                                                             const std::vector<Value>& vertices,
+                                                             std::vector<VMLI>& target);
 
 private:
     GraphSpaceID                                                spaceId_;

--- a/src/storage/transaction/TransactionManager.cpp
+++ b/src/storage/transaction/TransactionManager.cpp
@@ -92,8 +92,9 @@ folly::Future<cpp2::ErrorCode> TransactionManager::addSamePartEdges(
                 processor->spaceVidLen_ = vIdLen;
                 std::vector<KV> data{std::make_pair(kv.first, kv.second)};
                 auto optVal = processor->addEdges(localPart, data);
-                if (optVal) {
-                    return std::make_pair(NebulaKeyUtils::toLockKey(kv.first), *optVal);
+                if (nebula::ok(optVal)) {
+                    return std::make_pair(NebulaKeyUtils::toLockKey(kv.first),
+                                          nebula::value(optVal));
                 } else {
                     addEdgeErrorCode = cpp2::ErrorCode::E_ATOMIC_OP_FAILED;
                     return std::make_pair(NebulaKeyUtils::toLockKey(kv.first), std::string(""));
@@ -358,7 +359,12 @@ folly::SemiFuture<kvstore::ResultCode> TransactionManager::commitEdgeOut(GraphSp
 
         auto atomic = [partId, edges = std::move(data), this]() -> folly::Optional<std::string> {
             auto* processor = AddEdgesProcessor::instance(env_);
-            return processor->addEdges(partId, edges);
+            auto ret = processor->addEdges(partId, edges);
+            if (nebula::ok(ret)) {
+                return nebula::value(ret);
+            } else {
+                return folly::Optional<std::string>();
+            }
         };
 
         auto cb = [pro = std::move(c.first)](kvstore::ResultCode rc) mutable {


### PR DESCRIPTION
See https://github.com/vesoft-inc/nebula-storage/runs/2036566131?check_suite_focus=true.

1. fix mem leak
2. replace Optional<string> with ErrorOr<ResultCode, string>, so we could report leader change when read.

We need to unify kvstore and thrift ErrorCode later, it is really a disaster.
Please review carefully, or tell me if there are any better ideas.