### PR TITLE
speed up first election

### DIFF
--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -556,6 +556,8 @@ protected:
     uint64_t lastMsgAcceptedCostMs_{0};
     // Make sure only one election is in progress
     std::atomic_bool inElection_{false};
+    // Speed up first election when I don't know who is leader
+    bool isBlindFollower_{true};
 
     // Write-ahead Log
     std::shared_ptr<wal::FileBasedWal> wal_;


### PR DESCRIPTION
The quick path for first election `term_ == 0` is not activated quite long ago. The first election will be triggered after `raft_heartbeat_interval_secs`, by default is 30s in configuration.

Just add it back, once I know who is leader(elected as leader/vote for other/receive valid logs), no more shortcut.