### PR TITLE
Support specified columns for full-text index

### DIFF
--- a/src/kvstore/plugins/elasticsearch/ESListener.h
+++ b/src/kvstore/plugins/elasticsearch/ESListener.h
@@ -60,11 +60,8 @@ private:
 
     bool appendTagDocItem(std::vector<DocItem>& items, const KV& kv) const;
 
-    bool appendDocs(std::vector<DocItem>& items,
-                    const meta::SchemaProviderIf* schema,
-                    RowReader* reader,
-                    int32_t schemaId,
-                    bool isEdge) const;
+    bool appendDocs(std::vector<DocItem>& items, RowReader* reader,
+                    const std::pair<std::string, nebula::meta::cpp2::FTIndex>& fti) const;
 
     bool writeData(const std::vector<nebula::plugin::DocItem>& items) const;
 

--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -30,6 +30,7 @@ nebula_add_library(
     processors/indexMan/GetEdgeIndexProcessor.cpp
     processors/indexMan/ListEdgeIndexesProcessor.cpp
     processors/indexMan/FTServiceProcessor.cpp
+    processors/indexMan/FTIndexProcessor.cpp
     processors/customKV/GetProcessor.cpp
     processors/customKV/MultiGetProcessor.cpp
     processors/customKV/MultiPutProcessor.cpp

--- a/src/meta/MetaServiceHandler.cpp
+++ b/src/meta/MetaServiceHandler.cpp
@@ -32,6 +32,7 @@
 #include "meta/processors/indexMan/GetEdgeIndexProcessor.h"
 #include "meta/processors/indexMan/ListEdgeIndexesProcessor.h"
 #include "meta/processors/indexMan/FTServiceProcessor.h"
+#include "meta/processors/indexMan/FTIndexProcessor.h"
 #include "meta/processors/customKV/MultiPutProcessor.h"
 #include "meta/processors/customKV/GetProcessor.h"
 #include "meta/processors/customKV/MultiGetProcessor.h"
@@ -302,6 +303,24 @@ MetaServiceHandler::future_signOutFTService(const cpp2::SignOutFTServiceReq& req
 folly::Future<cpp2::ListFTClientsResp>
 MetaServiceHandler::future_listFTClients(const cpp2::ListFTClientsReq& req) {
     auto* processor = ListFTClientsProcessor::instance(kvstore_);
+    RETURN_FUTURE(processor);
+}
+
+folly::Future<cpp2::ExecResp>
+MetaServiceHandler::future_createFTIndex(const cpp2::CreateFTIndexReq& req) {
+    auto* processor = CreateFTIndexProcessor::instance(kvstore_);
+    RETURN_FUTURE(processor);
+}
+
+folly::Future<cpp2::ExecResp>
+MetaServiceHandler::future_dropFTIndex(const cpp2::DropFTIndexReq& req) {
+    auto* processor = DropFTIndexProcessor::instance(kvstore_);
+    RETURN_FUTURE(processor);
+}
+
+folly::Future<cpp2::ListFTIndexesResp>
+MetaServiceHandler::future_listFTIndexes(const cpp2::ListFTIndexesReq& req) {
+    auto* processor = ListFTIndexesProcessor::instance(kvstore_);
     RETURN_FUTURE(processor);
 }
 

--- a/src/meta/MetaServiceHandler.h
+++ b/src/meta/MetaServiceHandler.h
@@ -146,6 +146,15 @@ public:
     folly::Future<cpp2::ListFTClientsResp>
     future_listFTClients(const cpp2::ListFTClientsReq& req) override;
 
+    folly::Future<cpp2::ExecResp>
+    future_createFTIndex(const cpp2::CreateFTIndexReq& req) override;
+
+    folly::Future<cpp2::ExecResp>
+    future_dropFTIndex(const cpp2::DropFTIndexReq& req) override;
+
+    folly::Future<cpp2::ListFTIndexesResp>
+    future_listFTIndexes(const cpp2::ListFTIndexesReq& req) override;
+
     /**
      * User manager
      **/

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -1397,5 +1397,34 @@ meta::cpp2::Session MetaServiceUtils::parseSessionVal(const folly::StringPiece &
     apache::thrift::CompactSerializer::deserialize(val, session);
     return session;
 }
+
+std::string MetaServiceUtils::fulltextIndexKey(const std::string& indexName) {
+    std::string key;
+    key.reserve(kFTIndexTable.size() + indexName.size());
+    key.append(kFTIndexTable.data(), kFTIndexTable.size())
+       .append(indexName);
+    return key;
+}
+
+std::string MetaServiceUtils::fulltextIndexVal(const cpp2::FTIndex& index) {
+    std::string val;
+    apache::thrift::CompactSerializer::serialize(index, &val);
+    return val;
+}
+
+std::string MetaServiceUtils::parsefulltextIndexName(folly::StringPiece key) {
+    return key.subpiece(kFTIndexTable.size(), key.size()).toString();
+}
+
+cpp2::FTIndex MetaServiceUtils::parsefulltextIndex(folly::StringPiece val) {
+   cpp2::FTIndex ftIndex;
+   apache::thrift::CompactSerializer::deserialize(val, ftIndex);
+   return ftIndex;
+}
+
+std::string MetaServiceUtils::fulltextIndexPrefix() {
+    return kFTIndexTable;
+}
+
 }  // namespace meta
 }  // namespace nebula

