### PR TITLE
Generate log directory, if it does not exist

### DIFF
--- a/conf/nebula-metad.conf.default
+++ b/conf/nebula-metad.conf.default
@@ -5,7 +5,7 @@
 --pid_file=pids/nebula-metad.pid
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/conf/nebula-metad.conf.production
+++ b/conf/nebula-metad.conf.production
@@ -5,7 +5,7 @@
 --pid_file=pids/nebula-metad.pid
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/conf/nebula-storaged-listener.conf.production
+++ b/conf/nebula-storaged-listener.conf.production
@@ -6,7 +6,7 @@
 --pid_file=pids_listener/nebula-storaged.pid
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs_listener
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/conf/nebula-storaged.conf.default
+++ b/conf/nebula-storaged.conf.default
@@ -5,7 +5,7 @@
 --pid_file=pids/nebula-storaged.pid
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/conf/nebula-storaged.conf.production
+++ b/conf/nebula-storaged.conf.production
@@ -5,7 +5,7 @@
 --pid_file=pids/nebula-storaged.pid
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/src/daemons/SetupLogging.cpp
+++ b/src/daemons/SetupLogging.cpp
@@ -6,6 +6,7 @@
 
 #include "common/base/Base.h"
 #include "common/base/Status.h"
+#include "common/fs/FileUtils.h"
 
 DECLARE_string(log_dir);
 
@@ -14,8 +15,17 @@ DEFINE_string(stdout_log_file, "stdout.log", "Destination filename of stdout");
 DEFINE_string(stderr_log_file, "stderr.log", "Destination filename of stderr");
 
 using nebula::Status;
+using nebula::fs::FileUtils;
 
 Status setupLogging() {
+    // If the log directory does not exist, try to create
+    if (!FileUtils::exist(FLAGS_log_dir)) {
+        if (!FileUtils::makeDir(FLAGS_log_dir)) {
+            return Status::Error(
+                "Failed to create log directory `%s'", FLAGS_log_dir.c_str());
+        }
+    }
+
     if (!FLAGS_redirect_stdout) {
         return Status::OK();
     }


### PR DESCRIPTION
As title

When we start the service with the following script, the log directory will be created in the script.
` ./scripts/nebula.service -c  xxx/etc/nebula-storaged.conf start storaged> /dev/null 2>&1 &`

But when we start the service in other ways, because the directory log does not exist, the startup fails.
`xxx/bin/nebula-storaged --flagfile xxx/etc/nebula-storaged-1.conf >1.log 2 >&1 &`

Therefore, before starting the service, the log directory needs to be created automatically when it does not exist.