### PR TITLE
fix ASAN error

### DIFF
--- a/src/meta/processors/indexMan/FTIndexProcessor.cpp
+++ b/src/meta/processors/indexMan/FTIndexProcessor.cpp
@@ -85,7 +85,8 @@ void CreateFTIndexProcessor::process(const cpp2::CreateFTIndexReq& req) {
     }
 
     // Check fulltext index exist.
-    auto ret = doPrefix(MetaServiceUtils::fulltextIndexPrefix());
+    auto ftPrefix = MetaServiceUtils::fulltextIndexPrefix();
+    auto ret = doPrefix(ftPrefix);
     if (!nebula::ok(ret)) {
         auto retCode = nebula::error(ret);
         LOG(ERROR) << "Fulltext Prefix failed, "

--- a/src/meta/processors/partsMan/DropSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/DropSpaceProcessor.cpp
@@ -102,7 +102,8 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
     deleteKeys.emplace_back(statiskey);
 
     // 6. Delte related fulltext index meta data
-    auto ftRet = doPrefix(MetaServiceUtils::fulltextIndexPrefix());
+    auto ftPrefix = MetaServiceUtils::fulltextIndexPrefix();
+    auto ftRet = doPrefix(ftPrefix);
     if (!nebula::ok(ftRet)) {
         auto retCode = nebula::error(ftRet);
         LOG(ERROR) << "Drop space Failed, space " << spaceName


### PR DESCRIPTION
I0526 16:19:58.465111 55256 AuthenticationProcessor.cpp:115] Drop User user2
=================================================================
==55256==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7efea9ce06e0 at pc 0x7efead77946b bp 0x7ffc59fcf090 sp 0x7ffc59fce840
READ of size 12 at 0x7efea9ce06e0 thread T0
    #0 0x7efead77946a  (/opt/vesoft/toolset/gcc/9.1.0/lib64/libasan.so.5+0xd546a)
    #1 0x34d49c2 in rocksdb::Slice::starts_with(rocksdb::Slice const&) const /opt/vesoft/third-party/2.0/include/rocksdb/slice.h:121
    #2 0x34d6afa in nebula::kvstore::RocksPrefixIter::valid() const /home/bright2star/source/nebula2/nebula-storage/src/kvstore/RocksEngine.h:61
    #3 0x2cb7d87 in nebula::meta::DropSpaceProcessor::process(nebula::meta::cpp2::DropSpaceReq const&) /home/bright2star/source/nebula2/nebula-storage/src/meta/processors/partsMan/DropSpaceProcessor.cpp:111
    #4 0x29e6aae in nebula::meta::AuthProcessorTest_GrantRevokeTest_Test::TestBody() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x29e6aae)
    #5 0x5c3851d in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x5c3851d)
    #6 0x5c2fbc1 in testing::Test::Run() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x5c2fbc1)
    #7 0x5c2fd07 in testing::TestInfo::Run() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x5c2fd07)
    #8 0x5c2fde4 in testing::TestCase::Run() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x5c2fde4)
    #9 0x5c302eb in testing::internal::UnitTestImpl::RunAllTests() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x5c302eb)
    #10 0x5c303ec in testing::UnitTest::Run() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x5c303ec)
    #11 0x29cf329 in RUN_ALL_TESTS() (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x29cf329)
    #12 0x29ecde9 in main (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x29ecde9)
    #13 0x7efead360f42 in __libc_start_main (/usr/lib64/libc.so.6+0x23f42)
    #14 0x29c7c5d in _start (/home/bright2star/source/nebula2/nebula-storage/build/bin/test/authentication_test+0x29c7c5d)

Address 0x7efea9ce06e0 is located in stack of thread T0 at offset 1760 in frame
    #0 0x2cb57f5 in nebula::meta::DropSpaceProcessor::process(nebula::meta::cpp2::DropSpaceReq const&) /home/bright2star/source/nebula2/nebula-storage/src/meta/processors/partsMan/DropSpaceProcessor.cpp:12