--- a/src/meta/MetaServiceUtils.h
+++ b/src/meta/MetaServiceUtils.h
@@ -332,6 +332,16 @@ public:
 
     static meta::cpp2::Session parseSessionVal(const folly::StringPiece &val);
 
+    static std::string fulltextIndexKey(const std::string& indexName);
+
+    static std::string fulltextIndexVal(const cpp2::FTIndex& index);
+
+    static std::string parsefulltextIndexName(folly::StringPiece key);
+
+    static cpp2::FTIndex parsefulltextIndex(folly::StringPiece val);
+
+    static std::string fulltextIndexPrefix();
+
     static std::string genTimestampStr();
 
     static GraphSpaceID parseEdgesKeySpaceID(folly::StringPiece key);

--- a/src/meta/processors/BaseProcessor.h
+++ b/src/meta/processors/BaseProcessor.h
@@ -228,8 +228,15 @@ protected:
     indexCheck(const std::vector<cpp2::IndexItem>& items,
                const std::vector<cpp2::AlterSchemaItem>& alterItems);
 
+    nebula::cpp2::ErrorCode
+    ftIndexCheck(const std::vector<std::string>& cols,
+                 const std::vector<cpp2::AlterSchemaItem>& alterItems);
+
     ErrorOr<nebula::cpp2::ErrorCode, std::vector<cpp2::IndexItem>>
     getIndexes(GraphSpaceID spaceId, int32_t tagOrEdge);
+
+    ErrorOr<nebula::cpp2::ErrorCode, cpp2::FTIndex>
+    getFTIndex(GraphSpaceID spaceId, int32_t tagOrEdge);
 
     bool checkIndexExist(const std::vector<cpp2::IndexFieldDef>& fields,
                          const cpp2::IndexItem& item);

--- a/src/meta/processors/Common.h
+++ b/src/meta/processors/Common.h
@@ -67,6 +67,7 @@ GENERATE_LOCK(edge);
 GENERATE_LOCK(tagIndex);
 GENERATE_LOCK(edgeIndex);
 GENERATE_LOCK(fulltextServices);
+GENERATE_LOCK(fulltextIndex);
 GENERATE_LOCK(user);
 GENERATE_LOCK(config);
 GENERATE_LOCK(snapshot);

--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -133,6 +133,8 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
                 LOG(ERROR) << "Unsupport index type lengths greater than "
                            << MAX_INDEX_TYPE_LENGTH << " : "
                            << field.get_name();
