### PR TITLE
Improved data write logic to avoid reading dirty data

### DIFF
--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -153,6 +153,24 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
         visited.reserve(newEdges.size());
         for (auto& newEdge : newEdges) {
             auto edgeKey = *newEdge.key_ref();
+            auto l = std::make_tuple(spaceId_,
+                                     partId,
+                                     (*edgeKey.src_ref()).getStr(),
+                                     *edgeKey.edge_type_ref(),
+                                     *edgeKey.ranking_ref(),
+                                     (*edgeKey.dst_ref()).getStr());
+            if (std::find(dummyLock.begin(), dummyLock.end(), l) == dummyLock.end()) {
+                if (!env_->edgesML_->try_lock(l)) {
+                    LOG(ERROR) << folly::format("edge locked : src {}, type {}, rank {}, dst {}",
+                                                (*edgeKey.src_ref()).getStr(),
+                                                *edgeKey.edge_type_ref(),
+                                                *edgeKey.ranking_ref(),
+                                                (*edgeKey.dst_ref()).getStr());
+                    code = nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
+                    break;
+                }
+            }
+            dummyLock.emplace_back(std::move(l));
             VLOG(3) << "PartitionID: " << partId << ", VertexID: " << *edgeKey.src_ref()
                     << ", EdgeType: " << *edgeKey.edge_type_ref() << ", EdgeRanking: "
                     << *edgeKey.ranking_ref() << ", VertexID: "
@@ -274,32 +292,15 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
                 break;
             }
             batchHolder->put(std::move(key), std::move(retEnc.value()));
-            dummyLock.emplace_back(std::make_tuple(spaceId_,
-                                                   partId,
-                                                   (*edgeKey.src_ref()).getStr(),
-                                                   *edgeKey.edge_type_ref(),
-                                                   *edgeKey.ranking_ref(),
-                                                   (*edgeKey.dst_ref()).getStr()));
         }
         if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+            env_->edgesML_->unlockBatch(dummyLock);
             handleAsync(spaceId_, partId, code);
             continue;
         }
         auto batch = encodeBatchValue(std::move(batchHolder)->getBatch());
         DCHECK(!batch.empty());
-        nebula::MemoryLockGuard<EMLI> lg(env_->edgesML_.get(), std::move(dummyLock), true);
-        if (!lg) {
-            auto conflict = lg.conflictKey();
-            LOG(ERROR) << "edge conflict "
-                        << std::get<0>(conflict) << ":"
-                        << std::get<1>(conflict) << ":"
-                        << std::get<2>(conflict) << ":"
-                        << std::get<3>(conflict) << ":"
-                        << std::get<4>(conflict) << ":"
-                        << std::get<5>(conflict);
-            handleAsync(spaceId_, partId, nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR);
-            continue;
-        }
+        nebula::MemoryLockGuard<EMLI> lg(env_->edgesML_.get(), std::move(dummyLock), true, false);
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
             [l = std::move(lg), icw = std::move(wrapper), partId, this]
             (nebula::cpp2::ErrorCode retCode) {

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -169,8 +169,8 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
                     code = nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
                     break;
                 }
+                dummyLock.emplace_back(std::move(l));
             }
-            dummyLock.emplace_back(std::move(l));
             VLOG(3) << "PartitionID: " << partId << ", VertexID: " << *edgeKey.src_ref()
                     << ", EdgeType: " << *edgeKey.edge_type_ref() << ", EdgeRanking: "
                     << *edgeKey.ranking_ref() << ", VertexID: "
@@ -300,7 +300,7 @@ void AddEdgesProcessor::doProcessWithIndex(const cpp2::AddEdgesRequest& req) {
         }
         auto batch = encodeBatchValue(std::move(batchHolder)->getBatch());
         DCHECK(!batch.empty());
-        nebula::MemoryLockGuard<EMLI> lg(env_->edgesML_.get(), std::move(dummyLock), true, false);
+        nebula::MemoryLockGuard<EMLI> lg(env_->edgesML_.get(), std::move(dummyLock), false, false);
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
             [l = std::move(lg), icw = std::move(wrapper), partId, this]
             (nebula::cpp2::ErrorCode retCode) {

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -175,8 +175,8 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
                         code = nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
                         break;
                     }
+                    dummyLock.emplace_back(std::move(l));
                 }
-                dummyLock.emplace_back(std::move(l));
                 VLOG(3) << "PartitionID: " << partId << ", VertexID: " << vid
                         << ", TagID: " << tagId;
 
@@ -307,7 +307,7 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
         DCHECK(!batch.empty());
         nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(),
                                          std::move(dummyLock),
