### PR TITLE
Raft heartbeat process in event base

### DIFF
--- a/src/kvstore/KVEngine.h
+++ b/src/kvstore/KVEngine.h
@@ -47,10 +47,10 @@ public:
 
     virtual std::unique_ptr<WriteBatch> startBatchWrite() = 0;
 
-    virtual nebula::cpp2::ErrorCode
-    commitBatchWrite(std::unique_ptr<WriteBatch> batch,
-                     bool disableWAL = true,
-                     bool sync = false) = 0;
+    virtual nebula::cpp2::ErrorCode commitBatchWrite(std::unique_ptr<WriteBatch> batch,
+                                                     bool disableWAL,
+                                                     bool sync,
+                                                     bool wait) = 0;
 
     // Read a single key
     virtual nebula::cpp2::ErrorCode get(const std::string& key, std::string* value) = 0;

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -113,7 +113,7 @@ bool Listener::preProcessLog(LogID logId,
     return true;
 }
 
-bool Listener::commitLogs(std::unique_ptr<LogIterator> iter) {
+cpp2::ErrorCode Listener::commitLogs(std::unique_ptr<LogIterator> iter, bool) {
     LogID lastId = -1;
     while (iter->valid()) {
         lastId = iter->logId();
@@ -122,7 +122,7 @@ bool Listener::commitLogs(std::unique_ptr<LogIterator> iter) {
     if (lastId > 0) {
         leaderCommitId_ = lastId;
     }
-    return true;
+    return cpp2::ErrorCode::SUCCEEDED;
 }
 
 void Listener::doApply() {

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -52,7 +52,7 @@ derived class.
 
     // For listener, we just return true directly. Another background thread trigger the actual
     // apply work, and do it in worker thread, and update lastApplyLogId_
-    bool commitLogs(std::unique_ptr<LogIterator> iter)
+    cpp2::Errorcode commitLogs(std::unique_ptr<LogIterator> iter, bool)
 
     // For most of the listeners, just return true is enough. However, if listener need to be aware
     // of membership change, some log type of wal need to be pre-processed, could do it here.
@@ -154,7 +154,7 @@ protected:
 
     // For listener, we just return true directly. Another background thread trigger the actual
     // apply work, and do it in worker thread, and update lastApplyLogId_
-    bool commitLogs(std::unique_ptr<LogIterator>) override;
+    cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator>, bool) override;
 
     // For most of the listeners, just return true is enough. However, if listener need to be aware
     // of membership change, some log type of wal need to be pre-processed, could do it here.

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -533,15 +533,17 @@ void NebulaStore::checkRemoteListeners(GraphSpaceID spaceId,
 void NebulaStore::updateSpaceOption(GraphSpaceID spaceId,
                                     const std::unordered_map<std::string, std::string>& options,
                                     bool isDbOption) {
-    if (isDbOption) {
-        for (const auto& kv : options) {
-            setDBOption(spaceId, kv.first, kv.second);
+    storeWorker_->addTask([this, spaceId, opts = options, isDbOption] {
+        if (isDbOption) {
+            for (const auto& kv : opts) {
+                setDBOption(spaceId, kv.first, kv.second);
+            }
+        } else {
+            for (const auto& kv : opts) {
+                setOption(spaceId, kv.first, kv.second);
+            }
         }
-    } else {
-        for (const auto& kv : options) {
-            setOption(spaceId, kv.first, kv.second);
-        }
-    }
+    });
 }
 
 void NebulaStore::removeSpaceDir(const std::string& dir) {

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -195,7 +195,7 @@ void Part::onDiscoverNewLeader(HostAddr nLeader) {
     }
 }
 
-bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
+cpp2::ErrorCode Part::commitLogs(std::unique_ptr<LogIterator> iter, bool wait) {
     auto batch = engine_->startBatchWrite();
     LogID lastId = -1;
     TermID lastTerm = -1;
@@ -214,9 +214,10 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
         case OP_PUT: {
             auto pieces = decodeMultiValues(log);
             DCHECK_EQ(2, pieces.size());
-            if (batch->put(pieces[0], pieces[1]) != nebula::cpp2::ErrorCode::SUCCEEDED) {
+            auto code = batch->put(pieces[0], pieces[1]);
+            if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
                 LOG(ERROR) << idStr_ << "Failed to call WriteBatch::put()";
-                return false;
+                return code;
             }
             break;
         }
@@ -225,27 +226,30 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
             // Make the number of values are an even number
             DCHECK_EQ((kvs.size() + 1) / 2, kvs.size() / 2);
             for (size_t i = 0; i < kvs.size(); i += 2) {
-                if (batch->put(kvs[i], kvs[i + 1]) != nebula::cpp2::ErrorCode::SUCCEEDED) {
+                auto code = batch->put(kvs[i], kvs[i + 1]);
+                if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
                     LOG(ERROR) << idStr_ << "Failed to call WriteBatch::put()";
-                    return false;
+                    return code;
                 }
             }
             break;
         }
         case OP_REMOVE: {
             auto key = decodeSingleValue(log);
-            if (batch->remove(key) != nebula::cpp2::ErrorCode::SUCCEEDED) {
+            auto code = batch->remove(key);
+            if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
                 LOG(ERROR) << idStr_ << "Failed to call WriteBatch::remove()";
-                return false;
+                return code;
             }
             break;
         }
         case OP_MULTI_REMOVE: {
             auto keys = decodeMultiValues(log);
             for (auto k : keys) {
-                if (batch->remove(k) != nebula::cpp2::ErrorCode::SUCCEEDED) {
+                auto code = batch->remove(k);
+                if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
                     LOG(ERROR) << idStr_ << "Failed to call WriteBatch::remove()";
-                    return false;
+                    return code;
                 }
             }
             break;
@@ -253,9 +257,10 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
         case OP_REMOVE_RANGE: {
             auto range = decodeMultiValues(log);
             DCHECK_EQ(2, range.size());
-            if (batch->removeRange(range[0], range[1]) != nebula::cpp2::ErrorCode::SUCCEEDED) {
+            auto code = batch->removeRange(range[0], range[1]);
+            if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
                 LOG(ERROR) << idStr_ << "Failed to call WriteBatch::removeRange()";
-                return false;
+                return code;
             }
             break;
         }
@@ -272,7 +277,7 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
                 }
                 if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
                     LOG(ERROR) << idStr_ << "Failed to call WriteBatch";
-                    return false;
+                    return code;
                 }
             }
             break;
@@ -314,14 +319,14 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
     }
 
     if (lastId >= 0) {
-        if (putCommitMsg(batch.get(), lastId, lastTerm) != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        auto code = putCommitMsg(batch.get(), lastId, lastTerm);
+        if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
             LOG(ERROR) << idStr_ << "Commit msg failed";
-            return false;
+            return code;
         }
     }
-    return engine_->commitBatchWrite(std::move(batch),
-                                     FLAGS_rocksdb_disable_wal,
-                                     FLAGS_rocksdb_wal_sync) == nebula::cpp2::ErrorCode::SUCCEEDED;
+    return engine_->commitBatchWrite(
+        std::move(batch), FLAGS_rocksdb_disable_wal, FLAGS_rocksdb_wal_sync, wait);
 }
 
 std::pair<int64_t, int64_t> Part::commitSnapshot(const std::vector<std::string>& rows,
@@ -348,7 +353,9 @@ std::pair<int64_t, int64_t> Part::commitSnapshot(const std::vector<std::string>&
         }
     }
     // For snapshot, we open the rocksdb's wal to avoid loss data if crash.
-    if (nebula::cpp2::ErrorCode::SUCCEEDED != engine_->commitBatchWrite(std::move(batch), false)) {
+    auto code = engine_->commitBatchWrite(
+        std::move(batch), FLAGS_rocksdb_disable_wal, FLAGS_rocksdb_wal_sync, true);
+    if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
         LOG(ERROR) << idStr_ << "Put failed in commit";
         return std::make_pair(0, 0);
     }
@@ -431,6 +438,16 @@ bool Part::preProcessLog(LogID logId,
         }
     }
     return true;
