### PR TITLE
Fix core issue: for a new host with no partition, can't find it from …

### DIFF
--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -535,7 +535,11 @@ bool Balancer::assembleZoneParts(const std::string& groupName, HostParts& hostPa
         auto name = zoneIter->first.second;
         for (auto hostIter = hosts.begin(); hostIter != hosts.end(); hostIter++) {
             auto partIter = hostParts.find(*hostIter);
-            zoneParts_[it->first] = ZoneNameAndParts(name, partIter->second);
+            if (partIter == hostParts.end()) {
+                zoneParts_[it->first] = ZoneNameAndParts(name, std::vector<PartitionID>());
+            } else {
+                zoneParts_[it->first] = ZoneNameAndParts(name, partIter->second);
+            }
         }
     }
     return true;
@@ -985,7 +989,11 @@ bool Balancer::collectZoneParts(const std::string& groupName,
         auto name = zoneIter->first.second;
         for (auto hostIter = hosts.begin(); hostIter != hosts.end(); hostIter++) {
             auto partIter = hostParts.find(*hostIter);
-            zoneParts_[it->first] = ZoneNameAndParts(name, partIter->second);
+            if (partIter == hostParts.end()) {
+                zoneParts_[it->first] = ZoneNameAndParts(name, std::vector<PartitionID>());
+            } else {
+                zoneParts_[it->first] = ZoneNameAndParts(name, partIter->second);
+            }
         }
     }
     return true;


### PR DESCRIPTION
…hostParts.

Find a core issue, steps to reproduce this issue.
1. create a space on group_0, which contains(zone_0, zone_1, zone_2)
1. Add a new host（127.0.0.1:6778） to zone_0
2. run balance data

as （127.0.0.1:6778）host no part, and can't find it in hostParts, nebula-metad will core at following line:
 zoneParts_[it->first] = ZoneNameAndParts(name, partIter->second);