-                                         true,
+                                         false,
                                          false);
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
             [l = std::move(lg), icw = std::move(wrapper), partId, this] (

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -167,6 +167,16 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
 
             for (auto& newTag : newTags) {
                 auto tagId = newTag.get_tag_id();
+                auto l = std::make_tuple(spaceId_, partId, tagId, vid);
+                if (std::find(dummyLock.begin(), dummyLock.end(), l) == dummyLock.end()) {
+                    if (!env_->verticesML_->try_lock(l)) {
+                        LOG(ERROR) << folly::format("The vertex locked : tag {}, vid {}",
+                                                    tagId, vid);
+                        code = nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
+                        break;
+                    }
+                }
+                dummyLock.emplace_back(std::move(l));
                 VLOG(3) << "PartitionID: " << partId << ", VertexID: " << vid
                         << ", TagID: " << tagId;
 
@@ -277,7 +287,6 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
                 * step 3 , Insert new vertex data
                 */
                 batchHolder->put(std::move(key), std::move(retEnc.value()));
-                dummyLock.emplace_back(std::make_tuple(spaceId_, partId, tagId, vid));
 
                 if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
                     vertexCache_->evict(std::make_pair(vid, tagId));
@@ -290,22 +299,16 @@ void AddVerticesProcessor::doProcessWithIndex(const cpp2::AddVerticesRequest& re
             }
         }
         if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+            env_->verticesML_->unlockBatch(dummyLock);
             handleAsync(spaceId_, partId, code);
             continue;
         }
         auto batch = encodeBatchValue(std::move(batchHolder)->getBatch());
         DCHECK(!batch.empty());
-        nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(), std::move(dummyLock), true);
-        if (!lg) {
-            auto conflict = lg.conflictKey();
-            LOG(ERROR) << "vertex conflict "
-                        << std::get<0>(conflict) << ":"
-                        << std::get<1>(conflict) << ":"
-                        << std::get<2>(conflict) << ":"
-                        << std::get<3>(conflict);
-            handleAsync(spaceId_, partId, nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR);
-            continue;
-        }
+        nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(),
+                                         std::move(dummyLock),
+                                         true,
+                                         false);
         env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(batch),
             [l = std::move(lg), icw = std::move(wrapper), partId, this] (
                 nebula::cpp2::ErrorCode retCode) {

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -96,21 +96,15 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
             std::vector<VMLI> dummyLock;
             auto batch = deleteVertices(partId, std::move(pv).second, dummyLock);
             if (!nebula::ok(batch)) {
+                env_->verticesML_->unlockBatch(dummyLock);
                 handleAsync(spaceId_, partId, nebula::error(batch));
                 continue;
             }
             DCHECK(!nebula::value(batch).empty());
-            nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(), std::move(dummyLock), true);
-            if (!lg) {
-                auto conflict = lg.conflictKey();
-                LOG(ERROR) << "vertex conflict "
-                        << std::get<0>(conflict) << ":"
-                        << std::get<1>(conflict) << ":"
-                        << std::get<2>(conflict) << ":"
-                        << std::get<3>(conflict);
-                handleAsync(spaceId_, partId, nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR);
-                continue;
-            }
+            nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(),
+                                             std::move(dummyLock),
+                                             false,
+                                             false);
             env_->kvstore_->asyncAppendBatch(spaceId_, partId, std::move(nebula::value(batch)),
                 [l = std::move(lg), icw = std::move(wrapper), partId, this] (
                     nebula::cpp2::ErrorCode code) {
@@ -142,6 +136,13 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
         while (iter->valid()) {
             auto key = iter->key();
             auto tagId = NebulaKeyUtils::getTagId(spaceVidLen_, key);
+            auto l = std::make_tuple(spaceId_, partId, tagId, vertex.getStr());
+            if (!env_->verticesML_->try_lock(l)) {
+                LOG(ERROR) << folly::format("The vertex locked : tag {}, vid {}",
+                                            tagId, vertex.getStr());
+                return nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
+            }
+            target.emplace_back(std::move(l));
             RowReaderWrapper reader;
             for (auto& index : indexes_) {
                 if (index->get_schema_id().get_tag_id() == tagId) {
@@ -186,7 +187,6 @@ DeleteVerticesProcessor::deleteVertices(PartitionID partId,
                 VLOG(3) << "Evict vertex cache for vertex ID " << vertex << ", tagId " << tagId;
                 vertexCache_->evict(std::make_pair(vertex.getStr(), tagId));
             }
-            target.emplace_back(std::make_tuple(spaceId_, partId, tagId, vertex.getStr()));
             batchHolder->remove(key.str());
             iter->next();
         }

--- a/src/storage/test/MemoryLockTest.cpp
+++ b/src/storage/test/MemoryLockTest.cpp
@@ -83,6 +83,45 @@ TEST_F(MemoryLockTest, PrepTest) {
     EXPECT_EQ(0, mlock.size());
 }
 
+TEST_F(MemoryLockTest, DedupTest) {
+    MemoryLockCore<std::string> mlock;
+    {
+        std::vector<std::string> keys{"1", "2", "1", "2"};
+        auto* lk = new LockGuard(&mlock, keys, true, false);
+        EXPECT_TRUE(lk);
+        EXPECT_EQ(0, mlock.size());
+        delete lk;
+    }
+    EXPECT_EQ(0, mlock.size());
+    {
+        EXPECT_TRUE(mlock.try_lock("1"));
+        EXPECT_TRUE(mlock.try_lock("2"));
+        EXPECT_FALSE(mlock.try_lock("1"));
+        EXPECT_FALSE(mlock.try_lock("2"));
+        std::vector<std::string> keys{"1", "2", "1", "2"};
+        auto* lk = new LockGuard(&mlock, keys, true, false);
+        EXPECT_TRUE(lk);
+        EXPECT_EQ(2, mlock.size());
+        delete lk;
+    }
+    EXPECT_EQ(0, mlock.size());
+    {
+        std::vector<std::string> keys{"1", "2", "1", "2"};
+        auto* lk = new LockGuard(&mlock, keys, true, true);
+        EXPECT_TRUE(lk);
+        EXPECT_EQ(2, mlock.size());
+        delete lk;
+    }
+    EXPECT_EQ(0, mlock.size());
+    {
+        std::vector<std::string> keys{"1", "2", "1", "2"};
+        LockGuard lk(&mlock, keys, false, true);
+        EXPECT_FALSE(lk);
+        EXPECT_EQ(0, mlock.size());
+    }
+    EXPECT_EQ(0, mlock.size());
+}
+
 }  // namespace storage
 }  // namespace nebula
 

--- a/src/storage/test/MemoryLockTest.cpp
+++ b/src/storage/test/MemoryLockTest.cpp
@@ -68,6 +68,21 @@ TEST_F(MemoryLockTest, MoveTest) {
     }
 }
 
+TEST_F(MemoryLockTest, PrepTest) {
+    MemoryLockCore<std::string> mlock;
+    {
+        EXPECT_TRUE(mlock.try_lock("1"));
+        EXPECT_TRUE(mlock.try_lock("2"));
+        EXPECT_FALSE(mlock.try_lock("1"));
+        EXPECT_FALSE(mlock.try_lock("2"));
+        std::vector<std::string> keys{"1", "2"};
+        auto* lk = new LockGuard(&mlock, keys, false, false);
+        EXPECT_TRUE(lk);
+        delete lk;
+    }
+    EXPECT_EQ(0, mlock.size());
+}
+
 }  // namespace storage
 }  // namespace nebula
 

