### PR TITLE
restore update atomic operation

### DIFF
--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -167,10 +167,24 @@ public:
 
     kvstore::ResultCode execute(PartitionID partId, const VertexID& vId) override {
         CHECK_NOTNULL(planContext_->env_->kvstore_);
-        auto ret = kvstore::ResultCode::SUCCEEDED;
         IndexCountWrapper wrapper(planContext_->env_);
-        ret = RelNode::execute(partId, vId);
 
+        // Update is read-modify-write, which is an atomic operation.
+        std::vector<VMLI> dummyLock = {std::make_tuple(planContext_->spaceId_,
+                                                       partId, tagId_, vId)};
+        nebula::MemoryLockGuard<VMLI> lg(planContext_->env_->verticesML_.get(),
+                                         std::move(dummyLock));
+        if (!lg) {
+            auto conflict = lg.conflictKey();
+            LOG(ERROR) << "vertex conflict "
+                       << std::get<0>(conflict) << ":"
+                       << std::get<1>(conflict) << ":"
+                       << std::get<2>(conflict) << ":"
+                       << std::get<3>(conflict);
+            return kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR;
+        }
+
+        auto ret = RelNode::execute(partId, vId);
         if (ret != kvstore::ResultCode::SUCCEEDED) {
             return ret;
         }
@@ -203,20 +217,6 @@ public:
         auto batch = this->updateAndWriteBack(partId, vId);
         if (batch == folly::none) {
             return kvstore::ResultCode::ERR_INVALID_DATA;
-        }
-
-        std::vector<VMLI> dummyLock = {std::make_tuple(planContext_->spaceId_,
-                                                       partId, tagId_, vId)};
-        nebula::MemoryLockGuard<VMLI> lg(planContext_->env_->verticesML_.get(),
-                                         std::move(dummyLock));
-        if (!lg) {
-            auto conflict = lg.conflictKey();
-            LOG(ERROR) << "vertex conflict "
-                       << std::get<0>(conflict) << ":"
-                       << std::get<1>(conflict) << ":"
-                       << std::get<2>(conflict) << ":"
-                       << std::get<3>(conflict);
-            return kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR;
         }
 
         folly::Baton<true, std::atomic> baton;
@@ -463,6 +463,29 @@ public:
         auto ret = kvstore::ResultCode::SUCCEEDED;
         IndexCountWrapper wrapper(planContext_->env_);
 
+        // Update is read-modify-write, which is an atomic operation.
+        std::vector<EMLI> dummyLock = {
+            std::make_tuple(planContext_->spaceId_,
+                            partId,
+                            edgeKey.get_src().getStr(),
+                            edgeKey.get_edge_type(),
+                            edgeKey.get_ranking(),
+                            edgeKey.get_dst().getStr())
+        };
+        nebula::MemoryLockGuard<EMLI> lg(planContext_->env_->edgesML_.get(),
+                                         std::move(dummyLock));
+        if (!lg) {
+            auto conflict = lg.conflictKey();
+            LOG(ERROR) << "edge conflict "
+                       << std::get<0>(conflict) << ":"
+                       << std::get<1>(conflict) << ":"
+                       << std::get<2>(conflict) << ":"
+                       << std::get<3>(conflict) << ":"
+                       << std::get<4>(conflict) << ":"
+                       << std::get<5>(conflict);
+            return kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR;
+        }
+
         auto op = [&partId, &edgeKey, this]() -> folly::Optional<std::string> {
             this->exeResult_ = RelNode::execute(partId, edgeKey);
             if (this->exeResult_ == kvstore::ResultCode::SUCCEEDED) {
@@ -520,32 +543,13 @@ public:
             if (batch == folly::none) {
                 return this->exeResult_;
             }
-            std::vector<EMLI> dummyLock = {
-                std::make_tuple(planContext_->spaceId_, partId,
-                        edgeKey.get_src().getStr(),
-                        edgeKey.get_edge_type(),
-                        edgeKey.get_ranking(),
-                        edgeKey.get_dst().getStr()
-                        )
-            };
-            nebula::MemoryLockGuard<EMLI> lg(planContext_->env_->edgesML_.get(),
-                                             std::move(dummyLock));
-            if (!lg) {
-                auto conflict = lg.conflictKey();
-                LOG(ERROR) << "edge conflict "
-                           << std::get<0>(conflict) << ":"
-                           << std::get<1>(conflict) << ":"
-                           << std::get<2>(conflict) << ":"
-                           << std::get<3>(conflict) << ":"
-                           << std::get<4>(conflict) << ":"
-                           << std::get<5>(conflict);
-                return kvstore::ResultCode::ERR_DATA_CONFLICT_ERROR;
-            }
+
             folly::Baton<true, std::atomic> baton;
             auto callback = [&ret, &baton] (kvstore::ResultCode code) {
                 ret = code;
                 baton.post();
             };
+
             planContext_->env_->kvstore_->asyncAppendBatch(
                 planContext_->spaceId_, partId, std::move(batch).value(), callback);
             baton.wait();


### PR DESCRIPTION
update is read-modify-write, which is an atomic operation.
 pr https://github.com/vesoft-inc/nebula-storage/pull/355 change update operation into a non-atomic operation.
The result of the current update is unstable.

According to the logic before this modification, the following case:
```
create tag course(credits int);
insert vertex course(credits) VALUES "200":(1);
```
Then the two clients are executed separately
```
UPSERT VERTEX "200" SET course.credits = 2 WHEN $^.course.credits == 1 YIELD $^.course.credits;
UPSERT VERTEX "200" SET course.credits = 3 WHEN $^.course.credits == 1 YIELD $^.course.credits;
```
The second update statement may be executed successfully or failed.

The expectations are:
The execution of the second update statement failed.