+                handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
+                onFinished();
                 return;
             }
         } else if (col.type.get_type() == meta::cpp2::PropertyType::STRING) {

--- a/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateEdgeIndexProcessor.cpp
@@ -4,6 +4,7 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
+#include "common/base/CommonMacro.h"
 #include "meta/processors/indexMan/CreateEdgeIndexProcessor.h"
 
 namespace nebula {
@@ -127,10 +128,25 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
             return;
         }
         cpp2::ColumnDef col = *iter;
-        if (col.type.get_type() == meta::cpp2::PropertyType::STRING) {
+        if (col.type.get_type() == meta::cpp2::PropertyType::FIXED_STRING) {
+            if (*col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+                LOG(ERROR) << "Unsupport index type lengths greater than "
+                           << MAX_INDEX_TYPE_LENGTH << " : "
+                           << field.get_name();
+                return;
+            }
+        } else if (col.type.get_type() == meta::cpp2::PropertyType::STRING) {
             if (!field.type_length_ref().has_value()) {
                 LOG(ERROR) << "No type length set : " << field.get_name();
                 handleErrorCode(nebula::cpp2::ErrorCode::E_INVALID_PARM);
+                onFinished();
+                return;
+            }
+            if (*field.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+                LOG(ERROR) << "Unsupport index type lengths greater than "
+                           << MAX_INDEX_TYPE_LENGTH << " : "
+                           << field.get_name();
+                handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
                 onFinished();
                 return;
             }

--- a/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/CreateTagIndexProcessor.cpp
@@ -4,6 +4,7 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
+#include "common/base/CommonMacro.h"
 #include "meta/processors/indexMan/CreateTagIndexProcessor.h"
 
 namespace nebula {
@@ -126,10 +127,27 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
             return;
         }
         cpp2::ColumnDef col = *iter;
-        if (col.type.get_type() == meta::cpp2::PropertyType::STRING) {
+        if (col.type.get_type() == meta::cpp2::PropertyType::FIXED_STRING) {
+            if (*col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+                LOG(ERROR) << "Unsupport index type lengths greater than "
+                           << MAX_INDEX_TYPE_LENGTH << " : "
+                           << field.get_name();
+                handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
+                onFinished();
+                return;
+            }
+        } else if (col.type.get_type() == meta::cpp2::PropertyType::STRING) {
             if (!field.type_length_ref().has_value()) {
                 LOG(ERROR) << "No type length set : " << field.get_name();
                 handleErrorCode(nebula::cpp2::ErrorCode::E_INVALID_PARM);
+                onFinished();
+                return;
+            }
+            if (*field.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+                LOG(ERROR) << "Unsupport index type lengths greater than "
+                           << MAX_INDEX_TYPE_LENGTH << " : "
+                           << field.get_name();
+                handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
                 onFinished();
                 return;
             }

--- a/src/meta/processors/indexMan/FTIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/FTIndexProcessor.cpp
@@ -1,0 +1,172 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "common/base/CommonMacro.h"
+#include "meta/processors/indexMan/FTIndexProcessor.h"
+
+namespace nebula {
+namespace meta {
+
+void CreateFTIndexProcessor::process(const cpp2::CreateFTIndexReq& req) {
+    folly::SharedMutex::WriteHolder wHolder(LockUtils::fulltextIndexLock());
+    const auto& index = req.get_index();
+    const std::string& name = req.get_fulltext_index_name();
+    CHECK_SPACE_ID_AND_RETURN(index.get_space_id());
+    auto isEdge = index.get_depend_schema().getType() == cpp2::SchemaID::Type::edge_type;
+    folly::SharedMutex::ReadHolder rHolder(isEdge ? LockUtils::edgeLock() : LockUtils::tagLock());
+    auto schemaPrefix = isEdge
+                      ? MetaServiceUtils::schemaEdgePrefix(
+                          index.get_space_id(), index.get_depend_schema().get_edge_type())
+                      : MetaServiceUtils::schemaTagPrefix(
+                          index.get_space_id(), index.get_depend_schema().get_tag_id());
+
+    // Check tag or edge exist.
+    auto retPre = doPrefix(schemaPrefix);
+    if (!nebula::ok(retPre)) {
+        auto retCode = nebula::error(retPre);
+        LOG(ERROR) << "Tag or Edge Prefix failed, "
+                   << apache::thrift::util::enumNameSafe(retCode);
+        handleErrorCode(retCode);
+        onFinished();
+        return;
+    }
+    auto iter = nebula::value(retPre).get();
+    if (!iter->valid()) {
+        LOG(ERROR) << "Edge or Tag could not be found";
+        auto eCode = isEdge
+                  ? nebula::cpp2::ErrorCode::E_EDGE_NOT_FOUND
+                  : nebula::cpp2::ErrorCode::E_TAG_NOT_FOUND;
+        handleErrorCode(eCode);
+        onFinished();
+        return;
+    }
+
+    // verify the columns.
+    auto schema = MetaServiceUtils::parseSchema(iter->val());
+    auto columns = schema.get_columns();
+    for (const auto& col : index.get_fields()) {
+        auto targetCol = std::find_if(columns.begin(), columns.end(), [col] (const auto& c) {
+            return col == c.get_name();
+        });
+        if (targetCol == columns.end()) {
+            LOG(ERROR) << "Column not found : " << col;
+            auto eCode = isEdge
+                       ? nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND
+                       : nebula::cpp2::ErrorCode::E_TAG_PROP_NOT_FOUND;
+            handleErrorCode(eCode);
+            onFinished();
+            return;
+        }
+        // Only string or fixed_string types are supported.
+        if (targetCol->get_type().get_type() != meta::cpp2::PropertyType::STRING &&
+            targetCol->get_type().get_type() != meta::cpp2::PropertyType::FIXED_STRING) {
+            LOG(ERROR) << "Column data type error : "
+                       << apache::thrift::util::enumNameSafe(targetCol->get_type().get_type());
+            handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
+            onFinished();
+            return;
+        }
+        // if the data type is fixed_string,
+        // the data length must be less than MAX_INDEX_TYPE_LENGTH.
+        // else if the data type is string,
+        // will be truncated to MAX_INDEX_TYPE_LENGTH bytes when data insert.
+        if (targetCol->get_type().get_type() == meta::cpp2::PropertyType::FIXED_STRING &&
+            *targetCol->get_type().get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+            LOG(ERROR) << "Unsupported data length more than "
+                       << MAX_INDEX_TYPE_LENGTH << " bytes : "
+                       << col << "(" << *targetCol->get_type().get_type_length() << ")";
+            handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
+            onFinished();
+            return;
+        }
+    }
+
+    // Check fulltext index exist.
+    auto ret = doPrefix(MetaServiceUtils::fulltextIndexPrefix());
+    if (!nebula::ok(ret)) {
+        auto retCode = nebula::error(ret);
+        LOG(ERROR) << "Fulltext Prefix failed, "
+                   << apache::thrift::util::enumNameSafe(retCode);
+        handleErrorCode(retCode);
+        onFinished();
+        return;
+    }
+    auto it = nebula::value(ret).get();
+    // If already have a full-text index that depend on this tag or edge,  reject to create it.
+    // even though it's a different column.
+    while (it->valid()) {
+        auto indexName = MetaServiceUtils::parsefulltextIndexName(it->key());
+        auto indexItem = MetaServiceUtils::parsefulltextIndex(it->val());
+        if (indexName == name) {
+            LOG(ERROR) << "Fulltext index exist : " << indexName;
+            handleErrorCode(nebula::cpp2::ErrorCode::E_EXISTED);
+            onFinished();
+            return;
+        }
+        if (index.get_depend_schema() == indexItem.get_depend_schema()) {
+            LOG(ERROR) << "Depends on the same schema , index : " << indexName;
+            handleErrorCode(nebula::cpp2::ErrorCode::E_EXISTED);
+            onFinished();
+            return;
+        }
+        it->next();
+    }
+    std::vector<kvstore::KV> data;
+    data.emplace_back(MetaServiceUtils::fulltextIndexKey(name),
+                      MetaServiceUtils::fulltextIndexVal(index));
+    doSyncPutAndUpdate(std::move(data));
+}
+
+void DropFTIndexProcessor::process(const cpp2::DropFTIndexReq& req) {
+    CHECK_SPACE_ID_AND_RETURN(req.get_space_id());
+    folly::SharedMutex::WriteHolder wHolder(LockUtils::fulltextIndexLock());
+    auto indexKey = MetaServiceUtils::fulltextIndexKey(req.get_fulltext_index_name());
+    auto ret = doGet(indexKey);
+    if (!nebula::ok(ret)) {
+        auto retCode = nebula::error(ret);
+        if (retCode == nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND) {
+            LOG(ERROR) << "Drop fulltext index failed, Fulltext index not exists.";
+            handleErrorCode(nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND);
+            onFinished();
+            return;
+        }
+        LOG(ERROR) << "Drop fulltext index failed, error: "
+                   << apache::thrift::util::enumNameSafe(retCode);
+        handleErrorCode(retCode);
+        onFinished();
+        return;
+    }
+    doSyncMultiRemoveAndUpdate({std::move(indexKey)});
+}
+
+void ListFTIndexesProcessor::process(const cpp2::ListFTIndexesReq&) {
+    folly::SharedMutex::ReadHolder rHolder(LockUtils::fulltextIndexLock());
+    const auto& prefix = MetaServiceUtils::fulltextIndexPrefix();
+    auto iterRet = doPrefix(prefix);
+    if (!nebula::ok(iterRet)) {
+        auto retCode = nebula::error(iterRet);
+        LOG(ERROR) << "List fulltext indexes failed, error: "
+                   << apache::thrift::util::enumNameSafe(retCode);
+        handleErrorCode(retCode);
+        onFinished();
+        return;
+    }
+
+    auto iter = nebula::value(iterRet).get();
+    std::unordered_map<std::string, nebula::meta::cpp2::FTIndex> indexes;
+    while (iter->valid()) {
+        auto name = MetaServiceUtils::parsefulltextIndexName(iter->key());
+        auto index = MetaServiceUtils::parsefulltextIndex(iter->val());
+        indexes.emplace(std::move(name), std::move(index));
+        iter->next();
+    }
+    resp_.set_indexes(std::move(indexes));
+    handleErrorCode(nebula::cpp2::ErrorCode::SUCCEEDED);
+    onFinished();
+}
+
+}  // namespace meta
+}  // namespace nebula

--- a/src/meta/processors/indexMan/FTIndexProcessor.h
+++ b/src/meta/processors/indexMan/FTIndexProcessor.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+#ifndef META_FTINDEXPROCESSOR_H_
+#define META_FTINDEXPROCESSOR_H_
+
+#include "meta/processors/BaseProcessor.h"
+
+namespace nebula {
+namespace meta {
+
+class CreateFTIndexProcessor : public BaseProcessor<cpp2::ExecResp> {
+public:
+    static CreateFTIndexProcessor* instance(kvstore::KVStore* kvstore) {
+        return new CreateFTIndexProcessor(kvstore);
+    }
+
+    void process(const cpp2::CreateFTIndexReq& req);
+
+private:
+    explicit CreateFTIndexProcessor(kvstore::KVStore* kvstore)
+        : BaseProcessor<cpp2::ExecResp>(kvstore) {}
+};
+
+class DropFTIndexProcessor : public BaseProcessor<cpp2::ExecResp> {
+public:
+    static DropFTIndexProcessor* instance(kvstore::KVStore* kvstore) {
+        return new DropFTIndexProcessor(kvstore);
+    }
+
+    void process(const cpp2::DropFTIndexReq& req);
+
+private:
+    explicit DropFTIndexProcessor(kvstore::KVStore* kvstore)
+        : BaseProcessor<cpp2::ExecResp>(kvstore) {}
+};
+
+class ListFTIndexesProcessor : public BaseProcessor<cpp2::ListFTIndexesResp> {
+public:
+    static ListFTIndexesProcessor* instance(kvstore::KVStore* kvstore) {
+        return new ListFTIndexesProcessor(kvstore);
+    }
+
+    void process(const cpp2::ListFTIndexesReq&);
+
+private:
+    explicit ListFTIndexesProcessor(kvstore::KVStore* kvstore)
+        : BaseProcessor<cpp2::ListFTIndexesResp>(kvstore) {}
+};
+
+}  // namespace meta
+}  // namespace nebula
+
+#endif   // META_FTINDEXPROCESSOR_H_

--- a/src/meta/processors/indexMan/FTServiceProcessor.cpp
+++ b/src/meta/processors/indexMan/FTServiceProcessor.cpp
@@ -56,7 +56,7 @@ void SignOutFTServiceProcessor::process(const cpp2::SignOutFTServiceReq&) {
 }
 
 void ListFTClientsProcessor::process(const cpp2::ListFTClientsReq&) {
-    folly::SharedMutex::WriteHolder rHolder(LockUtils::fulltextServicesLock());
+    folly::SharedMutex::ReadHolder rHolder(LockUtils::fulltextServicesLock());
     const auto& prefix = MetaServiceUtils::fulltextServiceKey();
     auto iterRet = doPrefix(prefix);
     if (!nebula::ok(iterRet)) {

--- a/src/meta/processors/partsMan/DropSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/DropSpaceProcessor.cpp
@@ -101,6 +101,22 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
     auto statiskey = MetaServiceUtils::statisKey(spaceId);
     deleteKeys.emplace_back(statiskey);
 
+    // 6. Delte related fulltext index meta data
+    auto ftRet = doPrefix(MetaServiceUtils::fulltextIndexPrefix());
+    if (!nebula::ok(ftRet)) {
+        auto retCode = nebula::error(ftRet);
+        LOG(ERROR) << "Drop space Failed, space " << spaceName
+                   << " error: " << apache::thrift::util::enumNameSafe(retCode);
+        handleErrorCode(retCode);
+        onFinished();
+        return;
+    }
+    auto ftIter = nebula::value(ftRet).get();
+    while (ftIter->valid()) {
+        deleteKeys.emplace_back(ftIter->key());
+        ftIter->next();
+    }
+
     doSyncMultiRemoveAndUpdate(std::move(deleteKeys));
     LOG(INFO) << "Drop space " << spaceName << ", id " << spaceId;
 }

--- a/src/meta/processors/partsMan/DropSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/DropSpaceProcessor.cpp
@@ -113,7 +113,10 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
     }
     auto ftIter = nebula::value(ftRet).get();
     while (ftIter->valid()) {
-        deleteKeys.emplace_back(ftIter->key());
+        auto index = MetaServiceUtils::parsefulltextIndex(ftIter->val());
+        if (index.get_space_id() == spaceId) {
+            deleteKeys.emplace_back(ftIter->key());
+        }
         ftIter->next();
     }
 

--- a/src/meta/processors/schemaMan/DropEdgeProcessor.cpp
+++ b/src/meta/processors/schemaMan/DropEdgeProcessor.cpp
@@ -54,6 +54,21 @@ void DropEdgeProcessor::process(const cpp2::DropEdgeReq& req) {
         return;
     }
 
+    auto ftIdxRet = getFTIndex(spaceId, edgeType);
+    if (nebula::ok(ftIdxRet)) {
+        LOG(ERROR) << "Drop edge error, fulltext index conflict, "
+                   << "please delete fulltext index first.";
+        handleErrorCode(nebula::cpp2::ErrorCode::E_CONFLICT);
+        onFinished();
+        return;
+    }
+
+    if (nebula::error(ftIdxRet) != nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND) {
+        handleErrorCode(nebula::error(ftIdxRet));
+        onFinished();
+        return;
+    }
+
     auto ret = getEdgeKeys(spaceId, edgeType);
     if (!nebula::ok(ret)) {
         handleErrorCode(nebula::error(ret));

--- a/src/meta/processors/schemaMan/DropTagProcessor.cpp
+++ b/src/meta/processors/schemaMan/DropTagProcessor.cpp
@@ -54,6 +54,21 @@ void DropTagProcessor::process(const cpp2::DropTagReq& req) {
         return;
     }
 
+    auto ftIdxRet = getFTIndex(spaceId, tagId);
+    if (nebula::ok(ftIdxRet)) {
+        LOG(ERROR) << "Drop tag error, fulltext index conflict, "
+                   << "please delete fulltext index first.";
+        handleErrorCode(nebula::cpp2::ErrorCode::E_CONFLICT);
+        onFinished();
+        return;
+    }
+
+    if (nebula::error(ftIdxRet) != nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND) {
+        handleErrorCode(nebula::error(ftIdxRet));
+        onFinished();
+        return;
+    }
+
     auto ret = getTagKeys(spaceId, tagId);
     if (!nebula::ok(ret)) {
         handleErrorCode(nebula::error(ret));

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -8,6 +8,7 @@
 #define META_TEST_TESTUTILS_H_
 
 #include "common/base/Base.h"
+#include "common/base/CommonMacro.h"
 #include "common/interface/gen-cpp2/common_types.h"
 #include "common/time/WallClock.h"
 #include "common/expression/ConstantExpression.h"
@@ -250,8 +251,12 @@ public:
             for (auto i = 0; i < 2; i++) {
                 cpp2::ColumnDef column;
                 column.set_name(folly::stringPrintf("tag_%d_col_%d", tagId, i));
-                (*column.type_ref()).set_type(i < 1 ?
-                        PropertyType::INT64 : PropertyType::FIXED_STRING);
+                if (i < 1) {
+                    column.type.set_type(PropertyType::INT64);
+                } else {
+                    column.type.set_type(PropertyType::FIXED_STRING);
+                    column.type.set_type_length(MAX_INDEX_TYPE_LENGTH);
+                }
                 if (nullable) {
                     column.set_nullable(nullable);
                 }
@@ -338,7 +343,12 @@ public:
             for (auto i = 0; i < 2; i++) {
                 cpp2::ColumnDef column;
                 column.name = folly::stringPrintf("edge_%d_col_%d", edgeType, i);
-                column.type.set_type(i < 1 ? PropertyType::INT64 : PropertyType::FIXED_STRING);
+                if (i < 1) {
+                    column.type.set_type(PropertyType::INT64);
+                } else {
+                    column.type.set_type(PropertyType::FIXED_STRING);
+                    column.type.set_type_length(MAX_INDEX_TYPE_LENGTH);
+                }
                 if (nullable) {
                     column.set_nullable(nullable);
                 }

--- a/src/mock/AdHocSchemaManager.h
+++ b/src/mock/AdHocSchemaManager.h
@@ -108,6 +108,12 @@ public:
 
     void addFTClient(const nebula::meta::cpp2::FTClient& client);
 
+    StatusOr<std::pair<std::string, nebula::meta::cpp2::FTIndex>>
+    getFTIndex(GraphSpaceID, int32_t) override {
+        LOG(FATAL) << "Unimplemented";
+        return Status::Error("Unimplemented");
+    }
+
     StatusOr<int32_t> getPartsNum(GraphSpaceID) override {
         return partNum_;
     }


### PR DESCRIPTION
1, Changed full-text index structure, deleted field schema_id
2, Support for creating full-text index against fields
3, Support drop full-text index
4, Support show full-text index
5, Refuse to create full-text index if fixed_string type length > 256 
6, Refuse to drop or alter tag if full-text index exists.

depends on vesoft-inc/nebula-common#530