--- a/src/utils/MemoryLockWrapper.h
+++ b/src/utils/MemoryLockWrapper.h
@@ -24,14 +24,12 @@ public:
                     bool dedup = false,
                     bool prepCheck = true)
         : lock_(lock), keys_(keys) {
+        if (dedup) {
+            std::sort(keys_.begin(), keys_.end());
+            keys_.erase(unique(keys_.begin(), keys_.end()), keys_.end());
+        }
         if (prepCheck) {
-            if (dedup) {
-                std::sort(keys_.begin(), keys_.end());
-                auto last = std::unique(keys_.begin(), keys_.end());
-                std::tie(iter_, locked_) = lock_->lockBatch(keys_.begin(), last);
-            } else {
-                std::tie(iter_, locked_) = lock_->lockBatch(keys_);
-            }
+            std::tie(iter_, locked_) = lock_->lockBatch(keys_);
         } else {
             locked_ = true;
         }

--- a/src/utils/MemoryLockWrapper.h
+++ b/src/utils/MemoryLockWrapper.h
@@ -19,14 +19,21 @@ public:
     MemoryLockGuard(MemoryLockCore<Key>* lock, const Key& key)
         : MemoryLockGuard(lock, std::vector<Key>{key}) {}
 
-    MemoryLockGuard(MemoryLockCore<Key>* lock, const std::vector<Key>& keys, bool dedup = false)
+    MemoryLockGuard(MemoryLockCore<Key>* lock,
+                    const std::vector<Key>& keys,
+                    bool dedup = false,
+                    bool prepCheck = true)
         : lock_(lock), keys_(keys) {
-        if (dedup) {
-            std::sort(keys_.begin(), keys_.end());
-            auto last = std::unique(keys_.begin(), keys_.end());
-            std::tie(iter_, locked_) = lock_->lockBatch(keys_.begin(), last);
+        if (prepCheck) {
+            if (dedup) {
+                std::sort(keys_.begin(), keys_.end());
+                auto last = std::unique(keys_.begin(), keys_.end());
+                std::tie(iter_, locked_) = lock_->lockBatch(keys_.begin(), last);
+            } else {
+                std::tie(iter_, locked_) = lock_->lockBatch(keys_);
+            }
         } else {
-            std::tie(iter_, locked_) = lock_->lockBatch(keys_);
+            locked_ = true;
         }
     }
 


### PR DESCRIPTION
We are using `ConcurrentHashMap` to solve the performance issues of concurrent writes.
The current write logic may cause dirty data to be read, for example:
Thread A : -----> read -> lock -> write
Thread B : read----------------------------> lock -> write
If thread A terminates first, it will cause thread B to read dirty data.

changed to ：
Thread A : lock -----> read -> write -> unlock
Thread B : lock - > read-----------------------------> write -> unlock