+}
+
+void Part::cleanup() {
+    LOG(INFO) << idStr_ << "Clean rocksdb commit key";
+    auto res = engine_->remove(NebulaKeyUtils::systemCommitKey(partId_));
+    if (res != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        LOG(WARNING) << idStr_ << "Remove the committedLogId failed, error "
+                     << static_cast<int32_t>(res);
+    }
+    return;
 }
 
 // TODO(pandasheep) unify raft errorcode

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -462,7 +462,6 @@ nebula::cpp2::ErrorCode Part::toResultCode(raftex::AppendLogResult res) {
         case raftex::AppendLogResult::E_ATOMIC_OP_FAILURE:
             return nebula::cpp2::ErrorCode::E_ATOMIC_OP_FAILED;
         case raftex::AppendLogResult::E_BUFFER_OVERFLOW:
-            LOG_EVERY_N(ERROR, 100) << idStr_ << "RaftPart buffer is full";
             return nebula::cpp2::ErrorCode::E_CONSENSUS_ERROR;
         default:
             LOG(ERROR) << idStr_ << "Consensus error "

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -95,7 +95,7 @@ private:
 
     void onDiscoverNewLeader(HostAddr nLeader) override;
 
-    bool commitLogs(std::unique_ptr<LogIterator> iter) override;
+    cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) override;
 
     bool preProcessLog(LogID logId,
                        TermID termId,
@@ -110,15 +110,7 @@ private:
     nebula::cpp2::ErrorCode
     putCommitMsg(WriteBatch* batch, LogID committedLogId, TermID committedLogTerm);
 
-    void cleanup() override {
-        LOG(INFO) << idStr_ << "Clean rocksdb commit key";
-        auto res = engine_->remove(NebulaKeyUtils::systemCommitKey(partId_));
-        if (res != nebula::cpp2::ErrorCode::SUCCEEDED) {
-            LOG(WARNING) << idStr_ << "Remove the committedLogId failed, error "
-                         << static_cast<int32_t>(res);
-        }
-        return;
-    }
+    void cleanup() override;
 
     nebula::cpp2::ErrorCode toResultCode(raftex::AppendLogResult res);
 

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -137,14 +137,18 @@ std::unique_ptr<WriteBatch> RocksEngine::startBatchWrite() {
 nebula::cpp2::ErrorCode
 RocksEngine::commitBatchWrite(std::unique_ptr<WriteBatch> batch,
                               bool disableWAL,
-                              bool sync) {
+                              bool sync,
+                              bool wait) {
     rocksdb::WriteOptions options;
     options.disableWAL = disableWAL;
     options.sync = sync;
+    options.no_slowdown = !wait;
     auto* b = static_cast<RocksWriteBatch*>(batch.get());
     rocksdb::Status status = db_->Write(options, b->data());
     if (status.ok()) {
         return nebula::cpp2::ErrorCode::SUCCEEDED;
+    } else if (!wait && status.IsIncomplete()) {
+        return nebula::cpp2::ErrorCode::E_WRITE_STALLED;
     }
     LOG(ERROR) << "Write into rocksdb failed because of " << status.ToString();
     return nebula::cpp2::ErrorCode::E_UNKNOWN;

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -115,7 +115,8 @@ public:
     nebula::cpp2::ErrorCode
     commitBatchWrite(std::unique_ptr<WriteBatch> batch,
                      bool disableWAL,
-                     bool sync) override;
+                     bool sync,
+                     bool wait) override;
 
     /*********************
      * Data retrieval

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -508,6 +508,7 @@ folly::Future<cpp2::HeartbeatResponse> Host::sendHeartbeat(folly::EventBase* eb,
     req->set_last_log_term_sent(lastLogTerm);
     req->set_last_log_id_sent(lastLogId);
     folly::Promise<cpp2::HeartbeatResponse> promise;
+    auto future = promise.getFuture();
     sendHeartbeatRequest(eb, std::move(req))
         .via(eb)
         .then([self = shared_from_this(), pro = std::move(promise)]
@@ -522,7 +523,7 @@ folly::Future<cpp2::HeartbeatResponse> Host::sendHeartbeat(folly::EventBase* eb,
                 pro.setValue(std::move(t.value()));
             }
         });
-    return promise.getFuture();
+    return future;
 }
 
 folly::Future<cpp2::HeartbeatResponse> Host::sendHeartbeatRequest(

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -88,6 +88,14 @@ public:
         TermID lastLogTermSent,     // The last log term being sent
         LogID lastLogIdSent);       // The last log id being sent
 
+    folly::Future<cpp2::HeartbeatResponse> sendHeartbeat(
+        folly::EventBase* eb,
+        TermID term,
+        LogID latestLogId,
+        LogID commitLogId,
+        TermID lastLogTerm,
+        LogID lastLogId);
+
     const HostAddr& address() const {
         return addr_;
     }
@@ -102,6 +110,10 @@ private:
     void appendLogsInternal(
         folly::EventBase* eb,
         std::shared_ptr<cpp2::AppendLogRequest> req);
+
+    folly::Future<cpp2::HeartbeatResponse> sendHeartbeatRequest(
+        folly::EventBase* eb,
+        std::shared_ptr<cpp2::HeartbeatRequest> req);
 
     std::shared_ptr<cpp2::AppendLogRequest> prepareAppendLogRequest();
 

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -957,7 +957,7 @@ void RaftPart::processAppendLogResponses(
             auto walIt = wal_->iterator(committedId + 1, lastLogId);
             SlowOpTracker tracker;
             // Step 3: Commit the batch
-            if (commitLogs(std::move(walIt))) {
+            if (commitLogs(std::move(walIt), true) == nebula::cpp2::ErrorCode::SUCCEEDED) {
                 std::lock_guard<std::mutex> g(raftLock_);
                 committedLogId_ = lastLogId;
                 firstLogId = lastLogId_ + 1;

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1497,28 +1497,24 @@ void RaftPart::processAskForVoteRequest(
 void RaftPart::processAppendLogRequest(
         const cpp2::AppendLogRequest& req,
         cpp2::AppendLogResponse& resp) {
-    if (FLAGS_trace_raft) {
-        LOG(INFO) << idStr_
-                  << "Received logAppend "
-                  << ": GraphSpaceId = " << req.get_space()
-                  << ", partition = " << req.get_part()
-                  << ", leaderIp = " << req.get_leader_addr()
-                  << ", leaderPort = " << req.get_leader_port()
-                  << ", current_term = " << req.get_current_term()
-                  << ", lastLogId = " << req.get_last_log_id()
-                  << ", committedLogId = " << req.get_committed_log_id()
-                  << ", lastLogIdSent = " << req.get_last_log_id_sent()
-                  << ", lastLogTermSent = " << req.get_last_log_term_sent()
-                  << folly::stringPrintf(
-                        ", num_logs = %ld, logTerm = %ld",
-                        req.get_log_str_list().size(),
-                        req.get_log_term())
-                  << ", sendingSnapshot = " << req.get_sending_snapshot()
-                  << ", local lastLogId = " << lastLogId_
-                  << ", local lastLogTerm = " << lastLogTerm_
-                  << ", local committedLogId = " << committedLogId_
-                  << ", local current term = " << term_;
-    }
+    LOG_IF(INFO, FLAGS_trace_raft) << idStr_
+        << "Received logAppend"
+        << ": GraphSpaceId = " << req.get_space()
+        << ", partition = " << req.get_part()
+        << ", leaderIp = " << req.get_leader_addr()
+        << ", leaderPort = " << req.get_leader_port()
+        << ", current_term = " << req.get_current_term()
+        << ", lastLogId = " << req.get_last_log_id()
+        << ", committedLogId = " << req.get_committed_log_id()
+        << ", lastLogIdSent = " << req.get_last_log_id_sent()
+        << ", lastLogTermSent = " << req.get_last_log_term_sent()
+        << ", num_logs = " << req.get_log_str_list().size()
+        << ", logTerm = " << req.get_log_term()
+        << ", sendingSnapshot = " << req.get_sending_snapshot()
+        << ", local lastLogId = " << lastLogId_
+        << ", local lastLogTerm = " << lastLogTerm_
+        << ", local committedLogId = " << committedLogId_
+        << ", local current term = " << term_;
     std::lock_guard<std::mutex> g(raftLock_);
 
     resp.set_current_term(term_);
@@ -1815,23 +1811,21 @@ cpp2::ErrorCode RaftPart::verifyLeader(const REQ& req) {
 void RaftPart::processHeartbeatRequest(
         const cpp2::HeartbeatRequest& req,
         cpp2::HeartbeatResponse& resp) {
-    if (FLAGS_trace_raft) {
-        LOG(INFO) << idStr_
-                  << "Received heartbeat "
-                  << ": GraphSpaceId = " << req.get_space()
-                  << ", partition = " << req.get_part()
-                  << ", leaderIp = " << req.get_leader_addr()
-                  << ", leaderPort = " << req.get_leader_port()
-                  << ", current_term = " << req.get_current_term()
-                  << ", lastLogId = " << req.get_last_log_id()
-                  << ", committedLogId = " << req.get_committed_log_id()
-                  << ", lastLogIdSent = " << req.get_last_log_id_sent()
-                  << ", lastLogTermSent = " << req.get_last_log_term_sent()
-                  << ", local lastLogId = " << lastLogId_
-                  << ", local lastLogTerm = " << lastLogTerm_
-                  << ", local committedLogId = " << committedLogId_
-                  << ", local current term = " << term_;
-    }
+    LOG_IF(INFO, FLAGS_trace_raft) << idStr_
+        << "Received heartbeat"
+        << ": GraphSpaceId = " << req.get_space()
+        << ", partition = " << req.get_part()
+        << ", leaderIp = " << req.get_leader_addr()
+        << ", leaderPort = " << req.get_leader_port()
+        << ", current_term = " << req.get_current_term()
+        << ", lastLogId = " << req.get_last_log_id()
+        << ", committedLogId = " << req.get_committed_log_id()
+        << ", lastLogIdSent = " << req.get_last_log_id_sent()
+        << ", lastLogTermSent = " << req.get_last_log_term_sent()
+        << ", local lastLogId = " << lastLogId_
+        << ", local lastLogTerm = " << lastLogTerm_
+        << ", local committedLogId = " << committedLogId_
+        << ", local current term = " << term_;
     std::lock_guard<std::mutex> g(raftLock_);
 
     resp.set_current_term(term_);

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -12,6 +12,7 @@
 #include "common/interface/gen-cpp2/RaftexServiceAsyncClient.h"
 #include "common/time/Duration.h"
 #include "common/thread/GenericThreadPool.h"
+#include "kvstore/Common.h"
 #include "kvstore/raftex/SnapshotManager.h"
 #include "kvstore/DiskManager.h"
 #include <folly/futures/SharedPromise.h>
@@ -298,7 +299,7 @@ protected:
 
     // The inherited classes need to implement this method to commit
     // a batch of log messages
-    virtual bool commitLogs(std::unique_ptr<LogIterator> iter) = 0;
+    virtual nebula::cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) = 0;
 
     virtual bool preProcessLog(LogID logId,
                                TermID termId,

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -224,6 +224,10 @@ public:
         const cpp2::SendSnapshotRequest& req,
         cpp2::SendSnapshotResponse& resp);
 
+    void processHeartbeatRequest(
+        const cpp2::HeartbeatRequest& req,
+        cpp2::HeartbeatResponse& resp);
+
     bool leaseValid();
 
     bool needToCleanWal();
@@ -317,12 +321,10 @@ protected:
 private:
     // A list of <idx, resp>
     // idx  -- the index of the peer
-    // resp -- AskForVoteResponse
+    // resp -- coresponding response of peer[index]
     using ElectionResponses = std::vector<std::pair<size_t, cpp2::AskForVoteResponse>>;
-    // A list of <idx, resp>
-    // idx  -- the index of the peer
-    // resp -- AppendLogResponse
     using AppendLogResponses = std::vector<std::pair<size_t, cpp2::AppendLogResponse>>;
+    using HeartbeatResponses = std::vector<std::pair<size_t, cpp2::HeartbeatResponse>>;
 
     // <source, logType, log>
     using LogCache = std::vector<
@@ -339,13 +341,15 @@ private:
      ***************************************************/
     const char* roleStr(Role role) const;
 
-    cpp2::ErrorCode verifyLeader(const cpp2::AppendLogRequest& req);
+    template<typename REQ>
+    cpp2::ErrorCode verifyLeader(const REQ& req);
 
     /*****************************************************************
-     * Asynchronously send a heartbeat (An empty log entry)
+     *
+     * Asynchronously send a heartbeat
      *
      ****************************************************************/
-    folly::Future<AppendLogResult> sendHeartbeat();
+    void sendHeartbeat();
 
     /****************************************************
      *
@@ -566,6 +570,9 @@ protected:
     std::atomic_bool inElection_{false};
     // Speed up first election when I don't know who is leader
     bool isBlindFollower_{true};
+    // Check leader has commit log in this term (accepted by majority is not enough),
+    // leader is not allowed to service until it is true.
+    bool commitInThisTerm_{false};
 
     // Write-ahead Log
     std::shared_ptr<wal::FileBasedWal> wal_;

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -387,6 +387,10 @@ private:
     // Pre-condition: The caller needs to hold the raftLock_
     AppendLogResult canAppendLogs();
 
+    // Also check if term has changed
+    // Pre-condition: The caller needs to hold the raftLock_
+    AppendLogResult canAppendLogs(TermID currTerm);
+
     folly::Future<AppendLogResult> appendLogAsync(ClusterID source,
                                                   LogType logType,
                                                   std::string log,

--- a/src/kvstore/raftex/RaftexService.cpp
+++ b/src/kvstore/raftex/RaftexService.cpp
@@ -228,6 +228,21 @@ void RaftexService::sendSnapshot(
     part->processSendSnapshotRequest(req, resp);
 }
 
+void RaftexService::async_eb_heartbeat(
+        std::unique_ptr<apache::thrift::HandlerCallback<cpp2::HeartbeatResponse>> callback,
+        const cpp2::HeartbeatRequest& req) {
+    cpp2::HeartbeatResponse resp;
+    auto part = findPart(req.get_space(), req.get_part());
+    if (!part) {
+        // Not found
+        resp.set_error_code(cpp2::ErrorCode::E_UNKNOWN_PART);
+        callback->result(resp);
+        return;
+    }
+    part->processHeartbeatRequest(req, resp);
+    callback->result(resp);
+}
+
 }  // namespace raftex
 }  // namespace nebula
 

--- a/src/kvstore/raftex/RaftexService.h
+++ b/src/kvstore/raftex/RaftexService.h
@@ -49,6 +49,10 @@ public:
         cpp2::SendSnapshotResponse& resp,
         const cpp2::SendSnapshotRequest& req) override;
 
+    void async_eb_heartbeat(
+        std::unique_ptr<apache::thrift::HandlerCallback<cpp2::HeartbeatResponse>> callback,
+        const cpp2::HeartbeatRequest& req) override;
+
     void addPartition(std::shared_ptr<RaftPart> part);
     void removePartition(std::shared_ptr<RaftPart> part);
 

--- a/src/kvstore/raftex/test/TestShard.cpp
+++ b/src/kvstore/raftex/test/TestShard.cpp
@@ -165,7 +165,7 @@ void TestShard::onElected(TermID term) {
 }
 
 
-bool TestShard::commitLogs(std::unique_ptr<LogIterator> iter) {
+nebula::cpp2::ErrorCode TestShard::commitLogs(std::unique_ptr<LogIterator> iter, bool) {
     LogID firstId = -1;
     LogID lastId = -1;
     int32_t commitLogsNum = 0;
@@ -211,7 +211,7 @@ bool TestShard::commitLogs(std::unique_ptr<LogIterator> iter) {
     if (commitLogsNum > 0) {
         commitTimes_++;
     }
-    return true;
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 std::pair<int64_t, int64_t> TestShard::commitSnapshot(const std::vector<std::string>& data,

--- a/src/kvstore/raftex/test/TestShard.h
+++ b/src/kvstore/raftex/test/TestShard.h
@@ -80,7 +80,7 @@ public:
     void onElected(TermID term) override;
     void onDiscoverNewLeader(HostAddr) override {}
 
-    bool commitLogs(std::unique_ptr<LogIterator> iter) override;
+    nebula::cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) override;
 
     bool preProcessLog(LogID,
                        TermID,


### PR DESCRIPTION
Our workflow looks like below, as for an write request

| leader bgWorker | leader ioThreadPool | leader threadMananger | follower ioThreadPool | follower threadManager |
| --------------- | ------------------- | --------------------- | --------------------- | ---------------------- |
|                 | 1. requestReceived     |                       |                       |                        |
|                 |                     | 2. processInThread       |                       |                        |
| (heartbeat)     | 3. replicate           |                       |                       |                        |
|                 |                     |                       | 4. receive appendLog       |                        |
|                 |                     |                       |                       | 5. process      |
|                 | 6. collectN            |                       |                       |                        |
|                 |                     | 7. commit                |                       |                        |

From the view of a storaged process, there would be many partition, we could be blocked in **any** phase if it takes longer time to process. Phase 5 and 7 are the main cause of blocking as before. When pressure is big enough, it is possible that all worker thread is busy. This would raise a lot problems, one of the most notorious among them is leader change. 

Block reason:
1. lock
2. rocksdb write stall (while holding lock)

IMO, there should be only one phase could be blocked, which is leader commit (phase 7). To achieve that, many works need to do:
1. The second commit `don not hold raft lock when commit` will relax the restriction of raft lock. (we have another lock replicatingLogs to prevent concurrent replicate)
2. The third commit `follower delay commit if write stall` will make follower commit logs not to block (phase 5, follower could commit in async)
3. The first commit `heartbeat refactor` make heartbeat process in event base, even if all worker threads are blocked, there won't be unexpected election.

So, the heartbeat logic is:
1. If a log is on the fly, only send a heartbeat which will only be processed in eventbase.
2. If no log is on the fly, both a dummy log(previous behavior) and a heartbeat will be sent.

depends on https://github.com/vesoft-inc/nebula-common/pull/497
