### PR TITLE
unify reset/cleanup usage in Listener/Part

### DIFF
--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -115,17 +115,13 @@ bool Listener::preProcessLog(LogID logId,
 
 bool Listener::commitLogs(std::unique_ptr<LogIterator> iter) {
     LogID lastId = -1;
-    TermID lastTerm = -1;
     while (iter->valid()) {
         lastId = iter->logId();
-        lastTerm = iter->logTerm();
         ++(*iter);
     }
     if (lastId > 0) {
-        lastId_ = lastId;
-        lastTerm_ = lastTerm;
+        leaderCommitId_ = lastId;
     }
-    lastCommitTime_ = time::WallClock::fastNowInMilliSec();
     return true;
 }
 
@@ -214,7 +210,7 @@ void Listener::doApply() {
         if (apply(data)) {
             std::lock_guard<std::mutex> guard(raftLock_);
             lastApplyLogId_ = lastApplyId;
-            persist(lastId_, lastTerm_, lastApplyLogId_);
+            persist(committedLogId_, term_, lastApplyLogId_);
             VLOG(1) << idStr_ << "Listener succeeded apply log to " << lastApplyLogId_;
             lastApplyTime_ = time::WallClock::fastNowInMilliSec();
         }
@@ -242,10 +238,8 @@ std::pair<int64_t, int64_t> Listener::commitSnapshot(const std::vector<std::stri
     }
     if (finished) {
         CHECK(!raftLock_.try_lock());
-        lastId_ = committedLogId;
         lastApplyLogId_ = committedLogId;
-        lastTerm_ = committedLogTerm;
-        persist(committedLogId, lastTerm_, lastApplyLogId_);
+        persist(committedLogId, committedLogTerm, lastApplyLogId_);
         LOG(INFO) << idStr_ << "Listener succeeded apply log to " << lastApplyLogId_;
         lastApplyTime_ = time::WallClock::fastNowInMilliSec();
     }

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -238,6 +238,7 @@ std::pair<int64_t, int64_t> Listener::commitSnapshot(const std::vector<std::stri
     }
     if (finished) {
         CHECK(!raftLock_.try_lock());
+        leaderCommitId_ = committedLogId;
         lastApplyLogId_ = committedLogId;
         persist(committedLogId, committedLogTerm, lastApplyLogId_);
         LOG(INFO) << idStr_ << "Listener succeeded apply log to " << lastApplyLogId_;

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -111,6 +111,7 @@ public:
     }
 
     void cleanup() override {
+        leaderCommitId_ = 0;
         lastApplyLogId_ = 0;
         persist(0, 0, lastApplyLogId_);
     }

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -82,7 +82,7 @@ derived class.
     // persist last commit log id/term and lastApplyId
     bool persist(LogID, TermID, LogID)
 
-    // extra cleanup work, will be invoked when listener is about to be removed
+    // extra cleanup work, will be invoked when listener is about to be removed, or raft is reseted
     virtual void cleanup() = 0
 */
 
@@ -106,17 +106,18 @@ public:
     // Stop listener
     void stop() override;
 
-    int64_t logGapInMs() {
-        return lastCommitTime_ - lastApplyTime_;
-    }
-
     LogID getApplyId() {
         return lastApplyLogId_;
     }
 
-    void reset() {
-        LOG(INFO) << idStr_ << "Clean up all wals";
-        wal_->reset();
+    void cleanup() override {
+        lastApplyLogId_ = 0;
+        persist(0, 0, lastApplyLogId_);
+    }
+
+    void resetListener() {
+        std::lock_guard<std::mutex> g(raftLock_);
+        reset();
     }
 
 protected:
@@ -172,11 +173,8 @@ protected:
     void doApply();
 
 protected:
-    // lastId_ and lastTerm_ is same as committedLogId_ and term_
-    LogID lastId_ = -1;
-    TermID lastTerm_ = -1;
+    LogID leaderCommitId_ = 0;
     LogID lastApplyLogId_ = 0;
-    int64_t lastCommitTime_ = 0;
     int64_t lastApplyTime_ = 0;
     std::set<HostAddr> peers_;
     meta::SchemaManager* schemaMan_{nullptr};

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -425,7 +425,7 @@ void NebulaStore::removePart(GraphSpaceID spaceId, PartitionID partId) {
             CHECK_NOTNULL(e);
             raftService_->removePartition(partIt->second);
             diskMan_->removePartFromPath(spaceId, partId, e->getDataRoot());
-            partIt->second->reset();
+            partIt->second->resetPart();
             spaceIt->second->parts_.erase(partId);
             e->removePart(partId);
         }
@@ -499,7 +499,7 @@ void NebulaStore::removeListener(GraphSpaceID spaceId,
             auto listener = partIt->second.find(type);
             if (listener != partIt->second.end()) {
                 raftService_->removePartition(listener->second);
-                listener->second->reset();
+                listener->second->resetListener();
                 partIt->second.erase(type);
                 LOG(INFO) << "Listener of type " << apache::thrift::util::enumNameSafe(type)
                           << " of [Space: " << spaceId << ", Part: " << partId << "] is removed";

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -235,6 +235,9 @@ public:
 
     std::pair<LogID, TermID> lastLogInfo() const;
 
+    // Reset the part, clean up all data and WALs.
+    void reset();
+
 protected:
     // Protected constructor to prevent from instantiating directly
     RaftPart(
@@ -304,11 +307,8 @@ protected:
                                                        TermID committedLogTerm,
                                                        bool finished) = 0;
 
-    // Clean up all data about current part in storage.
+    // Clean up extra data about the part, usually related to state machine
     virtual void cleanup() = 0;
-
-    // Reset the part, clean up all data and WALs.
-    void reset();
 
     void addPeer(const HostAddr& peer);
 


### PR DESCRIPTION
1. Remove useless `lastId_` and `lastTerm_` in Listener. @bright-starry-sky, you can use `leaderCommitId_` to check if listener has catch up with leader. (when `leaderCommitId_ == 0`, could return false)
2. Unify the usage of `reset` and `cleanup` in RaftPart/Part/Listener:
* `reset` will clean all things (wal, Id, info about state machine), it will call `cleanup`
* `cleanup` only cleans info about state machine 