### PR TITLE
Avoid the conversion between folly::StringPiece and std::string.

### DIFF
--- a/src/codec/RowWriterV2.cpp
+++ b/src/codec/RowWriterV2.cpp
@@ -223,7 +223,7 @@ WriteResult RowWriterV2::setValue(ssize_t index, const Value& val) noexcept {
 }
 
 
-WriteResult RowWriterV2::setValue(folly::StringPiece name, const Value& val) noexcept {
+WriteResult RowWriterV2::setValue(const std::string &name, const Value& val) noexcept {
     CHECK(!finished_) << "You have called finish()";
     int64_t index = schema_->getFieldIndex(name);
     return setValue(index, val);
@@ -248,7 +248,7 @@ WriteResult RowWriterV2::setNull(ssize_t index) noexcept {
 }
 
 
-WriteResult RowWriterV2::setNull(folly::StringPiece name) noexcept {
+WriteResult RowWriterV2::setNull(const std::string& name) noexcept {
     CHECK(!finished_) << "You have called finish()";
     int64_t index = schema_->getFieldIndex(name);
     return setNull(index);

--- a/src/codec/RowWriterV2.h
+++ b/src/codec/RowWriterV2.h
@@ -129,7 +129,7 @@ public:
 
     // Data write
     template<typename T>
-    WriteResult set(folly::StringPiece name, T&& v) noexcept {
+    WriteResult set(const std::string &name, T&& v) noexcept {
         CHECK(!finished_) << "You have called finish()";
         int64_t index = schema_->getFieldIndex(name);
         if (index >= 0) {
@@ -140,10 +140,10 @@ public:
     }
 
     WriteResult setValue(ssize_t index, const Value& val) noexcept;
-    WriteResult setValue(folly::StringPiece name, const Value& val) noexcept;
+    WriteResult setValue(const std::string &name, const Value& val) noexcept;
 
     WriteResult setNull(ssize_t index) noexcept;
-    WriteResult setNull(folly::StringPiece name) noexcept;
+    WriteResult setNull(const std::string &name) noexcept;
 
 private:
     const meta::SchemaProviderIf* schema_;

--- a/src/codec/test/ResultSchemaProvider.cpp
+++ b/src/codec/test/ResultSchemaProvider.cpp
@@ -99,8 +99,8 @@ size_t ResultSchemaProvider::size() const noexcept {
 }
 
 
-int64_t ResultSchemaProvider::getFieldIndex(const folly::StringPiece name) const {
-    uint64_t hash = SpookyHashV2::Hash64(name.begin(), name.size(), 0);
+int64_t ResultSchemaProvider::getFieldIndex(const std::string& name) const {
+    uint64_t hash = SpookyHashV2::Hash64(name.data(), name.size(), 0);
     auto iter = nameIndex_.find(hash);
     if (iter == nameIndex_.end()) {
         return -1;
@@ -126,7 +126,7 @@ PropertyType ResultSchemaProvider::getFieldType(int64_t index) const {
 }
 
 
-PropertyType ResultSchemaProvider::getFieldType(const folly::StringPiece name) const {
+PropertyType ResultSchemaProvider::getFieldType(const std::string& name) const {
     auto index = getFieldIndex(name);
     if (index < 0) {
         return PropertyType::UNKNOWN;
@@ -145,7 +145,7 @@ const meta::SchemaProviderIf::Field* ResultSchemaProvider::field(int64_t index)
 
 
 const meta::SchemaProviderIf::Field* ResultSchemaProvider::field(
-        const folly::StringPiece name) const {
+        const std::string& name) const {
     auto index = getFieldIndex(name);
     if (index < 0) {
         return nullptr;

--- a/src/codec/test/ResultSchemaProvider.h
+++ b/src/codec/test/ResultSchemaProvider.h
@@ -57,15 +57,15 @@ public:
 
     size_t size() const noexcept override;
 
-    int64_t getFieldIndex(const folly::StringPiece name) const override;
+    int64_t getFieldIndex(const std::string& name) const override;
     const char* getFieldName(int64_t index) const override;
 
     meta::cpp2::PropertyType getFieldType(int64_t index) const override;
-    meta::cpp2::PropertyType getFieldType(const folly::StringPiece name)
+    meta::cpp2::PropertyType getFieldType(const std::string& name)
         const override;
 
     const meta::SchemaProviderIf::Field* field(int64_t index) const override;
-    const meta::SchemaProviderIf::Field* field(const folly::StringPiece name)
+    const meta::SchemaProviderIf::Field* field(const std::string& name)
         const override;
 
 protected:


### PR DESCRIPTION
Require https://github.com/vesoft-inc/nebula-common/pull/561

Before this PR, it convert property name from string to StringPiece and to string back.