### PR TITLE
fix index data loss when insert data during rebuilding index

### DIFF
--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -109,6 +109,23 @@ public:
         count_->fetch_add(1, std::memory_order_release);
     }
 
+    IndexCountWrapper(const IndexCountWrapper&) = delete;
+
+    IndexCountWrapper(IndexCountWrapper&& icw) noexcept
+        : count_(icw.count_) {
+        count_->fetch_add(1, std::memory_order_release);
+    }
+
+    IndexCountWrapper& operator=(const IndexCountWrapper&) = delete;
+
+    IndexCountWrapper& operator=(IndexCountWrapper&& icw) noexcept {
+        if (this != &icw) {
+            count_ = icw.count_;
+            count_->fetch_add(1, std::memory_order_release);
+        }
+        return *this;
+    }
+
     ~IndexCountWrapper() {
         count_->fetch_sub(1, std::memory_order_release);
     }

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -461,9 +461,9 @@ public:
     kvstore::ResultCode execute(PartitionID partId, const cpp2::EdgeKey& edgeKey) override {
         CHECK_NOTNULL(planContext_->env_->kvstore_);
         auto ret = kvstore::ResultCode::SUCCEEDED;
-        // folly::Function<folly::Optional<std::string>(void)>
+        IndexCountWrapper wrapper(planContext_->env_);
+
         auto op = [&partId, &edgeKey, this]() -> folly::Optional<std::string> {
-            IndexCountWrapper wrapper(planContext_->env_);
             this->exeResult_ = RelNode::execute(partId, edgeKey);
             if (this->exeResult_ == kvstore::ResultCode::SUCCEEDED) {
                 if (edgeKey.edge_type != this->edgeType_) {

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -268,9 +268,9 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
             continue;
         }
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
-            [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode kvRet) {
+            [l = std::move(lg), icw = std::move(wrapper), partId, this](kvstore::ResultCode kvRet) {
                 UNUSED(l);
-                UNUSED(wrapper);
+                UNUSED(icw);
                 handleAsync(spaceId_, partId, kvRet);
             });
     }

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -128,6 +128,7 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
         std::vector<EMLI> dummyLock;
         dummyLock.reserve(newEdges.size());
         cpp2::ErrorCode code = cpp2::ErrorCode::SUCCEEDED;
+
         for (auto& newEdge : newEdges) {
             auto edgeKey = newEdge.key;
             VLOG(3) << "PartitionID: " << partId << ", VertexID: " << edgeKey.src
@@ -267,8 +268,9 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
             continue;
         }
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
-            [l = std::move(lg), partId, this](kvstore::ResultCode kvRet) {
+            [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode kvRet) {
                 UNUSED(l);
+                UNUSED(wrapper);
                 handleAsync(spaceId_, partId, kvRet);
             });
     }

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -135,6 +135,7 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
         std::vector<VMLI> dummyLock;
         dummyLock.reserve(vertices.size());
         cpp2::ErrorCode code = cpp2::ErrorCode::SUCCEEDED;
+
         for (auto& vertex : vertices) {
             auto vid = vertex.get_id().getStr();
             const auto& newTags = vertex.get_tags();
@@ -278,8 +279,9 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
             continue;
         }
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
-            [l = std::move(lg), partId, this](kvstore::ResultCode kvRet) {
+            [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode kvRet) {
                 UNUSED(l);
+                UNUSED(wrapper);
                 handleAsync(spaceId_, partId, kvRet);
             });
     }

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -279,9 +279,9 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
             continue;
         }
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
-            [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode kvRet) {
+            [l = std::move(lg), icw = std::move(wrapper), partId, this](kvstore::ResultCode kvRet) {
                 UNUSED(l);
-                UNUSED(wrapper);
+                UNUSED(icw);
                 handleAsync(spaceId_, partId, kvRet);
             });
     }

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -111,9 +111,10 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
                 continue;
             }
             env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(nebula::value(batch)),
