### PR TITLE
Fixed crash error for TTL

### DIFF
--- a/src/storage/CommonUtils.cpp
+++ b/src/storage/CommonUtils.cpp
@@ -99,7 +99,10 @@ bool CommonUtils::checkDataExpiredForTTL(const meta::SchemaProviderIf* schema,
     }
     auto now = time::WallClock::fastNowInSec();
     auto v = reader->getValueByName(ttlCol);
-    if (now > (v.getInt() + ttlDuration)) {
+
+    // if the value is not INT type (sush as NULL), it will never expire.
+    // TODO (sky) : DateTime
+    if (v.isInt() && (now > (v.getInt() + ttlDuration))) {
         VLOG(2) << "ttl expired";
         return true;
     }


### PR DESCRIPTION
This problem can occur during the query or compact phase.

**Repeat**
```
CREATE SPACE IF NOT EXISTS test(PARTITION_NUM = 1, REPLICA_FACTOR = 1, vid_type = int64)
use test
create tag t1(c1 int) ttl_duration = 100, ttl_col = "c1"
insert vertex t1(c1) values 1:(NULL)
fetch prop on t1 1
```

**Trace**:
```
[Current thread is 1 (Thread 0x7f583d6fe700 (LWP 525))]
Missing separate debuginfos, use: dnf debuginfo-install glibc-2.29-22.fc30.x86_64
(gdb) bt
#0  0x00007f5874a04e35 in raise () from /usr/lib64/libc.so.6
#1  0x00007f58749ef895 in abort () from /usr/lib64/libc.so.6
#2  0x0000000002bc86de in ?? ()
#3  0x0000000004258e8d in google::LogMessage::Fail() ()
#4  0x000000000425d713 in google::LogMessage::SendToLog() ()
#5  0x0000000004258b8b in google::LogMessage::Flush() ()
#6  0x0000000004259379 in google::LogMessageFatal::~LogMessageFatal() ()
#7  0x0000000003bef8d1 in nebula::Value::getInt (this=0x7f583d6fb190) at /home/bright2star/source/nebula2/nebula-storage/modules/common/src/common/datatypes/Value.cpp:705
#8  0x0000000002eaab67 in nebula::storage::CommonUtils::checkDataExpiredForTTL (schema=0x7f585c544a90, reader=0x7f5838625150, ttlCol=..., ttlDuration=100)
    at /home/bright2star/source/nebula2/nebula-storage/src/storage/CommonUtils.cpp:102
#9  0x0000000002ccb77e in nebula::storage::TagNode::resetReader (this=0x7f5838625000, vId=...) at /home/bright2star/source/nebula2/nebula-storage/src/storage/exec/TagNode.h:117
#10 0x0000000002ccb4b2 in nebula::storage::TagNode::execute (this=0x7f5838625000, partId=1, vId=...) at /home/bright2star/source/nebula2/nebula-storage/src/storage/exec/TagNode.h:71
#11 0x0000000002cd268d in nebula::storage::RelNode<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::execute (this=0x7f583860d0a0, partId=1, 
    input=...) at /home/bright2star/source/nebula2/nebula-storage/src/storage/exec/RelNode.h:38
#12 0x0000000002d36579 in nebula::storage::GetTagPropNode::execute (this=0x7f583860d0a0, partId=1, vId=...)
    at /home/bright2star/source/nebula2/nebula-storage/src/storage/exec/GetPropNode.h:45
#13 0x0000000002cd268d in nebula::storage::RelNode<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::execute (this=0x7f583862a000, partId=1, 
    input=...) at /home/bright2star/source/nebula2/nebula-storage/src/storage/exec/RelNode.h:38
#14 0x0000000002cd42b0 in nebula::storage::StoragePlan<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::go (this=0x7f583d6fb6f0, partId=1, input=...)
    at /home/bright2star/source/nebula2/nebula-storage/src/storage/exec/StoragePlan.h:52
#15 0x0000000002d375b2 in nebula::storage::GetPropProcessor::doProcess (this=0x7f586522c000, req=...)
    at /home/bright2star/source/nebula2/nebula-storage/src/storage/query/GetPropProcessor.cpp:62
```