### PR TITLE
Fix show stats

### DIFF
--- a/conf/nebula-storaged.conf.default
+++ b/conf/nebula-storaged.conf.default
@@ -92,8 +92,6 @@
 
 # Whether or not to enable rocksdb's prefix bloom filter, disabled by default.
 --enable_rocksdb_prefix_filtering=false
-# Whether or not to enable the whole key filtering.
---enable_rocksdb_whole_key_filtering=true
 
 ############## rocksdb Options ##############
 # rocksdb DBOptions in json, each name and value of option is a string, given as "option_name":"option_value" separated by comma

--- a/conf/nebula-storaged.conf.production
+++ b/conf/nebula-storaged.conf.production
@@ -98,8 +98,6 @@
 
 # Whether or not to enable rocksdb's prefix bloom filter, disabled by default.
 --enable_rocksdb_prefix_filtering=false
-# Whether or not to enable the whole key filtering.
---enable_rocksdb_whole_key_filtering=true
 
 ############### misc ####################
 --max_handlers_per_req=1

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -220,7 +220,6 @@ nebula::cpp2::ErrorCode
 RocksEngine::prefix(const std::string& prefix,
                     std::unique_ptr<KVIterator>* storageIter) {
     rocksdb::ReadOptions options;
-    options.prefix_same_as_start = true;
     rocksdb::Iterator* iter = db_->NewIterator(options);
     if (iter) {
         iter->Seek(rocksdb::Slice(prefix));
@@ -234,7 +233,6 @@ RocksEngine::rangeWithPrefix(const std::string& start,
                              const std::string& prefix,
                              std::unique_ptr<KVIterator>* storageIter) {
     rocksdb::ReadOptions options;
-    options.prefix_same_as_start = true;
     rocksdb::Iterator* iter = db_->NewIterator(options);
     if (iter) {
         iter->Seek(rocksdb::Slice(start));

--- a/src/kvstore/RocksEngineConfig.h
+++ b/src/kvstore/RocksEngineConfig.h
@@ -49,7 +49,7 @@ DECLARE_string(rocksdb_stats_level);
 
 DECLARE_bool(enable_rocksdb_prefix_filtering);
 DECLARE_bool(rocksdb_prefix_bloom_filter_length_flag);
-DECLARE_bool(enable_rocksdb_whole_key_filtering);
+DECLARE_int32(rocksdb_plain_table_prefix_length);
 
 // rocksdb compact RangeOptions
 DECLARE_bool(rocksdb_compact_change_level);
@@ -58,9 +58,6 @@ DECLARE_int32(rocksdb_compact_target_level);
 DECLARE_string(rocksdb_wal_dir);
 DECLARE_string(rocksdb_backup_dir);
 DECLARE_int32(rocksdb_backup_interval_secs);
-
-DECLARE_string(rocksdb_memtable_type);
-DECLARE_int32(rocksdb_memtable_hash_bucket_count);
 
 namespace nebula {
 namespace kvstore {

--- a/src/utils/NebulaKeyUtils.h
+++ b/src/utils/NebulaKeyUtils.h
@@ -262,6 +262,8 @@ public:
         LOG(FATAL) << msg.str();
     }
 
+    static_assert(sizeof(NebulaKeyType) == sizeof(PartitionID));
+
 private:
     NebulaKeyUtils() = delete;
 


### PR DESCRIPTION
Both BlockBasedTable and PlainTable will failed in some certain case.

1. Both will failed when use HashSkipList as memtable.
2. BlockBasedTable will fail when specify `prefix_same_as_start`, it is ok to remove it since we check it externally.
 
Will dig more later and add some test case.