### PR TITLE
Fix cleanWAL block raft heartbeat

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -39,6 +39,8 @@ NebulaStore::~NebulaStore() {
     spaceListeners_.clear();
     bgWorkers_->stop();
     bgWorkers_->wait();
+    cleanWalWorker_->stop();
+    cleanWalWorker_->wait();
     LOG(INFO) << "~NebulaStore()";
 }
 
@@ -46,6 +48,8 @@ bool NebulaStore::init() {
     LOG(INFO) << "Start the raft service...";
     bgWorkers_ = std::make_shared<thread::GenericThreadPool>();
     bgWorkers_->start(FLAGS_num_workers, "nebula-bgworkers");
+    cleanWalWorker_ = std::make_shared<thread::GenericWorker>();
+    CHECK(cleanWalWorker_->start());
     snapshot_.reset(new SnapshotManagerImpl(this));
     raftService_ = raftex::RaftexService::createService(ioPool_,
                                                         workers_,
@@ -63,7 +67,8 @@ bool NebulaStore::init() {
         loadLocalListenerFromPartManager();
     }
 
-    bgWorkers_->addDelayTask(FLAGS_clean_wal_interval_secs * 1000, &NebulaStore::cleanWAL, this);
+    cleanWalWorker_->addDelayTask(
+        FLAGS_clean_wal_interval_secs * 1000, &NebulaStore::cleanWAL, this);
     LOG(INFO) << "Register handler...";
     options_.partMan_->registerHandler(this);
     return true;
@@ -1030,10 +1035,11 @@ bool NebulaStore::checkLeader(std::shared_ptr<Part> part, bool canReadFromFollow
 }
 
 void NebulaStore::cleanWAL() {
+    folly::RWSpinLock::ReadHolder rh(&lock_);
     SCOPE_EXIT {
-        bgWorkers_->addDelayTask(FLAGS_clean_wal_interval_secs * 1000,
-                                 &NebulaStore::cleanWAL,
-                                 this);
+        cleanWalWorker_->addDelayTask(FLAGS_clean_wal_interval_secs * 1000,
+                                      &NebulaStore::cleanWAL,
+                                      this);
     };
     for (const auto& spaceEntry : spaces_) {
         if (FLAGS_rocksdb_disable_wal) {

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -318,6 +318,7 @@ private:
     std::unordered_map<GraphSpaceID, std::shared_ptr<SpaceListenerInfo>> spaceListeners_;
 
     std::shared_ptr<folly::IOThreadPoolExecutor> ioPool_;
+    std::shared_ptr<thread::GenericWorker> cleanWalWorker_;
     std::shared_ptr<thread::GenericThreadPool> bgWorkers_;
     HostAddr storeSvcAddr_;
     std::shared_ptr<folly::Executor> workers_;

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -32,7 +32,6 @@ DEFINE_bool(trace_raft, false, "Enable trace one raft request");
 DECLARE_int32(wal_ttl);
 DECLARE_int64(wal_file_size);
 DECLARE_int32(wal_buffer_size);
-DECLARE_int32(wal_buffer_num);
 DECLARE_bool(wal_sync);
 
 namespace nebula {
@@ -227,7 +226,6 @@ RaftPart::RaftPart(
     FileBasedWalPolicy policy;
     policy.fileSize = FLAGS_wal_file_size;
     policy.bufferSize = FLAGS_wal_buffer_size;
-    policy.numBuffers = FLAGS_wal_buffer_num;
     policy.sync = FLAGS_wal_sync;
     wal_ = FileBasedWal::getWal(walRoot,
                                 idStr_,

--- a/src/kvstore/raftex/RaftexService.cpp
+++ b/src/kvstore/raftex/RaftexService.cpp
@@ -178,8 +178,8 @@ std::shared_ptr<RaftPart> RaftexService::findPart(
     auto it = parts_.find(std::make_pair(spaceId, partId));
     if (it == parts_.end()) {
         // Part not found
-        LOG(WARNING) << "Cannot find the part " << partId
-                     << " in the graph space " << spaceId;
+        LOG_EVERY_N(WARNING, 100) << "Cannot find the part " << partId
+                                  << " in the graph space " << spaceId;
         return std::shared_ptr<RaftPart>();
     }
 

--- a/src/kvstore/raftex/test/SnapshotTest.cpp
+++ b/src/kvstore/raftex/test/SnapshotTest.cpp
@@ -29,7 +29,6 @@ TEST(SnapshotTest, LearnerCatchUpDataTest) {
     fs::TempDir walRoot("/tmp/catch_up_data.XXXXXX");
     FLAGS_wal_file_size = 1024;
     FLAGS_wal_buffer_size = 512;
-    FLAGS_wal_buffer_num = 30;
     FLAGS_raft_rpc_timeout_ms = 2000;
     std::shared_ptr<thread::GenericThreadPool> workers;
     std::vector<std::string> wals;

--- a/src/kvstore/wal/FileBasedWal.h
+++ b/src/kvstore/wal/FileBasedWal.h
@@ -26,9 +26,6 @@ struct FileBasedWalPolicy {
     // Size of each buffer (in byte)
     size_t bufferSize = 8 * 1024L * 1024L;
 
-    // Number of buffers allowed. When the number of buffers reach this
-    // number, appendLogs() will be blocked until some buffers are flushed
-    size_t numBuffers = 2;
     // Whether fsync needs to be called every write
     bool sync = false;
 };
@@ -169,8 +166,6 @@ private:
     std::atomic<bool> stopped_{false};
 
     const FileBasedWalPolicy policy_;
-    const size_t maxFileSize_;
-    const size_t maxBufferSize_;
     LogID firstLogId_{0};
     LogID lastLogId_{0};
     TermID lastLogTerm_{0};

--- a/src/kvstore/wal/test/FileBasedWalTest.cpp
+++ b/src/kvstore/wal/test/FileBasedWalTest.cpp
@@ -85,7 +85,6 @@ TEST(FileBasedWal, CacheOverflow) {
     FileBasedWalPolicy policy;
     policy.fileSize = 1024L * 1024L;
     policy.bufferSize = 1024L * 1024L;
-    policy.numBuffers = 2;
 
     TempDir walDir("/tmp/testWal.XXXXXX");
     auto wal = FileBasedWal::getWal(walDir.path(),
@@ -138,7 +137,6 @@ TEST(FileBasedWal, Rollback) {
     FileBasedWalPolicy policy;
     policy.fileSize = 1024L * 1024L;
     policy.bufferSize = 1024L * 1024L;
-    policy.numBuffers = 2;
 
     TempDir walDir("/tmp/testWal.XXXXXX");
     auto wal = FileBasedWal::getWal(walDir.path(),
@@ -216,7 +214,6 @@ TEST(FileBasedWal, RollbackThenReopen) {
     FileBasedWalPolicy policy;
     policy.fileSize = 1024L * 1024L;
     policy.bufferSize = 1024L * 1024L;
-    policy.numBuffers = 2;
 
     TempDir walDir("/tmp/testWal.XXXXXX");
     auto wal = FileBasedWal::getWal(walDir.path(),
@@ -271,7 +268,6 @@ TEST(FileBasedWal, RollbackToZero) {
     FileBasedWalPolicy policy;
     policy.fileSize = 1024L * 1024L;
     policy.bufferSize = 1024L * 1024L;
-    policy.numBuffers = 2;
 
     TempDir walDir("/tmp/testWal.XXXXXX");
     auto wal = FileBasedWal::getWal(walDir.path(),
@@ -313,7 +309,6 @@ TEST(FileBasedWal, BackAndForth) {
     FileBasedWalPolicy policy;
     policy.fileSize = 1024L * 1024L;
     policy.bufferSize = 1024L * 1024L;
-    policy.numBuffers = 2;
 
     TempDir walDir("/tmp/testWal.XXXXXX");
     auto wal = FileBasedWal::getWal(walDir.path(),
@@ -358,7 +353,6 @@ TEST(FileBasedWal, TTLTest) {
     FileBasedWalPolicy policy;
     policy.bufferSize = 128;
     policy.fileSize = 1024;
-    policy.numBuffers = 30;
     auto wal = FileBasedWal::getWal(walDir.path(),
                                     "",
                                     policy,

--- a/src/utils/OperationKeyUtils.cpp
+++ b/src/utils/OperationKeyUtils.cpp
@@ -12,7 +12,7 @@ namespace nebula {
 // static
 std::string OperationKeyUtils::modifyOperationKey(PartitionID part, const std::string& key) {
     uint32_t item = (part << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kOperation);
-    int64_t ts = time::WallClock::fastNowInMicroSec();
+    int64_t ts = folly::Endian::big(time::WallClock::fastNowInMicroSec());
     uint32_t type = static_cast<uint32_t>(NebulaOperationType::kModify);
     int32_t keySize = key.size();
     std::string result;
@@ -27,7 +27,7 @@ std::string OperationKeyUtils::modifyOperationKey(PartitionID part, const std::s
 // static
 std::string OperationKeyUtils::deleteOperationKey(PartitionID part) {
     uint32_t item = (part << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kOperation);
-    int64_t ts = time::WallClock::fastNowInMicroSec();
+    int64_t ts = folly::Endian::big(time::WallClock::fastNowInMicroSec());
     uint32_t type = static_cast<uint32_t>(NebulaOperationType::kDelete);
     std::string result;
     result.reserve(sizeof(int32_t) + sizeof(int64_t) + sizeof(NebulaOperationType));


### PR DESCRIPTION
Sad story. After long time writing data, there will be plenty of wals, and `NebulaStore::cleanWAL` will take way more time (> 10s), which will block raft heartbeat because they share the same worker. So in this PR:
1. separate background worker thread.
2. clean some unused wal parameters in 2.0
3. fix endian in rebuild index