### PR TITLE
fix report error when field type and value not match in update edge

### DIFF
--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -523,7 +523,12 @@ public:
                 if (this->exeResult_ != nebula::cpp2::ErrorCode::SUCCEEDED) {
                     return folly::none;
                 }
-                return this->updateAndWriteBack(partId, edgeKey);
+                auto batch = this->updateAndWriteBack(partId, edgeKey);
+                if (batch == folly::none) {
+                    // There is an error in updateAndWriteBack
+                    this->exeResult_ = nebula::cpp2::ErrorCode::E_INVALID_DATA;
+                }
+                return batch;
             } else {
                 // If filter out, StorageExpressionContext is set in filterNode
                 return folly::none;


### PR DESCRIPTION
As title.

When the field type and the value type do not match and cannot be converted (RowWriterV2::write reports an error), nothing was written before, and now an error is reported.