-                [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode code) {
+                [l = std::move(lg), icw = std::move(wrapper), partId, this] (
+                    kvstore::ResultCode code) {
                     UNUSED(l);
-                    UNUSED(wrapper);
+                    UNUSED(icw);
                     handleAsync(spaceId_, partId, code);
                 });
         }

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -78,9 +78,11 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
         }
     } else {
         for (auto& part : partEdges) {
+            IndexCountWrapper wrapper(env_);
             auto partId = part.first;
             std::vector<EMLI> dummyLock;
             dummyLock.reserve(part.second.size());
+
             for (const auto& edgeKey : part.second) {
                 dummyLock.emplace_back(std::make_tuple(spaceId_,
                                                        partId,
@@ -109,8 +111,9 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
                 continue;
             }
             env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(nebula::value(batch)),
-                [l = std::move(lg), partId, this](kvstore::ResultCode code) {
+                [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode code) {
                     UNUSED(l);
+                    UNUSED(wrapper);
                     handleAsync(spaceId_, partId, code);
                 });
         }
@@ -120,7 +123,6 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
 
 ErrorOr<kvstore::ResultCode, std::string>
 DeleteEdgesProcessor::deleteEdges(PartitionID partId, const std::vector<cpp2::EdgeKey>& edges) {
-    IndexCountWrapper wrapper(env_);
     std::unique_ptr<kvstore::BatchHolder> batchHolder = std::make_unique<kvstore::BatchHolder>();
     for (auto& edge : edges) {
         auto type = edge.edge_type;

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -113,9 +113,10 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
                 continue;
             }
             env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(nebula::value(batch)),
-                [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode code) {
+                [l = std::move(lg), icw = std::move(wrapper), partId, this] (
+                    kvstore::ResultCode code) {
                     UNUSED(l);
-                    UNUSED(wrapper);
+                    UNUSED(icw);
                     handleAsync(spaceId_, partId, code);
                 });
         }

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -92,6 +92,7 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
         }
     } else {
         for (auto& pv : partVertices) {
+            IndexCountWrapper wrapper(env_);
             auto partId = pv.first;
             std::vector<VMLI> dummyLock;
             auto batch = deleteVertices(partId, std::move(pv).second, dummyLock);
@@ -112,8 +113,9 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
                 continue;
             }
             env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(nebula::value(batch)),
-                [l = std::move(lg), partId, this](kvstore::ResultCode code) {
+                [l = std::move(lg), &wrapper, partId, this](kvstore::ResultCode code) {
                     UNUSED(l);
+                    UNUSED(wrapper);
                     handleAsync(spaceId_, partId, code);
                 });
         }
@@ -125,7 +127,6 @@ ErrorOr<kvstore::ResultCode, std::string>
 DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                                         const std::vector<Value>& vertices,
                                         std::vector<VMLI>& target) {
-    IndexCountWrapper wrapper(env_);
     target.reserve(vertices.size());
     std::unique_ptr<kvstore::BatchHolder> batchHolder = std::make_unique<kvstore::BatchHolder>();
     for (auto& vertex : vertices) {


### PR DESCRIPTION
As title.

The steps are as follows:
1) If the index status of the specified space specified part is the building state at this time
In `AddVerticesProcessor::doProcessWithIndex`, the old index data to be deleted and the new index data added are organized into a vector, ready to be added to the operation table.

2) Because `AddVerticesProcessor::doProcessWithIndex` writes vector data into the operation table asynchronously. Release `env_->onFlyingRequest` in `IndexCountWrapper wrapper` before writing.

3) In `RebuildIndexTask::buildIndexOnOperations`, if it is judged that `env_->onFlyingRequest `is 0, it is assumed that the operation table data has been processed, and the rebuild part is completed.

4) At this time, step 2 writes the data into the operation table. At this time, the data written into the part in the operation table will always be invalid, because the data will never be processed.

So this part of the index data is lost.

Thanks chaos for discovering this problem.
