### PR TITLE
fix task in recovered balance plan is still marked as FAILED

### DIFF
--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -36,6 +36,10 @@ folly::Future<Status> AdminClient::transLeader(GraphSpaceID spaceId,
     if (it == peers.end()) {
         return Status::PartNotFound();
     }
+    if (peers.size() == 1 && peers.front() == leader) {
+        // if there is only one replica, skip transfer leader phase
+        return Status::OK();
+    }
     auto target = dst;
     if (dst == kRandomPeer) {
         for (auto& p : peers) {

--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -304,10 +304,6 @@ Balancer::genTasks(GraphSpaceID spaceId,
         }
     }
 
-    if (confirmedHostParts.size() < 2) {
-        LOG(INFO) << "Too few hosts, no need for balance!";
-        return nebula::cpp2::ErrorCode::E_NO_VALID_HOST;
-    }
     // 2. Make all hosts in confirmedHostParts balanced
     if (balanceParts(plan_->id_, spaceId, confirmedHostParts, totalParts, tasks)) {
         return tasks;

--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -174,7 +174,8 @@ nebula::cpp2::ErrorCode Balancer::recovery() {
             return recRet;
         }
     }
-    return nebula::cpp2::ErrorCode::SUCCEEDED;
+    // save the balance plan again because FAILED tasks would be marked as IN_PROGRESS again
+    return plan_->saveInStore();
 }
 
 nebula::cpp2::ErrorCode

--- a/src/meta/processors/partsMan/ListHostsProcessor.cpp
+++ b/src/meta/processors/partsMan/ListHostsProcessor.cpp
@@ -200,7 +200,7 @@ nebula::cpp2::ErrorCode ListHostsProcessor::fillLeaders() {
         }
         auto it = std::find(activeHosts.begin(), activeHosts.end(), host);
         if (it == activeHosts.end()) {
-            LOG(INFO) << "skip inactive host: " << host;
+            VLOG(1) << "skip inactive host: " << host;
             continue;  // skip inactive host
         }
 
@@ -209,7 +209,7 @@ nebula::cpp2::ErrorCode ListHostsProcessor::fillLeaders() {
         });
 
         if (hostIt == hostItems_.end()) {
-            LOG(INFO) << "skip inactive host";
+            VLOG(1) << "skip inactive host";
             continue;
         }
 

--- a/src/storage/StorageFlags.cpp
+++ b/src/storage/StorageFlags.cpp
@@ -15,7 +15,7 @@ DEFINE_int32(waiting_catch_up_retry_times, 30, "retry times when waiting for cat
 DEFINE_int32(waiting_catch_up_interval_in_secs, 30,
              "interval between two requests for catching up state");
 
-DEFINE_int32(waiting_new_leader_retry_times, 30, "retry times when waiting for catching up data");
+DEFINE_int32(waiting_new_leader_retry_times, 5, "retry times when waiting for new leader");
 
 DEFINE_int32(waiting_new_leader_interval_in_secs, 5,
              "interval between two requests for catching up state");


### PR DESCRIPTION
When task is failed for some reason, when recovering, they are marked as `IN_PROGRESS` again, but `balance data id` will still show `FAILED`. Just save the status when plan is recovered.