### PR TITLE
Corrected template for listener

### DIFF
--- a/conf/nebula-storaged-listener.conf.production
+++ b/conf/nebula-storaged-listener.conf.production
@@ -39,7 +39,10 @@
 --heartbeat_interval_secs=10
 
 ########## storage ##########
+# Listener wal directory. only one path is allowed.
 --listener_path=data/listener
+# This parameter can be ignored for compatibility. let's fill A default value of "data"
+--data_path=data
 # The type of part manager, [memory | meta]
 --part_man_type=memory
 # The default reserved bytes for one batch operation


### PR DESCRIPTION
This configuration parameter must be specified as a default value for data_path check. this logic will be optimized later in the other PR.

`Log file created at: 2021/03/19 18:40:20
Running on machine: nebula-dev-1
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
E0319 18:40:20.230365 29002 StorageDaemon.cpp:84] Storage Data Path should not empty`