### PR TITLE
fix show hosts errors

### DIFF
--- a/src/meta/processors/partsMan/DropSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/DropSpaceProcessor.cpp
@@ -35,7 +35,7 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
     auto spaceId = nebula::value(spaceRet);
     std::vector<std::string> deleteKeys;
 
-    // delete related part meta data.
+    // 1. Delete related part meta data.
     auto prefix = MetaServiceUtils::partPrefix(spaceId);
     auto iterRet = doPrefix(prefix);
     if (!nebula::ok(iterRet)) {
@@ -53,10 +53,11 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
         iter->next();
     }
 
+    // 2. Delete this space data
     deleteKeys.emplace_back(MetaServiceUtils::indexSpaceKey(spaceName));
     deleteKeys.emplace_back(MetaServiceUtils::spaceKey(spaceId));
 
-    // delete related role data.
+    // 3. Delete related role data.
     auto rolePrefix = MetaServiceUtils::roleSpacePrefix(spaceId);
     auto roleRet = doPrefix(rolePrefix);
     if (!nebula::ok(roleRet)) {
@@ -78,7 +79,7 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
         roleIter->next();
     }
 
-    // delete listener meta data
+    // 4. Delete listener meta data
     auto lstPrefix = MetaServiceUtils::listenerPrefix(spaceId);
     auto lstRet = doPrefix(rolePrefix);
     if (!nebula::ok(lstRet)) {
@@ -96,9 +97,28 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
         lstIter->next();
     }
 
-    // Delete statis data if it exists
+    // 5. Delete related statis data
     auto statiskey = MetaServiceUtils::statisKey(spaceId);
     deleteKeys.emplace_back(statiskey);
+
+    // 6. Delete related leader data
+    auto leaderKey = MetaServiceUtils::leaderPrefix(spaceId);
+
+    auto leaderRet = doPrefix(leaderKey);
+    if (!nebula::ok(leaderRet)) {
+        auto retCode = nebula::error(leaderRet);
+        LOG(ERROR) << "Drop space Failed, space " << spaceName
+                   << " error: " << apache::thrift::util::enumNameSafe(retCode);
+        handleErrorCode(retCode);
+        onFinished();
+        return;
+    }
+
+    auto leaderIter = nebula::value(leaderRet).get();
+    while (leaderIter->valid()) {
+        deleteKeys.emplace_back(leaderIter->key());
+        leaderIter->next();
+    }
 
     doSyncMultiRemoveAndUpdate(std::move(deleteKeys));
     LOG(INFO) << "Drop space " << spaceName << ", id " << spaceId;

--- a/src/meta/processors/partsMan/ListHostsProcessor.h
+++ b/src/meta/processors/partsMan/ListHostsProcessor.h
@@ -47,6 +47,8 @@ private:
 
     void removeExpiredHosts(std::vector<std::string>&& removeHostsKey);
 
+    void removeInvalidLeaders(std::vector<std::string>&& removeLeadersKey);
+
 private:
     std::vector<GraphSpaceID>                     spaceIds_;
     std::unordered_map<GraphSpaceID, std::string> spaceIdNameMap_;


### PR DESCRIPTION
As title~
1) Because the corresponding leader information was not deleted when the space was dropped, then the leader information was incorrect when `show host`.
2) Even if the corresponding leader information is deleted during `drop space`, the` show hosts` result  will occasionally be incorrect. The reasons are as follows:

When dropping the space，heartBeat (HBProcessor) will also write leader information of this space to the meta.
As a result, after the drop space, the leader information written by heartBeat may be out of date. 
Cause `show hosts`  to display incorrect leader information.

Two verification methods：
1）when no any space，
```
create space yy(partition_num=1, replica_factor=1);
show hosts;
drop space yy;
show hosts;
```
2)  After `drop space`, there is no space, use meta_dump tool

